### PR TITLE
Added inventory_hostname as an acceptable connection variable

### DIFF
--- a/plugins/connection/aoscx.py
+++ b/plugins/connection/aoscx.py
@@ -20,6 +20,7 @@ options:
     default: inventory_hostname
     vars:
       - name: ansible_host
+      - name: inventory_hostname
   port:
     type: int
     description: >


### PR DESCRIPTION
This fixes issue #99 

Adding `inventory_hostname` as an acceptable connection variable in `plugins/connection/aoscx.py` fixes the issue when hostnames/FQDNs are specified in the inventory file. 