### PR TITLE
Migrate `warnings` key in `exit_json` to `AnsibleModule.warn`

### DIFF
--- a/plugins/module_utils/aoscx.py
+++ b/plugins/module_utils/aoscx.py
@@ -88,13 +88,6 @@ def get_provider_argspec():
     return aoscx_provider_spec
 
 
-def check_args(module, warnings):
-    """
-    Checks the argument
-    """
-    pass
-
-
 def get_config(module, flags=None):
     """
     Obtains the switch configuration
@@ -463,7 +456,6 @@ class ArubaAnsibleModule:
             argument_spec=module_args, supports_check_mode=True
         )
 
-        self.warnings = list()
         self.changed = False
         self.original_config = None
         self.running_config = None
@@ -567,7 +559,7 @@ class ArubaAnsibleModule:
         """
         Update switch config
         """
-        self.result = dict(changed=self.changed, warnings=self.warnings)
+        self.result = dict(changed=self.changed)
 
         if self.original_config != self.running_config:
             self.upload_switch_config(self.running_config)

--- a/plugins/modules/aoscx_acl_interface.py
+++ b/plugins/modules/aoscx_acl_interface.py
@@ -134,8 +134,8 @@ def main():
     acl_direction = ansible_module.params["acl_direction"]
     state = ansible_module.params["state"]
     result = dict(changed=False)
-    warnings = []
-    warnings.append("This module is deprecated, use aoscx_interface instead")
+
+    ansible_module.warn("This module is deprecated, use aoscx_interface instead")
 
     if ansible_module.check_mode:
         ansible_module.exit_json(**result)
@@ -174,9 +174,6 @@ def main():
                 result["changed"] = True
 
     # Exit
-    if warnings:
-        result["warnings"] = warnings
-
     ansible_module.exit_json(**result)
 
 

--- a/plugins/modules/aoscx_acl_vlan.py
+++ b/plugins/modules/aoscx_acl_vlan.py
@@ -116,8 +116,8 @@ def main():
     acl_direction = ansible_module.params["acl_direction"]
     state = ansible_module.params["state"]
     result = dict(changed=False)
-    warnings = []
-    warnings.append("This module is deprecated, use aoscx_vlan instead")
+
+    ansible_module.warn("This module is deprecated, use aoscx_vlan instead")
 
     if ansible_module.check_mode:
         ansible_module.exit_json(**result)
@@ -150,9 +150,6 @@ def main():
             result["changed"] = modified
 
     # Exit
-    if warnings:
-        result["warnings"] = warnings
-
     ansible_module.exit_json(**result)
 
 

--- a/plugins/modules/aoscx_command.py
+++ b/plugins/modules/aoscx_command.py
@@ -277,9 +277,7 @@ def main():
 
     argument_spec.update(aoscx_argument_spec)
 
-    warnings = list()
-
-    result = {"changed": False, "warnings": warnings}
+    result = {"changed": False}
     module = AnsibleModule(
         argument_spec=argument_spec, supports_check_mode=True
     )

--- a/plugins/modules/aoscx_config.py
+++ b/plugins/modules/aoscx_config.py
@@ -336,9 +336,6 @@ from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx import (
 from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx import (  # NOQA
     aoscx_argument_spec,
 )
-from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx import (  # NOQA
-    check_args as aoscx_check_args,
-)
 from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.config import (  # NOQA
     NetworkConfig,
     dumps,
@@ -430,9 +427,7 @@ def main():
         supports_check_mode=True,
     )
 
-    warnings = list()
-    aoscx_check_args(module, warnings)
-    result = {"changed": False, "warnings": warnings}
+    result = {"changed": False}
 
     config = None
 

--- a/plugins/modules/aoscx_facts.py
+++ b/plugins/modules/aoscx_facts.py
@@ -228,9 +228,8 @@ def main():
             msg="Could not get PYAOSCX Session: {0}".format(str(e))
         )
 
-    warnings = []
     if ansible_module.params["gather_subset"] == "!config":
-        warnings.append(
+        ansible_module.warn(
             "default value for `gather_subset` will be changed "
             "to `min` from `!config` v2.11 onwards"
         )
@@ -363,16 +362,19 @@ def main():
                 main_version > 10 or sub_version > 8
             ):
                 if str(session.api) in ["10.04", "10.08"]:
-                    w_message = (
-                        "Physical interfaces: "
-                        "REST v{0} is no longer supported "
-                        "for this version {1}-{2}.{3}. "
-                        "Add parameter 'ansible_aoscx_rest_version: 10.09'"
-                        " in your inventory file for this host. Or define "
-                        "environment variable ANSIBLE_AOSCX_REST_VERSION "
-                        "with value 10.09"
-                    ).format(session.api, platform, main_version, sub_version)
-                    warnings.append(w_message)
+                    ansible_module.warn(
+                        (
+                            "Physical interfaces: "
+                            "REST v{0} is no longer supported "
+                            "for this version {1}-{2}.{3}. "
+                            "Add parameter 'ansible_aoscx_rest_version: 10.09'"
+                            " in your inventory file for this host. Or define "
+                            "environment variable ANSIBLE_AOSCX_REST_VERSION "
+                            "with value 10.09"
+                        ).format(
+                            session.api, platform, main_version, sub_version
+                        )
+                    )
                 else:
                     use_data_planes = True
                     try:
@@ -386,11 +388,10 @@ def main():
         elif subset == "host_name":
             subset = "hostname"
         elif subset == "config":
-            w_message = (
+            ansible_module.warn(
                 "gather_subset:config is not available yet, it will "
                 "be available in a future release"
             )
-            warnings.append(w_message)
         str_subset = "ansible_net_" + subset
 
         # Check if current subset is inside the Device object
@@ -418,7 +419,7 @@ def main():
                     intfs = switch.subsystems[subsystem][subset]
                 ansible_facts[str_subset].update({subsystem: intfs})
 
-    ansible_module.exit_json(ansible_facts=ansible_facts, warnings=warnings)
+    ansible_module.exit_json(ansible_facts=ansible_facts)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/aoscx_interface.py
+++ b/plugins/modules/aoscx_interface.py
@@ -657,16 +657,13 @@ def main():
                 )
 
             if "forced_speeds" not in status_int.hw_intf_info:
-                warning = (
-                    "Interface {0} might not support the combination of "
-                    "speeds/duplex configured, check your hardware specifications "
-                    "and/or CLI to make sure."
-                ).format(name)
-                if "warnings" in result:
-                    result["warnings"].append(warning)
-                else:
-                    result["warnings"] = [warning]
-
+                module.warn(
+                    (
+                        "Interface {0} might not support the combination of "
+                        "speeds/duplex configured, check your hardware specifications "
+                        "and/or CLI to make sure."
+                    ).format(name)
+                )
             try:
                 interface.configure_speed_duplex(**_user_config)
             except Exception as exc:

--- a/plugins/modules/aoscx_ospf_router.py
+++ b/plugins/modules/aoscx_ospf_router.py
@@ -668,8 +668,6 @@ def main():
         "redistribute",
     ]
 
-    warnings = []
-
     passive_interface_default = params.get("passive_interface_default")
     passive_as_default = (
         passive_interface_default
@@ -679,7 +677,7 @@ def main():
     if passive_as_default:
         passive_interfaces = params.get("passive_interfaces")
         if passive_interfaces is not None and passive_interfaces != []:
-            warnings.append(
+            ansible_module.warn(
                 "Interfaces are passive by default, "
                 "'passive_interfaces' should be empty"
             )
@@ -688,7 +686,7 @@ def main():
     else:
         active_interfaces = params.get("active_interfaces")
         if active_interfaces is not None and active_interfaces != []:
-            warnings.append(
+            ansible_module.warn(
                 "Interfaces are active by default, "
                 "'active_interfaces' should be empty"
             )
@@ -716,8 +714,6 @@ def main():
         setattr(ospf_router, key, value)
     if result["changed"]:
         ospf_router.apply()
-    if warnings:
-        result["warnings"] = warnings
     ansible_module.exit_json(**result)
 
 

--- a/plugins/modules/aoscx_ospfv3_router.py
+++ b/plugins/modules/aoscx_ospfv3_router.py
@@ -653,8 +653,6 @@ def main():
         "redistribute",
     ]
 
-    warnings = []
-
     passive_interface_default = params.get("passive_interface_default")
     passive_as_default = (
         passive_interface_default
@@ -664,7 +662,7 @@ def main():
     if passive_as_default:
         passive_interfaces = params.get("passive_interfaces")
         if passive_interfaces is not None and passive_interfaces != []:
-            warnings.append(
+            ansible_module.warn(
                 "Interfaces are passive by default, "
                 "'passive_interfaces' should be empty"
             )
@@ -673,7 +671,7 @@ def main():
     else:
         active_interfaces = params.get("active_interfaces")
         if active_interfaces is not None and active_interfaces != []:
-            warnings.append(
+            ansible_module.warn(
                 "Interfaces are active by default, "
                 "'active_interfaces' should be empty"
             )
@@ -701,8 +699,6 @@ def main():
         setattr(ospf_router, key, value)
     if result["changed"]:
         ospf_router.apply()
-    if warnings:
-        result["warnings"] = warnings
     ansible_module.exit_json(**result)
 
 

--- a/plugins/modules/aoscx_poe.py
+++ b/plugins/modules/aoscx_poe.py
@@ -250,16 +250,12 @@ def main():
             poe_interface.allocate_by_method = "usage"
         if class_number:
             if platform == "RL" or platform == "FL":
-                warning = (
+                ansible_module.warn(
                     "Currently there are limitations to delete the "
                     "assigned_class on platforms RL and FL. "
                     "The recommendation is to use a workaround explained on "
                     "the documentation of the Config Ansible module. "
                 )
-                if "warnings" in result:
-                    result["warnings"].append(warning)
-                else:
-                    result["warnings"] = [warning]
             # CR 249060 does not allow deleting platforms RL and FL.
             # After this issue is solved, remove this comment, remove the
             # warning above and uncomment the funcionality below.
@@ -303,14 +299,10 @@ def main():
             result["changed"] = True
             poe_interface.pd_class_override = pd_class_override
             poe_interface.allocate_by_method = "class"
-            warning = (
+            ansible_module.warn(
                 "Enabling pd-class-override will also change the allocate-by "
                 "setting to class."
             )
-            if "warnings" in result:
-                result["warnings"].append(warning)
-            else:
-                result["warnings"] = [warning]
         if (
             pre_standard_detect is not None
             and poe_interface.pre_standard_detect != pre_standard_detect

--- a/plugins/modules/aoscx_vlan.py
+++ b/plugins/modules/aoscx_vlan.py
@@ -223,7 +223,6 @@ def main():
     # device = Device(session)
     Vlan = session.api.get_module_class(session, "Vlan")
     vlan = Vlan(session, vlan_id, vlan_name)
-    warnings = []
     modified = False
 
     try:
@@ -266,7 +265,7 @@ def main():
                 modified |= vlan.admin != admin_state
                 vlan.admin = admin_state
             elif admin_state == "down":
-                warnings.append(
+                ansible_module.warn(
                     "Unable to set admin_state to down on VLAN {0}".format(
                         vlan_id
                     )
@@ -308,7 +307,6 @@ def main():
                 ansible_module.fail_json(msg=str(e))
 
     result["changed"] = modified
-    result["warnings"] = warnings
 
     # Exit
     ansible_module.exit_json(**result)


### PR DESCRIPTION
This commit should update the remaining modules that do not already use the `AnsibleModule.warn` method for raising warnings instead of the deprecated practice of passing a `warnings` key to `exit_json` (see #134)