### PR TITLE
Ansible-Test: Update GitHub Actions Workflows

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -11,10 +11,6 @@ on:
     branches:
       - master
   pull_request:
-  # Run CI once per day (at 06:00 UTC)
-  # This ensures that even if there haven't been commits that we are still testing against latest version of ansible-test for each ansible-base version
-  schedule:
-    - cron: '0 6 * * *'
 env:
   NAMESPACE: arubanetworks
   COLLECTION_NAME: aoscx 

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -30,11 +30,13 @@ jobs:
           # It's important that Sanity is tested against all stable-X.Y branches
           # Testing against `devel` may fail as new tests are added.
         # - stable-2.9 # Only if your collection supports Ansible 2.9
-          - stable-2.10
-          - stable-2.11
+        #  - stable-2.10
+        #  - stable-2.11
           - stable-2.12
           - stable-2.13
           - stable-2.14
+          - stable-2.15
+          - stable-2.16
           - devel
     runs-on: >-
       ${{ contains(fromJson(

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           # it is just required to run that once as "ansible-test sanity" in the docker image
           # will run on all python versions it supports.
-          python-version: '3.10'
+          python-version: '3.11'
 
       # Install the head of the given branch (devel, stable-2.10)
       - name: Install ansible-base (${{ matrix.ansible }})

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -37,6 +37,7 @@ jobs:
           - stable-2.14
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - devel
     runs-on: >-
       ${{ contains(fromJson(

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -48,12 +48,12 @@ jobs:
       # .../ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}/
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           # it is just required to run that once as "ansible-test sanity" in the docker image
           # will run on all python versions it supports.

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -34,7 +34,7 @@ jobs:
         #  - stable-2.11
         #  - stable-2.12
         #  - stable-2.13
-          - stable-2.14
+        #  - stable-2.14
           - stable-2.15
           - stable-2.16
           - stable-2.17

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -50,7 +50,7 @@ jobs:
       # .../ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}/
 
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}
 

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -32,7 +32,7 @@ jobs:
         # - stable-2.9 # Only if your collection supports Ansible 2.9
         #  - stable-2.10
         #  - stable-2.11
-          - stable-2.12
+        #  - stable-2.12
           - stable-2.13
           - stable-2.14
           - stable-2.15

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -13,7 +13,7 @@ on:
   pull_request:
 env:
   NAMESPACE: arubanetworks
-  COLLECTION_NAME: aoscx 
+  COLLECTION_NAME: aoscx
 
 jobs:
 
@@ -72,7 +72,7 @@ jobs:
       # run ansible-test sanity inside of Docker.
       # The docker container has all the pinned dependencies that are required
       # and all python versions ansible supports.
-      
+
       - name: Run sanity tests
         run: ansible-test sanity --docker -v --color --coverage
         working-directory: ./ansible_collections/${{env.NAMESPACE}}/${{env.COLLECTION_NAME}}

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
         #  - stable-2.10
         #  - stable-2.11
         #  - stable-2.12
-          - stable-2.13
+        #  - stable-2.13
           - stable-2.14
           - stable-2.15
           - stable-2.16

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -39,6 +39,8 @@ jobs:
           - stable-2.16
           - stable-2.17
           - stable-2.18
+          - stable-2.19
+          - stable-2.20
           - devel
     runs-on: >-
       ${{ contains(fromJson(

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           # it is just required to run that once as "ansible-test sanity" in the docker image
           # will run on all python versions it supports.
-          python-version: '3.11'
+          python-version: '3.12'
 
       # Install the head of the given branch (devel, stable-2.10)
       - name: Install ansible-base (${{ matrix.ansible }})

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -35,7 +35,7 @@ jobs:
         #  - stable-2.12
         #  - stable-2.13
         #  - stable-2.14
-          - stable-2.15
+        #  - stable-2.15
           - stable-2.16
           - stable-2.17
           - stable-2.18

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -38,6 +38,7 @@ jobs:
           - stable-2.15
           - stable-2.16
           - stable-2.17
+          - stable-2.18
           - devel
     runs-on: >-
       ${{ contains(fromJson(

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,1 +1,1 @@
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.10.0"

--- a/plugins/connection/aoscx.py
+++ b/plugins/connection/aoscx.py
@@ -135,7 +135,9 @@ from ansible.plugins.connection import (
     NetworkConnectionBase,
     ensure_connect,
 )
-from ansible.module_utils.six import PY3
+import sys
+
+PY3 = sys.version_info.major >= 3
 
 try:
     from pyaoscx.session import Session

--- a/plugins/module_utils/providers.py
+++ b/plugins/module_utils/providers.py
@@ -12,7 +12,6 @@ __metaclass__ = type
 import json
 from threading import RLock
 
-from ansible.module_utils.six import itervalues
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.utils import (  # NOQA
     to_list,
 )
@@ -31,7 +30,7 @@ def register_provider(network_os, module_name):
                 if ct not in _registered_providers[network_os]:
                     _registered_providers[network_os][ct] = {}
             for item in to_list(module_name):
-                for entry in itervalues(_registered_providers[network_os]):
+                for entry in _registered_providers[network_os].values():
                     entry[item] = cls
         finally:
             _provider_lock.release()

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,0 +1,1 @@
+plugins/modules/aoscx_command.py validate-modules:parameter-list-no-elements #commands

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,1 @@
+plugins/modules/aoscx_command.py validate-modules:parameter-list-no-elements #commands

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -1,0 +1,1 @@
+plugins/modules/aoscx_command.py validate-modules:parameter-list-no-elements #commands

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,0 +1,1 @@
+plugins/modules/aoscx_command.py validate-modules:parameter-list-no-elements #commands

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,0 +1,1 @@
+plugins/modules/aoscx_command.py validate-modules:parameter-list-no-elements #commands


### PR DESCRIPTION
Remove ansible-2.10 and 2.11 (EOS) add 2.15, 2.16 (and 2.17, it is new devel)

Also add ignore-2.[16|17].txt

See https://github.com/ansible-collections/news-for-maintainers/issues/41