### PR TITLE
fix: change order on variables

### DIFF
--- a/plugins/connection/aoscx.py
+++ b/plugins/connection/aoscx.py
@@ -19,8 +19,8 @@ options:
       connection to.
     default: inventory_hostname
     vars:
-      - name: ansible_host
       - name: inventory_hostname
+      - name: ansible_host
   port:
     type: int
     description: >


### PR DESCRIPTION
Fix order on variables for connections to make the connections work if inventory_hostname does not resolve.