### PR TITLE
acl(aoscx): fix DOCUMENTATION (ansible-doc...)

### DIFF
--- a/plugins/modules/aoscx_acl.py
+++ b/plugins/modules/aoscx_acl.py
@@ -110,19 +110,22 @@ options:
       src_l4_port_max:
         type: int
         required: false
-        description: Maximum L4 port to match on the packet. Use only if
-        `src_l4_port` is not specified.
+        description: >
+          Maximum L4 port to match on the packet. Use only if
+          `src_l4_port` is not specified.
       src_l4_port_min:
         type: int
         required: false
-        description: Minimum L4 port to match on the packet. Use only if
-        `src_l4_port` is not specified.
+        description: >
+          Minimum L4 port to match on the packet. Use only if
+          `src_l4_port` is not specified.
       src_l4_port:
         type: str
         required: false
-        description: Range of L4 ports or L4 source port to match on the
-        packet. Use only if `src_l4_port_min` and `src_l4_port_max` are not
-        specified.
+        description: >
+          Range of L4 ports or L4 source port to match on the
+          packet. Use only if `src_l4_port_min` and `src_l4_port_max` are not
+          specified.
       dst_l4_port_group:
         type: str
         required: false
@@ -151,9 +154,10 @@ options:
       dst_l4_port:
         type: str
         required: false
-        description: Range of L4 ports or L4 destination port to match on the
-        packet. Use only if `dst_l4_port_min` and `dst_l4_port_max` are not
-        specified.
+        description: >
+          Range of L4 ports or L4 destination port to match on the
+          packet. Use only if `dst_l4_port_min` and `dst_l4_port_max` are not
+          specified.
       src_ip_group:
         type: str
         required: false


### PR DESCRIPTION
Fix

ERROR! module arubanetworks.aoscx.aoscx_acl missing documentation (or could not parse documentation): arubanetworks.aoscx.aoscx_acl did not contain a DOCUMENTATION attribute (/root/ansible_collections/arubanetworks/aoscx/plugins/modules/aoscx_acl.py). Unable to parse documentation in python file '/root/ansible_collections/arubanetworks/aoscx/plugins/modules/aoscx_acl.py': while scanning for the next token found character that cannot start any token
  in "<unicode string>", line 97, column 9. while scanning for the next token
found character that cannot start any token
  in "<unicode string>", line 97, column 9

and

ERROR: plugins/modules/aoscx_acl.py:114:9: error: DOCUMENTATION: syntax error: found character '`' that cannot start any token (syntax)
ERROR: plugins/modules/aoscx_acl.py:114:9: unparsable-with-libyaml: while scanning for the next token - found character that cannot start any token