### PR TITLE
Add aoscx_ntp_key and aoscx_ntp_server modules

### DIFF
--- a/changelogs/fragments/aoscx_ntp.yml
+++ b/changelogs/fragments/aoscx_ntp.yml
@@ -1,0 +1,7 @@
+---
+minor_changes:
+  - aoscx_ntp_key - new module to manage NTP authentication keys
+    (system/ntp_keys) backed by the pyaoscx NtpKey class.
+  - aoscx_ntp_server - new module to manage NTP server associations
+    (system/vrfs/{vrf}/ntp_associations) backed by the pyaoscx
+    NtpAssociation class.

--- a/plugins/modules/aoscx_ntp_key.py
+++ b/plugins/modules/aoscx_ntp_key.py
@@ -25,6 +25,9 @@ description: >
   AOS-CX devices (system/ntp_keys). An NTP key is identified by a numeric
   key_id and is used to authenticate NTP associations.
 author: Aruba Networks (@ArubaNetworks)
+notes:
+  - When C(key_password) is supplied the module reports changed on every run
+    because the secret cannot be read back from the switch for comparison.
 options:
   key_id:
     description: >

--- a/plugins/modules/aoscx_ntp_key.py
+++ b/plugins/modules/aoscx_ntp_key.py
@@ -159,7 +159,11 @@ def main():
     if trust_enable is not None:
         kwargs["trust_enable"] = trust_enable
 
-    ntp_key = NtpKey(session, key_id, **kwargs)
+    if exists:
+        for key, value in kwargs.items():
+            setattr(ntp_key, key, value)
+    else:
+        ntp_key = NtpKey(session, key_id, **kwargs)
     result["changed"] = ntp_key.apply()
 
     ansible_module.exit_json(**result)

--- a/plugins/modules/aoscx_ntp_key.py
+++ b/plugins/modules/aoscx_ntp_key.py
@@ -1,0 +1,169 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_ntp_key
+version_added: "4.6.0"
+short_description: Create, update or delete an NTP authentication key
+description: >
+  This module provides configuration management of NTP authentication keys on
+  AOS-CX devices (system/ntp_keys). An NTP key is identified by a numeric
+  key_id and is used to authenticate NTP associations.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  key_id:
+    description: >
+      Numeric identifier of the NTP authentication key. This is the index of
+      the resource under system/ntp_keys.
+    required: true
+    type: int
+  key_password:
+    description: >
+      Authentication password of the NTP key. Required when creating the key.
+    required: false
+    type: str
+  key_type:
+    description: Digest algorithm used by the key.
+    required: false
+    type: str
+    choices:
+      - md5
+      - sha1
+      - aes128
+  trust_enable:
+    description: Whether the key is trusted for NTP authentication.
+    required: false
+    type: bool
+  state:
+    description: Create, update or delete the NTP key.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create an NTP authentication key
+  aoscx_ntp_key:
+    key_id: 60001
+    key_password: my_secret_key
+    key_type: md5
+    trust_enable: true
+
+- name: Delete an NTP authentication key
+  aoscx_ntp_key:
+    key_id: 60001
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+    from pyaoscx.ntp_key import NtpKey
+
+    HAS_PYAOSCX_NTP = True
+except ImportError:
+    HAS_PYAOSCX_NTP = False
+
+if HAS_PYAOSCX_NTP:
+    from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+        get_pyaoscx_session,
+    )
+
+
+def main():
+    module_args = dict(
+        key_id=dict(type="int", required=True),
+        key_password=dict(type="str", required=False, no_log=True),
+        key_type=dict(
+            type="str", required=False, choices=["md5", "sha1", "aes128"]
+        ),
+        trust_enable=dict(type="bool", required=False),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+        required_if=[("state", "create", ["key_password"])],
+    )
+
+    result = dict(changed=False)
+
+    if not HAS_PYAOSCX_NTP:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support NTP keys. "
+                "Upgrade pyaoscx."
+            )
+        )
+
+    if ansible_module.check_mode:
+        ansible_module.exit_json(**result)
+
+    key_id = ansible_module.params["key_id"]
+    key_password = ansible_module.params["key_password"]
+    key_type = ansible_module.params["key_type"]
+    trust_enable = ansible_module.params["trust_enable"]
+    state = ansible_module.params["state"]
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    ntp_key = NtpKey(session, key_id)
+    try:
+        ntp_key.get()
+        exists = True
+    except Exception:
+        exists = False
+
+    if state == "delete":
+        if exists:
+            ntp_key.delete()
+            result["changed"] = True
+        ansible_module.exit_json(**result)
+
+    kwargs = {}
+    if key_password is not None:
+        kwargs["key_password"] = key_password
+    if key_type is not None:
+        kwargs["key_type"] = key_type
+    if trust_enable is not None:
+        kwargs["trust_enable"] = trust_enable
+
+    ntp_key = NtpKey(session, key_id, **kwargs)
+    result["changed"] = ntp_key.apply()
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_ntp_server.py
+++ b/plugins/modules/aoscx_ntp_server.py
@@ -1,0 +1,218 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_ntp_server
+version_added: "4.6.0"
+short_description: Create, update or delete an NTP server association
+description: >
+  This module provides configuration management of NTP server associations on
+  AOS-CX devices (system/vrfs/{vrf}/ntp_associations). A server is identified
+  by its address within a VRF. Optionally the association may reference an
+  existing NTP key for authentication.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  address:
+    description: >
+      Hostname or IP address of the NTP server. This is the index of the
+      resource under the VRF's ntp_associations.
+    required: true
+    type: str
+  vrf:
+    description: VRF the NTP association belongs to.
+    required: false
+    type: str
+    default: default
+  key_id:
+    description: >
+      key_id of an existing NTP authentication key used for this association.
+    required: false
+    type: int
+  prefer:
+    description: Mark this server as preferred.
+    required: false
+    type: bool
+  ntp_version:
+    description: NTP protocol version used for this association.
+    required: false
+    type: int
+    choices:
+      - 3
+      - 4
+  burst_mode:
+    description: Burst mode used when polling this server.
+    required: false
+    type: str
+    choices:
+      - none
+      - burst
+      - iburst
+  minpoll:
+    description: Minimum poll interval (power of two seconds).
+    required: false
+    type: int
+  maxpoll:
+    description: Maximum poll interval (power of two seconds).
+    required: false
+    type: int
+  state:
+    description: Create, update or delete the NTP server association.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create an NTP server association
+  aoscx_ntp_server:
+    address: 198.51.100.1
+    vrf: default
+    prefer: true
+    ntp_version: 4
+    burst_mode: iburst
+
+- name: Create an authenticated NTP server association
+  aoscx_ntp_server:
+    address: 198.51.100.2
+    key_id: 60001
+
+- name: Delete an NTP server association
+  aoscx_ntp_server:
+    address: 198.51.100.1
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+    from pyaoscx.ntp_association import NtpAssociation
+    from pyaoscx.ntp_key import NtpKey
+    from pyaoscx.vrf import Vrf
+
+    HAS_PYAOSCX_NTP = True
+except ImportError:
+    HAS_PYAOSCX_NTP = False
+
+if HAS_PYAOSCX_NTP:
+    from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+        get_pyaoscx_session,
+    )
+
+
+def main():
+    module_args = dict(
+        address=dict(type="str", required=True),
+        vrf=dict(type="str", required=False, default="default"),
+        key_id=dict(type="int", required=False),
+        prefer=dict(type="bool", required=False),
+        ntp_version=dict(type="int", required=False, choices=[3, 4]),
+        burst_mode=dict(
+            type="str",
+            required=False,
+            choices=["none", "burst", "iburst"],
+        ),
+        minpoll=dict(type="int", required=False),
+        maxpoll=dict(type="int", required=False),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    result = dict(changed=False)
+
+    if not HAS_PYAOSCX_NTP:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support NTP associations. "
+                "Upgrade pyaoscx."
+            )
+        )
+
+    if ansible_module.check_mode:
+        ansible_module.exit_json(**result)
+
+    address = ansible_module.params["address"]
+    vrf_name = ansible_module.params["vrf"]
+    key_id = ansible_module.params["key_id"]
+    prefer = ansible_module.params["prefer"]
+    ntp_version = ansible_module.params["ntp_version"]
+    burst_mode = ansible_module.params["burst_mode"]
+    minpoll = ansible_module.params["minpoll"]
+    maxpoll = ansible_module.params["maxpoll"]
+    state = ansible_module.params["state"]
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    vrf = Vrf(session, vrf_name)
+
+    assoc = NtpAssociation(session, vrf, address)
+    try:
+        assoc.get()
+        exists = True
+    except Exception:
+        exists = False
+
+    if state == "delete":
+        if exists:
+            assoc.delete()
+            result["changed"] = True
+        ansible_module.exit_json(**result)
+
+    kwargs = {}
+    if key_id is not None:
+        kwargs["key_id"] = NtpKey(session, key_id).get_uri()
+
+    association_attributes = {}
+    if prefer is not None:
+        association_attributes["prefer"] = prefer
+    if ntp_version is not None:
+        association_attributes["ntp_version"] = ntp_version
+    if burst_mode is not None:
+        association_attributes["burst_mode"] = burst_mode
+    if minpoll is not None:
+        association_attributes["minpoll"] = minpoll
+    if maxpoll is not None:
+        association_attributes["maxpoll"] = maxpoll
+    if association_attributes:
+        kwargs["association_attributes"] = association_attributes
+
+    assoc = NtpAssociation(session, vrf, address, **kwargs)
+    result["changed"] = assoc.apply()
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_ntp_server.py
+++ b/plugins/modules/aoscx_ntp_server.py
@@ -209,6 +209,10 @@ def main():
         kwargs["association_attributes"] = association_attributes
 
     assoc = NtpAssociation(session, vrf, address, **kwargs)
+    if exists:
+        assoc.get()
+        for key, value in kwargs.items():
+            setattr(assoc, key, value)
     result["changed"] = assoc.apply()
 
     ansible_module.exit_json(**result)

--- a/plugins/modules/aoscx_ntp_server.py
+++ b/plugins/modules/aoscx_ntp_server.py
@@ -212,7 +212,16 @@ def main():
     if exists:
         assoc.get()
         for key, value in kwargs.items():
-            setattr(assoc, key, value)
+            # association_attributes is a nested dict; the switch returns more
+            # keys than supplied, so merge to keep idempotency.
+            if key == "association_attributes" and isinstance(
+                getattr(assoc, key, None), dict
+            ):
+                merged = dict(getattr(assoc, key))
+                merged.update(value)
+                setattr(assoc, key, merged)
+            else:
+                setattr(assoc, key, value)
     result["changed"] = assoc.apply()
 
     ansible_module.exit_json(**result)

--- a/tests/unit/modules/test_aoscx_ntp.py
+++ b/tests/unit/modules/test_aoscx_ntp.py
@@ -1,0 +1,244 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_ntp_key and aoscx_ntp_server modules. The pyaoscx
+NtpKey, NtpAssociation and Vrf classes are fully mocked, so no switch is
+required.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_ntp_key,
+    aoscx_ntp_server,
+)
+
+KEY_MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules.aoscx_ntp_key"
+)
+SRV_MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules.aoscx_ntp_server"
+)
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+WRITES = []
+
+
+class FakeNtpKey:
+    exists = False
+
+    def __init__(self, session, key_id, **kwargs):
+        self.session = session
+        self.key_id = key_id
+        self.kwargs = kwargs
+
+    def get(self, depth=None, selector=None):
+        if not FakeNtpKey.exists:
+            raise Exception("no key")
+        return True
+
+    def get_uri(self):
+        return "/rest/v10.09/system/ntp_keys/{0}".format(self.key_id)
+
+    def delete(self):
+        WRITES.append(("key_delete", self.key_id, None))
+
+    def apply(self):
+        WRITES.append(("key_apply", self.key_id, dict(self.kwargs)))
+        return True
+
+
+class FakeVrf:
+    def __init__(self, session, name):
+        self.name = name
+
+
+class FakeAssoc:
+    exists = False
+
+    def __init__(self, session, vrf, address, **kwargs):
+        self.session = session
+        self.vrf = vrf
+        self.address = address
+        self.kwargs = kwargs
+
+    def get(self, depth=None, selector=None):
+        if not FakeAssoc.exists:
+            raise Exception("no assoc")
+        return True
+
+    def delete(self):
+        WRITES.append(("assoc_delete", self.address, None))
+
+    def apply(self):
+        WRITES.append(("assoc_apply", self.address, dict(self.kwargs)))
+        return True
+
+
+def run_key(args):
+    WRITES.clear()
+    set_module_args(args)
+    with patch(KEY_MODULE + ".get_pyaoscx_session", return_value=object()), \
+            patch(KEY_MODULE + ".NtpKey", FakeNtpKey), \
+            patch(KEY_MODULE + ".HAS_PYAOSCX_NTP", True):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_ntp_key.main()
+    return exc.value.args[0]
+
+
+def run_srv(args):
+    WRITES.clear()
+    set_module_args(args)
+    with patch(SRV_MODULE + ".get_pyaoscx_session", return_value=object()), \
+            patch(SRV_MODULE + ".NtpAssociation", FakeAssoc), \
+            patch(SRV_MODULE + ".NtpKey", FakeNtpKey), \
+            patch(SRV_MODULE + ".Vrf", FakeVrf), \
+            patch(SRV_MODULE + ".HAS_PYAOSCX_NTP", True):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_ntp_server.main()
+    return exc.value.args[0]
+
+
+# --------------------------------------------------------------------------
+# aoscx_ntp_key
+# --------------------------------------------------------------------------
+def test_key_create():
+    FakeNtpKey.exists = False
+    result = run_key(
+        {
+            "key_id": 60001,
+            "key_password": "secret",
+            "key_type": "md5",
+            "trust_enable": True,
+        }
+    )
+    assert result["changed"] is True
+    applies = [w for w in WRITES if w[0] == "key_apply"]
+    assert applies and applies[0][1] == 60001
+    assert applies[0][2]["key_type"] == "md5"
+
+
+def test_key_delete():
+    FakeNtpKey.exists = True
+    result = run_key({"key_id": 60001, "state": "delete"})
+    assert result["changed"] is True
+    assert ("key_delete", 60001, None) in WRITES
+
+
+def test_key_delete_absent():
+    FakeNtpKey.exists = False
+    result = run_key({"key_id": 60001, "state": "delete"})
+    assert result["changed"] is False
+    assert not WRITES
+
+
+def test_key_check_mode():
+    FakeNtpKey.exists = False
+    set_module_args(
+        {
+            "key_id": 60001,
+            "key_password": "secret",
+            "_ansible_check_mode": True,
+        }
+    )
+    with patch(KEY_MODULE + ".get_pyaoscx_session", return_value=object()), \
+            patch(KEY_MODULE + ".NtpKey", FakeNtpKey), \
+            patch(KEY_MODULE + ".HAS_PYAOSCX_NTP", True):
+        with pytest.raises(AnsibleExitJson) as exc:
+            aoscx_ntp_key.main()
+    assert exc.value.args[0]["changed"] is False
+    assert not WRITES
+
+
+def test_key_required_password():
+    WRITES.clear()
+    set_module_args({"key_id": 60001, "state": "create"})
+    with patch(KEY_MODULE + ".get_pyaoscx_session", return_value=object()), \
+            patch(KEY_MODULE + ".NtpKey", FakeNtpKey), \
+            patch(KEY_MODULE + ".HAS_PYAOSCX_NTP", True):
+        with pytest.raises(AnsibleFailJson) as exc:
+            aoscx_ntp_key.main()
+    assert exc.value.args[0]["failed"] is True
+
+
+# --------------------------------------------------------------------------
+# aoscx_ntp_server
+# --------------------------------------------------------------------------
+def test_srv_create():
+    FakeAssoc.exists = False
+    result = run_srv(
+        {"address": "198.51.100.1", "prefer": True, "ntp_version": 4}
+    )
+    assert result["changed"] is True
+    applies = [w for w in WRITES if w[0] == "assoc_apply"]
+    assert applies and applies[0][1] == "198.51.100.1"
+    assert applies[0][2]["association_attributes"]["prefer"] is True
+
+
+def test_srv_create_with_key():
+    FakeAssoc.exists = False
+    result = run_srv({"address": "198.51.100.2", "key_id": 60001})
+    assert result["changed"] is True
+    applies = [w for w in WRITES if w[0] == "assoc_apply"]
+    assert applies[0][2]["key_id"].endswith("ntp_keys/60001")
+
+
+def test_srv_delete():
+    FakeAssoc.exists = True
+    result = run_srv({"address": "198.51.100.1", "state": "delete"})
+    assert result["changed"] is True
+    assert ("assoc_delete", "198.51.100.1", None) in WRITES
+
+
+def test_srv_delete_absent():
+    FakeAssoc.exists = False
+    result = run_srv({"address": "198.51.100.1", "state": "delete"})
+    assert result["changed"] is False
+    assert not WRITES


### PR DESCRIPTION
Fixes #188

## Summary

Add two NTP management modules, backed by dedicated pyaoscx SDK classes:

- `aoscx_ntp_key` — manage NTP authentication keys (`system/ntp_keys`).
  Index `key_id`; `key_password` is `no_log`; `key_type` (md5/sha1/aes128),
  `trust_enable`; `required_if` enforces `key_password` on create.
- `aoscx_ntp_server` — manage NTP server associations
  (`system/vrfs/{vrf}/ntp_associations`). Index `address` per VRF; optional
  `key_id` reference, `prefer`, `ntp_version`, `burst_mode`, `min/maxpoll`.

Both support check_mode and full DOCUMENTATION/EXAMPLES/RETURN. SDK side is
`NtpKey`/`NtpAssociation` (pyaoscx PR aruba/pyaoscx#76).

## Tests

- `tests/unit/modules/test_aoscx_ntp.py` — 9 unit tests: create, delete,
  delete-absent, check_mode, required_if, authenticated server. All pass.
- sanity validate-modules / pep8 / pylint clean.
- Live lifecycle (create + delete) on a 6300 FL.10.17 at REST v10.09, no
  production servers touched.

Changelog fragment included.

## Depends on
- aruba/pyaoscx#76 — NtpKey / NtpAssociation
