### PR TITLE
Back MACsec, MKA and keychain modules with the pyaoscx SDK

### DIFF
--- a/changelogs/fragments/macsec.yml
+++ b/changelogs/fragments/macsec.yml
@@ -2,5 +2,9 @@
 minor_changes:
   - aoscx_macsec_policy - new module to create, update or delete MACsec policies
     (system/macsec_policies), including their cipher suites and bypass options.
+  - aoscx_keychain - new module to create, update or delete keychains and their
+    authentication keys (system/keychains).
+  - aoscx_mka_policy - new module to create, update or delete MKA policies
+    (system/mka_policies), referencing a keychain and pre-shared CAK/CKN.
   - aoscx connection plugin - allow REST API version 10.16, which is required
     by the MACsec modules.

--- a/changelogs/fragments/macsec.yml
+++ b/changelogs/fragments/macsec.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - aoscx_macsec_policy - new module to create, update or delete MACsec policies
+    (system/macsec_policies), including their cipher suites and bypass options.
+  - aoscx connection plugin - allow REST API version 10.16, which is required
+    by the MACsec modules.

--- a/docs/aoscx_keychain.md
+++ b/docs/aoscx_keychain.md
@@ -1,0 +1,122 @@
+# module: aoscx_keychain
+
+description: This module provides configuration management of keychains on AOS-CX
+devices (system/keychains). A keychain is a named container of authentication
+keys used by MKA policies and routing protocol authentication. This module
+requires REST API version 10.16 (set ansible_aoscx_rest_version to 10.16). The
+supplied keys fully replace the existing keys of the keychain. The fields of a
+key cannot be modified in place; when they change the key is recreated. The
+auth_key value is write-only on the switch and cannot be read back, so a change
+to auth_key alone (without any other key field change) is not detected.
+
+##### ARGUMENTS
+
+```YAML
+  name:
+    description: Name of the keychain (index under system/keychains).
+    required: true
+    type: str
+  keys:
+    description: >
+      List of keys of the keychain. The supplied list fully replaces the
+      existing keys. When omitted, the keys are left untouched and only the
+      existence of the keychain is reconciled.
+    required: false
+    type: list
+    elements: dict
+    suboptions:
+      key_id:
+        description: Identifier of the key within the keychain.
+        required: true
+        type: int
+      auth_type:
+        description: Authentication algorithm of the key.
+        required: false
+        type: str
+        choices:
+          - md5
+          - sha1
+          - sha256
+          - sha384
+          - sha512
+          - aes_cmac128
+      auth_key:
+        description: >
+          Authentication key value. This value is write-only on the switch and
+          cannot be read back; a change to auth_key alone is not detected.
+        required: false
+        type: str
+      name:
+        description: Optional name of the key.
+        required: false
+        type: str
+      accept_start:
+        description: >
+          Start of the period during which the key is accepted, as a Unix
+          timestamp (between 1577836800 and 2556143999).
+        required: false
+        type: int
+      accept_end:
+        description: >
+          End of the period during which the key is accepted, as a Unix
+          timestamp (between 1577836800 and 2556143999).
+        required: false
+        type: int
+      send_start:
+        description: >
+          Start of the period during which the key is used to send, as a Unix
+          timestamp (between 1577836800 and 2556143999).
+        required: false
+        type: int
+      send_end:
+        description: >
+          End of the period during which the key is used to send, as a Unix
+          timestamp (between 1577836800 and 2556143999).
+        required: false
+        type: int
+      recv_id:
+        description: Receive identifier of the key.
+        required: false
+        type: int
+      send_id:
+        description: Send identifier of the key.
+        required: false
+        type: int
+  state:
+    description: Create, update or delete the keychain.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create a keychain with one SHA-256 key
+  aoscx_keychain:
+    name: mka_keys
+    keys:
+      - key_id: 1
+        auth_type: sha256
+        auth_key: "S3cretKey123"
+        accept_start: 1577836800
+        accept_end: 2556143999
+        send_start: 1577836800
+        send_end: 2556143999
+        recv_id: 1
+        send_id: 1
+
+- name: Remove all keys but keep the keychain
+  aoscx_keychain:
+    name: mka_keys
+    keys: []
+
+- name: Delete a keychain
+  aoscx_keychain:
+    name: mka_keys
+    state: delete
+```

--- a/docs/aoscx_macsec_policy.md
+++ b/docs/aoscx_macsec_policy.md
@@ -1,0 +1,145 @@
+# module: aoscx_macsec_policy
+
+description: This module provides configuration management of MACsec policies on
+AOS-CX devices (system/macsec_policies). A MACsec policy defines the
+confidentiality, replay protection and cipher suite behaviour applied to a
+MACsec protected channel; it is referenced by MKA policies and port access
+roles. This module requires REST API version 10.16 (set
+ansible_aoscx_rest_version to 10.16).
+
+##### ARGUMENTS
+
+```YAML
+  name:
+    description: Name of the MACsec policy, index under system/macsec_policies.
+    required: true
+    type: str
+  clear_tag_mode:
+    description: >
+      Ethernet data that must precede the MACsec SecTAG in clear text. With
+      dot1q the 802.1q tag is sent in clear and untagged traffic is not allowed
+      on the MACsec channel.
+    required: false
+    type: str
+    choices:
+      - none
+      - dot1q
+  confidentiality_disable:
+    description: Disable encryption on the MACsec interface.
+    required: false
+    type: bool
+  confidentiality_offset:
+    description: >
+      Number of leading octets of an Ethernet frame that are left unencrypted.
+      Only applicable when confidentiality is enabled.
+    required: false
+    type: str
+    choices:
+      - byte_0
+      - byte_30
+      - byte_50
+  data_delay_protection_enable:
+    description: >
+      Enable data delay protection so that MACsec frames delayed by more than
+      two seconds are dropped.
+    required: false
+    type: bool
+  include_sci_disable:
+    description: >
+      Disable inclusion of the Secure Channel Identifier (SCI) in MACsec
+      frames.
+    required: false
+    type: bool
+  replay_protect_disable:
+    description: Disable replay protection on the MACsec interface.
+    required: false
+    type: bool
+  replay_window:
+    description: >
+      Replay protection window. A received packet is processed only if its
+      packet number is within this window. Only applicable when replay
+      protection is enabled.
+    required: false
+    type: int
+  secure_mode:
+    description: >
+      Forwarding behaviour of the interface when the MKA session is not
+      established. should-secure opens the data plane without MACsec
+      protection; must-secure blocks the interface.
+    required: false
+    type: str
+    choices:
+      - should-secure
+      - must-secure
+  bypass:
+    description: Features that bypass MACsec processing on the channel.
+    required: false
+    type: dict
+    suboptions:
+      ieee_bpdu_enabled:
+        description: >
+          Bypass MACsec protection for IEEE BPDU frames (destination MAC in
+          01:80:c2:00:00:0*) in both directions.
+        required: false
+        type: bool
+  cipher_suites:
+    description: >
+      MACsec cipher suites used to protect the frames. When more than one is
+      enabled the most secure one is used to generate the SAK when the switch
+      is the key server.
+    required: false
+    type: dict
+    suboptions:
+      gcm_aes_128_enabled:
+        description: Enable GCM with the AES-128 cipher.
+        required: false
+        type: bool
+      gcm_aes_256_enabled:
+        description: Enable GCM with the AES-256 cipher.
+        required: false
+        type: bool
+      gcm_aes_xpn_128_enabled:
+        description: >
+          Enable GCM with the AES-128 cipher and extended packet numbering.
+        required: false
+        type: bool
+      gcm_aes_xpn_256_enabled:
+        description: >
+          Enable GCM with the AES-256 cipher and extended packet numbering.
+        required: false
+        type: bool
+  state:
+    description: Create, update or delete the MACsec policy.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create a MACsec policy that must secure with AES-256
+  aoscx_macsec_policy:
+    name: secure_uplinks
+    secure_mode: must-secure
+    confidentiality_offset: byte_0
+    cipher_suites:
+      gcm_aes_256_enabled: true
+
+- name: Relax a MACsec policy to should-secure and bypass BPDUs
+  aoscx_macsec_policy:
+    name: secure_uplinks
+    state: update
+    secure_mode: should-secure
+    bypass:
+      ieee_bpdu_enabled: true
+
+- name: Delete a MACsec policy
+  aoscx_macsec_policy:
+    name: secure_uplinks
+    state: delete
+```

--- a/docs/aoscx_mka_policy.md
+++ b/docs/aoscx_mka_policy.md
@@ -1,0 +1,96 @@
+# module: aoscx_mka_policy
+
+description: This module provides configuration management of MKA (MACsec Key
+Agreement) policies on AOS-CX devices (system/mka_policies). An MKA policy
+references a keychain and defines the pre-shared CAK/CKN and EAPOL parameters
+used to establish MACsec sessions. This module requires REST API version 10.16
+(set ansible_aoscx_rest_version to 10.16). The cak and ckn values are write-only
+on the switch and cannot be read back, so a change to cak or ckn alone (without
+any other field change) is not detected.
+
+##### ARGUMENTS
+
+```YAML
+  name:
+    description: Name of the MKA policy (index under system/mka_policies).
+    required: true
+    type: str
+  mode:
+    description: Key agreement mode of the policy.
+    required: false
+    type: str
+    choices:
+      - psk
+      - eap-tls
+  keychain:
+    description: >
+      Name of the keychain referenced by the policy. The keychain must already
+      exist on the device.
+    required: false
+    type: str
+  cak:
+    description: >
+      Connectivity Association Key. This value is write-only on the switch and
+      cannot be read back; a change to cak alone is not detected.
+    required: false
+    type: str
+  ckn:
+    description: >
+      Connectivity Association Key Name. This value is write-only on the switch
+      and cannot be read back; a change to ckn alone is not detected.
+    required: false
+    type: str
+  key_server_priority:
+    description: Priority of the key server.
+    required: false
+    type: int
+  transmit_interval:
+    description: MKA hello transmit interval in seconds.
+    required: false
+    type: int
+  eapol_destination_mac:
+    description: Destination MAC address used for EAPOL frames.
+    required: false
+    type: str
+  eapol_dot1q_tagged:
+    description: Whether EAPOL frames are 802.1Q tagged.
+    required: false
+    type: bool
+  eapol_eth_type:
+    description: Ethertype used for EAPOL frames.
+    required: false
+    type: str
+  state:
+    description: Create, update or delete the MKA policy.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create an MKA policy referencing a keychain
+  aoscx_mka_policy:
+    name: mka1
+    mode: psk
+    keychain: mka_keys
+    cak: "00112233445566778899aabbccddeeff"
+    ckn: "11"
+    key_server_priority: 5
+    transmit_interval: 2
+
+- name: Update the transmit interval of an MKA policy
+  aoscx_mka_policy:
+    name: mka1
+    transmit_interval: 6
+
+- name: Delete an MKA policy
+  aoscx_mka_policy:
+    name: mka1
+    state: delete
+```

--- a/plugins/connection/aoscx.py
+++ b/plugins/connection/aoscx.py
@@ -120,9 +120,9 @@ options:
       - name: ansible_persistent_log_messages
   rest_version:
     description: >
-      Configures REST version, default version is 10.04, but 10.08 or 10.09
-      can be used in a specific host or globaly if it is set as an environment
-      variable.
+      Configures REST version, default version is 10.04, but 10.08, 10.09 or
+      10.16 can be used in a specific host or globaly if it is set as an
+      environment variable. The MACsec modules require 10.16.
     default: '10.04'
     env:
       - name: ANSIBLE_AOSCX_REST_VERSION
@@ -208,7 +208,7 @@ class Connection(NetworkConnectionBase):
             password = self.get_option("password")
             self.use_proxy = self.get_option("use_proxy")
             rest_version = self.get_option("rest_version")
-            if rest_version not in ["10.04", "10.08", "10.09"]:
+            if rest_version not in ["10.04", "10.08", "10.09", "10.16"]:
                 raise AnsibleConnectionFailure("Invalid REST version: %s"
                                                % rest_version)
             self.base_url = "https://{0}/rest/v{1}/".format(switchip, rest_version)

--- a/plugins/modules/aoscx_keychain.py
+++ b/plugins/modules/aoscx_keychain.py
@@ -1,0 +1,363 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_keychain
+version_added: "4.6.0"
+short_description: Create, update or delete a keychain
+description: >
+  This module provides configuration management of keychains on AOS-CX devices
+  (system/keychains). A keychain is a named container of authentication keys
+  used by MKA policies and routing protocol authentication. This module
+  requires REST API version 10.16 (set ansible_aoscx_rest_version to 10.16).
+  The supplied keys fully replace the existing keys of the keychain. The
+  fields of a key cannot be modified in place; when they change the key is
+  recreated. The auth_key value is write-only on the switch and cannot be read
+  back, so a change to auth_key alone (without any other key field change) is
+  not detected.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: Name of the keychain (index under system/keychains).
+    required: true
+    type: str
+  keys:
+    description: >
+      List of keys of the keychain. The supplied list fully replaces the
+      existing keys. When omitted, the keys are left untouched and only the
+      existence of the keychain is reconciled.
+    required: false
+    type: list
+    elements: dict
+    suboptions:
+      key_id:
+        description: Identifier of the key within the keychain.
+        required: true
+        type: int
+      auth_type:
+        description: Authentication algorithm of the key.
+        required: false
+        type: str
+        choices:
+          - md5
+          - sha1
+          - sha256
+          - sha384
+          - sha512
+          - aes_cmac128
+      auth_key:
+        description: >
+          Authentication key value. This value is write-only on the switch and
+          cannot be read back; a change to auth_key alone is not detected.
+        required: false
+        type: str
+      name:
+        description: Optional name of the key.
+        required: false
+        type: str
+      accept_start:
+        description: >
+          Start of the period during which the key is accepted, as a Unix
+          timestamp (between 1577836800 and 2556143999).
+        required: false
+        type: int
+      accept_end:
+        description: >
+          End of the period during which the key is accepted, as a Unix
+          timestamp (between 1577836800 and 2556143999).
+        required: false
+        type: int
+      send_start:
+        description: >
+          Start of the period during which the key is used to send, as a Unix
+          timestamp (between 1577836800 and 2556143999).
+        required: false
+        type: int
+      send_end:
+        description: >
+          End of the period during which the key is used to send, as a Unix
+          timestamp (between 1577836800 and 2556143999).
+        required: false
+        type: int
+      recv_id:
+        description: Receive identifier of the key.
+        required: false
+        type: int
+      send_id:
+        description: Send identifier of the key.
+        required: false
+        type: int
+  state:
+    description: Create, update or delete the keychain.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a keychain with one SHA-256 key
+  aoscx_keychain:
+    name: mka_keys
+    keys:
+      - key_id: 1
+        auth_type: sha256
+        auth_key: "S3cretKey123"
+        accept_start: 1577836800
+        accept_end: 2556143999
+        send_start: 1577836800
+        send_end: 2556143999
+        recv_id: 1
+        send_id: 1
+
+- name: Remove all keys but keep the keychain
+  aoscx_keychain:
+    name: mka_keys
+    keys: []
+
+- name: Delete a keychain
+  aoscx_keychain:
+    name: mka_keys
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+COLLECTION = "system/keychains"
+
+# Comparable (immutable) key fields used to decide whether an existing key
+# must be recreated. auth_key is excluded because it is write-only and cannot
+# be read back for comparison.
+COMPARABLE_KEY_FIELDS = [
+    "auth_type",
+    "name",
+    "accept_start",
+    "accept_end",
+    "send_start",
+    "send_end",
+    "recv_id",
+    "send_id",
+]
+
+KEY_FIELDS = [
+    {
+        "name": "auth_type",
+        "type": "str",
+        "choices": [
+            "md5",
+            "sha1",
+            "sha256",
+            "sha384",
+            "sha512",
+            "aes_cmac128",
+        ],
+    },
+    {"name": "auth_key", "type": "str", "no_log": True},
+    {"name": "name", "type": "str"},
+    {"name": "accept_start", "type": "int"},
+    {"name": "accept_end", "type": "int"},
+    {"name": "send_start", "type": "int"},
+    {"name": "send_end", "type": "int"},
+    {"name": "recv_id", "type": "int"},
+    {"name": "send_id", "type": "int"},
+]
+
+
+def ok(response):
+    return response is not None and response.status_code < 400
+
+
+def build_argument_spec():
+    key_spec = dict(key_id=dict(type="int", required=True))
+    for field in KEY_FIELDS:
+        opt = dict(type=field["type"], required=False, default=None)
+        if field.get("choices"):
+            opt["choices"] = list(field["choices"])
+        if field.get("no_log"):
+            opt["no_log"] = True
+        key_spec[field["name"]] = opt
+
+    return dict(
+        name=dict(type="str", required=True),
+        keys=dict(
+            type="list",
+            elements="dict",
+            options=key_spec,
+            required=False,
+            default=None,
+        ),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+
+
+def _build_desired(ansible_module, keys):
+    desired = {}
+    for key in keys:
+        key_id = key["key_id"]
+        if key_id in desired:
+            ansible_module.fail_json(msg="Duplicate key_id {0}".format(key_id))
+        body = {"key_id": key_id}
+        for field in KEY_FIELDS:
+            value = key.get(field["name"])
+            if value is not None:
+                body[field["name"]] = value
+        desired[key_id] = body
+    return desired
+
+
+def _key_differs(want, current):
+    for field in COMPARABLE_KEY_FIELDS:
+        if field in want and want[field] != current.get(field):
+            return True
+    return False
+
+
+def _get_keys(session, container_path):
+    response = session.request(
+        "GET",
+        "{0}/keys".format(container_path),
+        params={"depth": 2, "selector": "configuration"},
+    )
+    if not ok(response):
+        return {}
+    return {int(kid): data for kid, data in response.json().items()}
+
+
+def _reconcile_keys(
+    ansible_module, session, container_path, desired, current, check_mode
+):
+    base = "{0}/keys".format(container_path)
+    changed = False
+
+    for key_id in current:
+        if key_id not in desired:
+            changed = True
+            if not check_mode:
+                session.request("DELETE", "{0}/{1}".format(base, key_id))
+
+    for key_id, want in desired.items():
+        cur = current.get(key_id)
+        if cur is None or _key_differs(want, cur):
+            changed = True
+            if not check_mode:
+                if cur is not None:
+                    session.request("DELETE", "{0}/{1}".format(base, key_id))
+                response = session.request(
+                    "POST", base, data=ansible_module.jsonify(want)
+                )
+                if not ok(response):
+                    ansible_module.fail_json(
+                        msg="Could not create key {0}: {1}".format(
+                            key_id, response.text
+                        )
+                    )
+
+    return changed
+
+
+def run_module(ansible_module, session):
+    params = ansible_module.params
+    name = params["name"]
+    state = params["state"]
+    keys_param = params["keys"]
+    manage_keys = keys_param is not None
+    keys = keys_param or []
+    check_mode = ansible_module.check_mode
+    container_path = "{0}/{1}".format(COLLECTION, name)
+
+    result = dict(changed=False)
+    exists = ok(session.request("GET", container_path))
+
+    if state == "delete":
+        if exists and not check_mode:
+            response = session.request("DELETE", container_path)
+            if not ok(response):
+                ansible_module.fail_json(
+                    msg="Could not delete {0}: {1}".format(name, response.text)
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    desired = {}
+    if manage_keys:
+        desired = _build_desired(ansible_module, keys)
+
+    changed = False
+    if not exists:
+        changed = True
+        if not check_mode:
+            response = session.request(
+                "POST",
+                COLLECTION,
+                data=ansible_module.jsonify({"name": name}),
+            )
+            if not ok(response):
+                ansible_module.fail_json(
+                    msg="Could not create {0}: {1}".format(name, response.text)
+                )
+        current = {}
+    elif manage_keys:
+        current = _get_keys(session, container_path)
+    else:
+        current = {}
+
+    if manage_keys:
+        changed = (
+            _reconcile_keys(
+                ansible_module,
+                session,
+                container_path,
+                desired,
+                current,
+                check_mode,
+            )
+            or changed
+        )
+
+    result["changed"] = changed
+    ansible_module.exit_json(**result)
+
+
+def main():
+    ansible_module = AnsibleModule(
+        argument_spec=build_argument_spec(),
+        supports_check_mode=True,
+    )
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+    run_module(ansible_module, session)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_keychain.py
+++ b/plugins/modules/aoscx_keychain.py
@@ -210,6 +210,7 @@ def build_argument_spec():
             options=key_spec,
             required=False,
             default=None,
+            no_log=False,
         ),
         state=dict(
             type="str",

--- a/plugins/modules/aoscx_keychain.py
+++ b/plugins/modules/aoscx_keychain.py
@@ -31,6 +31,9 @@ description: >
   back, so a change to auth_key alone (without any other key field change) is
   not detected.
 author: Aruba Networks (@ArubaNetworks)
+notes:
+  - When a key C(auth_key) is supplied the module reports changed on every
+    run because the secret cannot be read back from the switch for comparison.
 options:
   name:
     description: Name of the keychain (index under system/keychains).

--- a/plugins/modules/aoscx_keychain.py
+++ b/plugins/modules/aoscx_keychain.py
@@ -146,7 +146,13 @@ from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx 
     get_pyaoscx_session,
 )
 
-COLLECTION = "system/keychains"
+try:
+    from pyaoscx.keychain import Keychain
+    from pyaoscx.keychain_key import KeychainKey
+
+    HAS_PYAOSCX_KEYCHAIN = True
+except ImportError:
+    HAS_PYAOSCX_KEYCHAIN = False
 
 # Comparable (immutable) key fields used to decide whether an existing key
 # must be recreated. auth_key is excluded because it is write-only and cannot
@@ -184,10 +190,6 @@ KEY_FIELDS = [
     {"name": "recv_id", "type": "int"},
     {"name": "send_id", "type": "int"},
 ]
-
-
-def ok(response):
-    return response is not None and response.status_code < 400
 
 
 def build_argument_spec():
@@ -239,28 +241,27 @@ def _key_differs(want, current):
     return False
 
 
-def _get_keys(session, container_path):
-    response = session.request(
-        "GET",
-        "{0}/keys".format(container_path),
-        params={"depth": 2, "selector": "configuration"},
-    )
-    if not ok(response):
-        return {}
-    return {int(kid): data for kid, data in response.json().items()}
+def _get_keys(session, keychain):
+    keys = {}
+    for key in KeychainKey.get_all(session, keychain).values():
+        key.get()
+        key_id = int(key.key_id)
+        keys[key_id] = {
+            field: getattr(key, field, None) for field in COMPARABLE_KEY_FIELDS
+        }
+    return keys
 
 
 def _reconcile_keys(
-    ansible_module, session, container_path, desired, current, check_mode
+    ansible_module, session, keychain, desired, current, check_mode
 ):
-    base = "{0}/keys".format(container_path)
     changed = False
 
     for key_id in current:
         if key_id not in desired:
             changed = True
             if not check_mode:
-                session.request("DELETE", "{0}/{1}".format(base, key_id))
+                KeychainKey(session, key_id, parent_keychain=keychain).delete()
 
     for key_id, want in desired.items():
         cur = current.get(key_id)
@@ -268,21 +269,30 @@ def _reconcile_keys(
             changed = True
             if not check_mode:
                 if cur is not None:
-                    session.request("DELETE", "{0}/{1}".format(base, key_id))
-                response = session.request(
-                    "POST", base, data=ansible_module.jsonify(want)
+                    KeychainKey(
+                        session, key_id, parent_keychain=keychain
+                    ).delete()
+                attrs = {k: v for k, v in want.items() if k != "key_id"}
+                key = KeychainKey(
+                    session, key_id, parent_keychain=keychain, **attrs
                 )
-                if not ok(response):
+                try:
+                    key.create()
+                except Exception as e:
                     ansible_module.fail_json(
                         msg="Could not create key {0}: {1}".format(
-                            key_id, response.text
+                            key_id, str(e)
                         )
                     )
 
     return changed
 
 
-def run_module(ansible_module, session):
+def main():
+    ansible_module = AnsibleModule(
+        argument_spec=build_argument_spec(),
+        supports_check_mode=True,
+    )
     params = ansible_module.params
     name = params["name"]
     state = params["state"]
@@ -290,17 +300,38 @@ def run_module(ansible_module, session):
     manage_keys = keys_param is not None
     keys = keys_param or []
     check_mode = ansible_module.check_mode
-    container_path = "{0}/{1}".format(COLLECTION, name)
 
     result = dict(changed=False)
-    exists = ok(session.request("GET", container_path))
+
+    if not HAS_PYAOSCX_KEYCHAIN:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support keychains. "
+                "Upgrade pyaoscx."
+            )
+        )
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    keychain = Keychain(session, name)
+    try:
+        keychain.get()
+        exists = True
+    except Exception:
+        exists = False
 
     if state == "delete":
         if exists and not check_mode:
-            response = session.request("DELETE", container_path)
-            if not ok(response):
+            try:
+                keychain.delete()
+            except Exception as e:
                 ansible_module.fail_json(
-                    msg="Could not delete {0}: {1}".format(name, response.text)
+                    msg="Could not delete {0}: {1}".format(name, str(e))
                 )
         result["changed"] = exists
         ansible_module.exit_json(**result)
@@ -313,18 +344,15 @@ def run_module(ansible_module, session):
     if not exists:
         changed = True
         if not check_mode:
-            response = session.request(
-                "POST",
-                COLLECTION,
-                data=ansible_module.jsonify({"name": name}),
-            )
-            if not ok(response):
+            try:
+                keychain.create()
+            except Exception as e:
                 ansible_module.fail_json(
-                    msg="Could not create {0}: {1}".format(name, response.text)
+                    msg="Could not create {0}: {1}".format(name, str(e))
                 )
         current = {}
     elif manage_keys:
-        current = _get_keys(session, container_path)
+        current = _get_keys(session, keychain)
     else:
         current = {}
 
@@ -333,7 +361,7 @@ def run_module(ansible_module, session):
             _reconcile_keys(
                 ansible_module,
                 session,
-                container_path,
+                keychain,
                 desired,
                 current,
                 check_mode,
@@ -343,20 +371,6 @@ def run_module(ansible_module, session):
 
     result["changed"] = changed
     ansible_module.exit_json(**result)
-
-
-def main():
-    ansible_module = AnsibleModule(
-        argument_spec=build_argument_spec(),
-        supports_check_mode=True,
-    )
-    try:
-        session = get_pyaoscx_session(ansible_module)
-    except Exception as e:
-        ansible_module.fail_json(
-            msg="Could not get PYAOSCX Session: {0}".format(str(e))
-        )
-    run_module(ansible_module, session)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/aoscx_macsec_policy.py
+++ b/plugins/modules/aoscx_macsec_policy.py
@@ -1,0 +1,340 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_macsec_policy
+version_added: "4.6.0"
+short_description: Create, update or delete a MACsec policy
+description: >
+  This module provides configuration management of MACsec policies on AOS-CX
+  devices (system/macsec_policies). A MACsec policy defines the
+  confidentiality, replay protection and cipher suite behaviour applied to a
+  MACsec protected channel; it is referenced by MKA policies and port access
+  roles. This module requires REST API version 10.16 (set
+  ansible_aoscx_rest_version to 10.16).
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: Name of the MACsec policy, index under system/macsec_policies.
+    required: true
+    type: str
+  clear_tag_mode:
+    description: >
+      Ethernet data that must precede the MACsec SecTAG in clear text. With
+      dot1q the 802.1q tag is sent in clear and untagged traffic is not allowed
+      on the MACsec channel.
+    required: false
+    type: str
+    choices:
+      - none
+      - dot1q
+  confidentiality_disable:
+    description: Disable encryption on the MACsec interface.
+    required: false
+    type: bool
+  confidentiality_offset:
+    description: >
+      Number of leading octets of an Ethernet frame that are left unencrypted.
+      Only applicable when confidentiality is enabled.
+    required: false
+    type: str
+    choices:
+      - byte_0
+      - byte_30
+      - byte_50
+  data_delay_protection_enable:
+    description: >
+      Enable data delay protection so that MACsec frames delayed by more than
+      two seconds are dropped.
+    required: false
+    type: bool
+  include_sci_disable:
+    description: >
+      Disable inclusion of the Secure Channel Identifier (SCI) in MACsec
+      frames.
+    required: false
+    type: bool
+  replay_protect_disable:
+    description: Disable replay protection on the MACsec interface.
+    required: false
+    type: bool
+  replay_window:
+    description: >
+      Replay protection window. A received packet is processed only if its
+      packet number is within this window. Only applicable when replay
+      protection is enabled.
+    required: false
+    type: int
+  secure_mode:
+    description: >
+      Forwarding behaviour of the interface when the MKA session is not
+      established. should-secure opens the data plane without MACsec
+      protection; must-secure blocks the interface.
+    required: false
+    type: str
+    choices:
+      - should-secure
+      - must-secure
+  bypass:
+    description: Features that bypass MACsec processing on the channel.
+    required: false
+    type: dict
+    suboptions:
+      ieee_bpdu_enabled:
+        description: >
+          Bypass MACsec protection for IEEE BPDU frames (destination MAC in
+          01:80:c2:00:00:0*) in both directions.
+        required: false
+        type: bool
+  cipher_suites:
+    description: >
+      MACsec cipher suites used to protect the frames. When more than one is
+      enabled the most secure one is used to generate the SAK when the switch
+      is the key server.
+    required: false
+    type: dict
+    suboptions:
+      gcm_aes_128_enabled:
+        description: Enable GCM with the AES-128 cipher.
+        required: false
+        type: bool
+      gcm_aes_256_enabled:
+        description: Enable GCM with the AES-256 cipher.
+        required: false
+        type: bool
+      gcm_aes_xpn_128_enabled:
+        description: >
+          Enable GCM with the AES-128 cipher and extended packet numbering.
+        required: false
+        type: bool
+      gcm_aes_xpn_256_enabled:
+        description: >
+          Enable GCM with the AES-256 cipher and extended packet numbering.
+        required: false
+        type: bool
+  state:
+    description: Create, update or delete the MACsec policy.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a MACsec policy that must secure with AES-256
+  aoscx_macsec_policy:
+    name: secure_uplinks
+    secure_mode: must-secure
+    confidentiality_offset: byte_0
+    cipher_suites:
+      gcm_aes_256_enabled: true
+
+- name: Relax a MACsec policy to should-secure and bypass BPDUs
+  aoscx_macsec_policy:
+    name: secure_uplinks
+    state: update
+    secure_mode: should-secure
+    bypass:
+      ieee_bpdu_enabled: true
+
+- name: Delete a MACsec policy
+  aoscx_macsec_policy:
+    name: secure_uplinks
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+COLLECTION = "system/macsec_policies"
+
+SCALAR_FIELDS = [
+    {"name": "clear_tag_mode", "type": "str", "choices": ["none", "dot1q"]},
+    {"name": "confidentiality_disable", "type": "bool"},
+    {
+        "name": "confidentiality_offset",
+        "type": "str",
+        "choices": ["byte_0", "byte_30", "byte_50"],
+    },
+    {"name": "data_delay_protection_enable", "type": "bool"},
+    {"name": "include_sci_disable", "type": "bool"},
+    {"name": "replay_protect_disable", "type": "bool"},
+    {"name": "replay_window", "type": "int"},
+    {
+        "name": "secure_mode",
+        "type": "str",
+        "choices": ["should-secure", "must-secure"],
+    },
+]
+
+NESTED_FIELDS = {
+    "bypass": ["ieee_bpdu_enabled"],
+    "cipher_suites": [
+        "gcm_aes_128_enabled",
+        "gcm_aes_256_enabled",
+        "gcm_aes_xpn_128_enabled",
+        "gcm_aes_xpn_256_enabled",
+    ],
+}
+
+
+def ok(response):
+    return response is not None and response.status_code < 400
+
+
+def build_argument_spec():
+    spec = dict(
+        name=dict(type="str", required=True),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    for field in SCALAR_FIELDS:
+        opt = dict(type=field["type"], required=False, default=None)
+        if field.get("choices"):
+            opt["choices"] = list(field["choices"])
+        spec[field["name"]] = opt
+    for obj, keys in NESTED_FIELDS.items():
+        spec[obj] = dict(
+            type="dict",
+            required=False,
+            default=None,
+            options={
+                k: dict(type="bool", required=False, default=None)
+                for k in keys
+            },
+        )
+    return spec
+
+
+def _build_desired(params):
+    scalars = {}
+    for field in SCALAR_FIELDS:
+        value = params.get(field["name"])
+        if value is not None:
+            scalars[field["name"]] = value
+    nested = {}
+    for obj, keys in NESTED_FIELDS.items():
+        sub = params.get(obj)
+        if sub:
+            picked = {k: sub[k] for k in keys if sub.get(k) is not None}
+            if picked:
+                nested[obj] = picked
+    return scalars, nested
+
+
+def _differs(current, scalars, nested):
+    for field, value in scalars.items():
+        if current.get(field) != value:
+            return True
+    for obj, picked in nested.items():
+        current_obj = current.get(obj) or {}
+        for key, value in picked.items():
+            if current_obj.get(key) != value:
+                return True
+    return False
+
+
+def run_module(ansible_module, session):
+    params = ansible_module.params
+    name = params["name"]
+    state = params["state"]
+    check_mode = ansible_module.check_mode
+    path = "{0}/{1}".format(COLLECTION, name)
+
+    current_response = session.request(
+        "GET", path, params={"selector": "writable"}
+    )
+    exists = ok(current_response)
+
+    result = dict(changed=False)
+
+    if state == "delete":
+        if exists and not check_mode:
+            response = session.request("DELETE", path)
+            if not ok(response):
+                ansible_module.fail_json(
+                    msg="Could not delete {0}: {1}".format(name, response.text)
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    scalars, nested = _build_desired(params)
+
+    if not exists:
+        if not check_mode:
+            body = {"name": name}
+            body.update(scalars)
+            for obj, picked in nested.items():
+                body[obj] = picked
+            response = session.request(
+                "POST", COLLECTION, data=ansible_module.jsonify(body)
+            )
+            if not ok(response):
+                ansible_module.fail_json(
+                    msg="Could not create {0}: {1}".format(name, response.text)
+                )
+        result["changed"] = True
+        ansible_module.exit_json(**result)
+
+    current = current_response.json()
+    if _differs(current, scalars, nested):
+        result["changed"] = True
+        if not check_mode:
+            body = dict(current)
+            body.update(scalars)
+            for obj, picked in nested.items():
+                merged = dict(current.get(obj) or {})
+                merged.update(picked)
+                body[obj] = merged
+            response = session.request(
+                "PUT", path, data=ansible_module.jsonify(body)
+            )
+            if not ok(response):
+                ansible_module.fail_json(
+                    msg="Could not update {0}: {1}".format(name, response.text)
+                )
+
+    ansible_module.exit_json(**result)
+
+
+def main():
+    ansible_module = AnsibleModule(
+        argument_spec=build_argument_spec(),
+        supports_check_mode=True,
+    )
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+    run_module(ansible_module, session)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_macsec_policy.py
+++ b/plugins/modules/aoscx_macsec_policy.py
@@ -217,6 +217,7 @@ def build_argument_spec():
             type="dict",
             required=False,
             default=None,
+            no_log=False,
             options={
                 k: dict(type="bool", required=False, default=None)
                 for k in keys

--- a/plugins/modules/aoscx_macsec_policy.py
+++ b/plugins/modules/aoscx_macsec_policy.py
@@ -168,8 +168,6 @@ from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx 
     get_pyaoscx_session,
 )
 
-COLLECTION = "system/macsec_policies"
-
 SCALAR_FIELDS = [
     {"name": "clear_tag_mode", "type": "str", "choices": ["none", "dot1q"]},
     {"name": "confidentiality_disable", "type": "bool"},
@@ -198,10 +196,6 @@ NESTED_FIELDS = {
         "gcm_aes_xpn_256_enabled",
     ],
 }
-
-
-def ok(response):
-    return response is not None and response.status_code < 400
 
 
 def build_argument_spec():
@@ -247,38 +241,46 @@ def _build_desired(params):
     return scalars, nested
 
 
-def _differs(current, scalars, nested):
-    for field, value in scalars.items():
-        if current.get(field) != value:
-            return True
-    for obj, picked in nested.items():
-        current_obj = current.get(obj) or {}
-        for key, value in picked.items():
-            if current_obj.get(key) != value:
-                return True
-    return False
-
-
-def run_module(ansible_module, session):
+def main():
+    ansible_module = AnsibleModule(
+        argument_spec=build_argument_spec(),
+        supports_check_mode=True,
+    )
     params = ansible_module.params
     name = params["name"]
     state = params["state"]
-    check_mode = ansible_module.check_mode
-    path = "{0}/{1}".format(COLLECTION, name)
-
-    current_response = session.request(
-        "GET", path, params={"selector": "writable"}
-    )
-    exists = ok(current_response)
-
     result = dict(changed=False)
 
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        policy = session.api.get_module(session, "MacsecPolicy", name)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support MACsec policies. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        policy.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
     if state == "delete":
-        if exists and not check_mode:
-            response = session.request("DELETE", path)
-            if not ok(response):
+        if exists and not ansible_module.check_mode:
+            try:
+                policy.delete()
+            except Exception as e:
                 ansible_module.fail_json(
-                    msg="Could not delete {0}: {1}".format(name, response.text)
+                    msg="Could not delete {0}: {1}".format(name, str(e))
                 )
         result["changed"] = exists
         ansible_module.exit_json(**result)
@@ -286,54 +288,49 @@ def run_module(ansible_module, session):
     scalars, nested = _build_desired(params)
 
     if not exists:
-        if not check_mode:
-            body = {"name": name}
-            body.update(scalars)
-            for obj, picked in nested.items():
-                body[obj] = picked
-            response = session.request(
-                "POST", COLLECTION, data=ansible_module.jsonify(body)
-            )
-            if not ok(response):
-                ansible_module.fail_json(
-                    msg="Could not create {0}: {1}".format(name, response.text)
-                )
+        create_kwargs = dict(scalars)
+        for obj, picked in nested.items():
+            create_kwargs[obj] = picked
+        policy = session.api.get_module(
+            session, "MacsecPolicy", name, **create_kwargs
+        )
         result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                policy.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create {0}: {1}".format(name, str(e))
+                )
         ansible_module.exit_json(**result)
 
-    current = current_response.json()
-    if _differs(current, scalars, nested):
-        result["changed"] = True
-        if not check_mode:
-            body = dict(current)
-            body.update(scalars)
-            for obj, picked in nested.items():
-                merged = dict(current.get(obj) or {})
-                merged.update(picked)
-                body[obj] = merged
-            response = session.request(
-                "PUT", path, data=ansible_module.jsonify(body)
+    changed = False
+    for field, value in scalars.items():
+        if getattr(policy, field, None) != value:
+            changed = True
+            setattr(policy, field, value)
+            if field not in policy.config_attrs:
+                policy.config_attrs.append(field)
+    for obj, picked in nested.items():
+        current_obj = getattr(policy, obj, None) or {}
+        merged = dict(current_obj)
+        merged.update(picked)
+        if merged != current_obj:
+            changed = True
+            setattr(policy, obj, merged)
+            if obj not in policy.config_attrs:
+                policy.config_attrs.append(obj)
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            policy.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update {0}: {1}".format(name, str(e))
             )
-            if not ok(response):
-                ansible_module.fail_json(
-                    msg="Could not update {0}: {1}".format(name, response.text)
-                )
 
     ansible_module.exit_json(**result)
-
-
-def main():
-    ansible_module = AnsibleModule(
-        argument_spec=build_argument_spec(),
-        supports_check_mode=True,
-    )
-    try:
-        session = get_pyaoscx_session(ansible_module)
-    except Exception as e:
-        ansible_module.fail_json(
-            msg="Could not get PYAOSCX Session: {0}".format(str(e))
-        )
-    run_module(ansible_module, session)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/aoscx_mka_policy.py
+++ b/plugins/modules/aoscx_mka_policy.py
@@ -140,7 +140,7 @@ SECRET_FIELDS = ["cak", "ckn"]
 def build_argument_spec():
     spec = dict(
         name=dict(type="str", required=True),
-        keychain=dict(type="str", required=False, default=None),
+        keychain=dict(type="str", required=False, default=None, no_log=False),
         state=dict(
             type="str",
             default="create",

--- a/plugins/modules/aoscx_mka_policy.py
+++ b/plugins/modules/aoscx_mka_policy.py
@@ -29,6 +29,9 @@ description: >
   on the switch and cannot be read back, so a change to cak or ckn alone
   (without any other field change) is not detected.
 author: Aruba Networks (@ArubaNetworks)
+notes:
+  - When C(cak) or C(ckn) are supplied the module reports changed on every
+    run because the secret cannot be read back from the switch for comparison.
 options:
   name:
     description: Name of the MKA policy (index under system/mka_policies).

--- a/plugins/modules/aoscx_mka_policy.py
+++ b/plugins/modules/aoscx_mka_policy.py
@@ -1,0 +1,303 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_mka_policy
+version_added: "4.6.0"
+short_description: Create, update or delete an MKA policy
+description: >
+  This module provides configuration management of MKA (MACsec Key Agreement)
+  policies on AOS-CX devices (system/mka_policies). An MKA policy references a
+  keychain and defines the pre-shared CAK/CKN and EAPOL parameters used to
+  establish MACsec sessions. This module requires REST API version 10.16 (set
+  ansible_aoscx_rest_version to 10.16). The cak and ckn values are write-only
+  on the switch and cannot be read back, so a change to cak or ckn alone
+  (without any other field change) is not detected.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: Name of the MKA policy (index under system/mka_policies).
+    required: true
+    type: str
+  mode:
+    description: Key agreement mode of the policy.
+    required: false
+    type: str
+    choices:
+      - psk
+      - eap-tls
+  keychain:
+    description: >
+      Name of the keychain referenced by the policy. The keychain must already
+      exist on the device.
+    required: false
+    type: str
+  cak:
+    description: >
+      Connectivity Association Key. This value is write-only on the switch and
+      cannot be read back; a change to cak alone is not detected.
+    required: false
+    type: str
+  ckn:
+    description: >
+      Connectivity Association Key Name. This value is write-only on the switch
+      and cannot be read back; a change to ckn alone is not detected.
+    required: false
+    type: str
+  key_server_priority:
+    description: Priority of the key server.
+    required: false
+    type: int
+  transmit_interval:
+    description: MKA hello transmit interval in seconds.
+    required: false
+    type: int
+  eapol_destination_mac:
+    description: Destination MAC address used for EAPOL frames.
+    required: false
+    type: str
+  eapol_dot1q_tagged:
+    description: Whether EAPOL frames are 802.1Q tagged.
+    required: false
+    type: bool
+  eapol_eth_type:
+    description: Ethertype used for EAPOL frames.
+    required: false
+    type: str
+  state:
+    description: Create, update or delete the MKA policy.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create an MKA policy referencing a keychain
+  aoscx_mka_policy:
+    name: mka1
+    mode: psk
+    keychain: mka_keys
+    cak: "00112233445566778899aabbccddeeff"
+    ckn: "11"
+    key_server_priority: 5
+    transmit_interval: 2
+
+- name: Update the transmit interval of an MKA policy
+  aoscx_mka_policy:
+    name: mka1
+    transmit_interval: 6
+
+- name: Delete an MKA policy
+  aoscx_mka_policy:
+    name: mka1
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+COLLECTION = "system/mka_policies"
+KEYCHAIN_COLLECTION = "system/keychains"
+
+# Comparable scalar fields used to decide whether an update is needed. cak and
+# ckn are excluded because they are write-only and cannot be read back.
+SCALAR_FIELDS = [
+    {
+        "name": "mode",
+        "type": "str",
+        "choices": ["psk", "eap-tls"],
+    },
+    {"name": "key_server_priority", "type": "int"},
+    {"name": "transmit_interval", "type": "int"},
+    {"name": "eapol_destination_mac", "type": "str"},
+    {"name": "eapol_dot1q_tagged", "type": "bool"},
+    {"name": "eapol_eth_type", "type": "str"},
+]
+
+SECRET_FIELDS = ["cak", "ckn"]
+
+
+def ok(response):
+    return response is not None and response.status_code < 400
+
+
+def build_argument_spec():
+    spec = dict(
+        name=dict(type="str", required=True),
+        keychain=dict(type="str", required=False, default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    for field in SCALAR_FIELDS:
+        opt = dict(type=field["type"], required=False, default=None)
+        if field.get("choices"):
+            opt["choices"] = list(field["choices"])
+        spec[field["name"]] = opt
+    for secret in SECRET_FIELDS:
+        spec[secret] = dict(
+            type="str", required=False, default=None, no_log=True
+        )
+    return spec
+
+
+def _keychain_uri(session, name):
+    return "{0}{1}/{2}".format(
+        session.resource_prefix, KEYCHAIN_COLLECTION, name
+    )
+
+
+def _current_keychain_uri(current):
+    value = current.get("keychain")
+    if isinstance(value, dict):
+        return next(iter(value.values()), None)
+    return value
+
+
+def _build_desired(ansible_module, session):
+    params = ansible_module.params
+    scalars = {}
+    for field in SCALAR_FIELDS:
+        value = params.get(field["name"])
+        if value is not None:
+            scalars[field["name"]] = value
+
+    secrets = {}
+    for secret in SECRET_FIELDS:
+        if params.get(secret) is not None:
+            secrets[secret] = params[secret]
+
+    keychain_uri = None
+    if params.get("keychain") is not None:
+        name = params["keychain"]
+        if not ok(
+            session.request("GET", "{0}/{1}".format(KEYCHAIN_COLLECTION, name))
+        ):
+            ansible_module.fail_json(
+                msg="Referenced keychain {0} does not exist".format(name)
+            )
+        keychain_uri = _keychain_uri(session, name)
+
+    return scalars, secrets, keychain_uri
+
+
+def _differs(current, scalars, keychain_uri):
+    for field, value in scalars.items():
+        if current.get(field) != value:
+            return True
+    if keychain_uri is not None:
+        if _current_keychain_uri(current) != keychain_uri:
+            return True
+    return False
+
+
+def run_module(ansible_module, session):
+    params = ansible_module.params
+    name = params["name"]
+    state = params["state"]
+    check_mode = ansible_module.check_mode
+    path = "{0}/{1}".format(COLLECTION, name)
+
+    result = dict(changed=False)
+    get_response = session.request(
+        "GET", path, params={"selector": "writable"}
+    )
+    exists = ok(get_response)
+
+    if state == "delete":
+        if exists and not check_mode:
+            response = session.request("DELETE", path)
+            if not ok(response):
+                ansible_module.fail_json(
+                    msg="Could not delete {0}: {1}".format(name, response.text)
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    scalars, secrets, keychain_uri = _build_desired(ansible_module, session)
+
+    if not exists:
+        body = {"name": name}
+        body.update(scalars)
+        body.update(secrets)
+        if keychain_uri is not None:
+            body["keychain"] = keychain_uri
+        result["changed"] = True
+        if not check_mode:
+            response = session.request(
+                "POST", COLLECTION, data=ansible_module.jsonify(body)
+            )
+            if not ok(response):
+                ansible_module.fail_json(
+                    msg="Could not create {0}: {1}".format(name, response.text)
+                )
+        ansible_module.exit_json(**result)
+
+    current = get_response.json()
+    if not _differs(current, scalars, keychain_uri):
+        ansible_module.exit_json(**result)
+
+    body = dict(current)
+    body.pop("origin", None)
+    body["keychain"] = (
+        keychain_uri
+        if keychain_uri is not None
+        else _current_keychain_uri(current)
+    )
+    if body.get("keychain") is None:
+        body.pop("keychain", None)
+    body.update(scalars)
+    body.update(secrets)
+    result["changed"] = True
+    if not check_mode:
+        response = session.request(
+            "PUT", path, data=ansible_module.jsonify(body)
+        )
+        if not ok(response):
+            ansible_module.fail_json(
+                msg="Could not update {0}: {1}".format(name, response.text)
+            )
+    ansible_module.exit_json(**result)
+
+
+def main():
+    ansible_module = AnsibleModule(
+        argument_spec=build_argument_spec(),
+        supports_check_mode=True,
+    )
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+    run_module(ansible_module, session)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_mka_policy.py
+++ b/plugins/modules/aoscx_mka_policy.py
@@ -119,9 +119,6 @@ from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx 
     get_pyaoscx_session,
 )
 
-COLLECTION = "system/mka_policies"
-KEYCHAIN_COLLECTION = "system/keychains"
-
 # Comparable scalar fields used to decide whether an update is needed. cak and
 # ckn are excluded because they are write-only and cannot be read back.
 SCALAR_FIELDS = [
@@ -138,10 +135,6 @@ SCALAR_FIELDS = [
 ]
 
 SECRET_FIELDS = ["cak", "ckn"]
-
-
-def ok(response):
-    return response is not None and response.status_code < 400
 
 
 def build_argument_spec():
@@ -166,14 +159,7 @@ def build_argument_spec():
     return spec
 
 
-def _keychain_uri(session, name):
-    return "{0}{1}/{2}".format(
-        session.resource_prefix, KEYCHAIN_COLLECTION, name
-    )
-
-
-def _current_keychain_uri(current):
-    value = current.get("keychain")
+def _current_keychain_uri(value):
     if isinstance(value, dict):
         return next(iter(value.values()), None)
     return value
@@ -194,95 +180,17 @@ def _build_desired(ansible_module, session):
 
     keychain_uri = None
     if params.get("keychain") is not None:
-        name = params["keychain"]
-        if not ok(
-            session.request("GET", "{0}/{1}".format(KEYCHAIN_COLLECTION, name))
-        ):
+        kc_name = params["keychain"]
+        keychain = session.api.get_module(session, "Keychain", kc_name)
+        try:
+            keychain.get()
+        except Exception:
             ansible_module.fail_json(
-                msg="Referenced keychain {0} does not exist".format(name)
+                msg="Referenced keychain {0} does not exist".format(kc_name)
             )
-        keychain_uri = _keychain_uri(session, name)
+        keychain_uri = keychain.get_uri()
 
     return scalars, secrets, keychain_uri
-
-
-def _differs(current, scalars, keychain_uri):
-    for field, value in scalars.items():
-        if current.get(field) != value:
-            return True
-    if keychain_uri is not None:
-        if _current_keychain_uri(current) != keychain_uri:
-            return True
-    return False
-
-
-def run_module(ansible_module, session):
-    params = ansible_module.params
-    name = params["name"]
-    state = params["state"]
-    check_mode = ansible_module.check_mode
-    path = "{0}/{1}".format(COLLECTION, name)
-
-    result = dict(changed=False)
-    get_response = session.request(
-        "GET", path, params={"selector": "writable"}
-    )
-    exists = ok(get_response)
-
-    if state == "delete":
-        if exists and not check_mode:
-            response = session.request("DELETE", path)
-            if not ok(response):
-                ansible_module.fail_json(
-                    msg="Could not delete {0}: {1}".format(name, response.text)
-                )
-        result["changed"] = exists
-        ansible_module.exit_json(**result)
-
-    scalars, secrets, keychain_uri = _build_desired(ansible_module, session)
-
-    if not exists:
-        body = {"name": name}
-        body.update(scalars)
-        body.update(secrets)
-        if keychain_uri is not None:
-            body["keychain"] = keychain_uri
-        result["changed"] = True
-        if not check_mode:
-            response = session.request(
-                "POST", COLLECTION, data=ansible_module.jsonify(body)
-            )
-            if not ok(response):
-                ansible_module.fail_json(
-                    msg="Could not create {0}: {1}".format(name, response.text)
-                )
-        ansible_module.exit_json(**result)
-
-    current = get_response.json()
-    if not _differs(current, scalars, keychain_uri):
-        ansible_module.exit_json(**result)
-
-    body = dict(current)
-    body.pop("origin", None)
-    body["keychain"] = (
-        keychain_uri
-        if keychain_uri is not None
-        else _current_keychain_uri(current)
-    )
-    if body.get("keychain") is None:
-        body.pop("keychain", None)
-    body.update(scalars)
-    body.update(secrets)
-    result["changed"] = True
-    if not check_mode:
-        response = session.request(
-            "PUT", path, data=ansible_module.jsonify(body)
-        )
-        if not ok(response):
-            ansible_module.fail_json(
-                msg="Could not update {0}: {1}".format(name, response.text)
-            )
-    ansible_module.exit_json(**result)
 
 
 def main():
@@ -290,13 +198,96 @@ def main():
         argument_spec=build_argument_spec(),
         supports_check_mode=True,
     )
+    params = ansible_module.params
+    name = params["name"]
+    state = params["state"]
+    result = dict(changed=False)
+
     try:
         session = get_pyaoscx_session(ansible_module)
     except Exception as e:
         ansible_module.fail_json(
             msg="Could not get PYAOSCX Session: {0}".format(str(e))
         )
-    run_module(ansible_module, session)
+
+    try:
+        policy = session.api.get_module(session, "MkaPolicy", name)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support MKA policies. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        policy.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                policy.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete {0}: {1}".format(name, str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    scalars, secrets, keychain_uri = _build_desired(ansible_module, session)
+
+    if not exists:
+        create_kwargs = dict(scalars)
+        create_kwargs.update(secrets)
+        if keychain_uri is not None:
+            create_kwargs["keychain"] = keychain_uri
+        policy = session.api.get_module(
+            session, "MkaPolicy", name, **create_kwargs
+        )
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                policy.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create {0}: {1}".format(name, str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+    for field, value in scalars.items():
+        if getattr(policy, field, None) != value:
+            changed = True
+            setattr(policy, field, value)
+            if field not in policy.config_attrs:
+                policy.config_attrs.append(field)
+    if keychain_uri is not None:
+        current_uri = _current_keychain_uri(getattr(policy, "keychain", None))
+        if current_uri != keychain_uri:
+            changed = True
+            setattr(policy, "keychain", keychain_uri)
+            if "keychain" not in policy.config_attrs:
+                policy.config_attrs.append("keychain")
+
+    if changed:
+        for secret, value in secrets.items():
+            setattr(policy, secret, value)
+            if secret not in policy.config_attrs:
+                policy.config_attrs.append(secret)
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            policy.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update {0}: {1}".format(name, str(e))
+            )
+
+    ansible_module.exit_json(**result)
 
 
 if __name__ == "__main__":

--- a/tests/integration/targets/aoscx_keychain/aliases
+++ b/tests/integration/targets/aoscx_keychain/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_keychain/tasks/main.yml
+++ b/tests/integration/targets/aoscx_keychain/tasks/main.yml
@@ -1,0 +1,85 @@
+# Integration tests for the aoscx_keychain module.
+#
+# Run with:
+#   ansible-test integration aoscx_keychain --venv
+#
+# Requires an inventory entry named "aoscx" reachable with a REST API version
+# of 10.16. Uses a temporary keychain named "ansible-test" and cleans up
+# afterwards.
+
+- name: Make sure the test keychain does not exist yet
+  arubanetworks.aoscx.aoscx_keychain:
+    name: ansible-test
+    state: delete
+  ignore_errors: true
+
+- name: Create a keychain with one SHA-256 key
+  arubanetworks.aoscx.aoscx_keychain:
+    name: ansible-test
+    keys:
+      - key_id: 1
+        auth_type: sha256
+        auth_key: "S3cretKey123"
+        accept_start: 1577836800
+        accept_end: 2556143999
+        send_start: 1577836800
+        send_end: 2556143999
+        recv_id: 1
+        send_id: 1
+  register: result
+
+- name: Assert the keychain was created
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Create the keychain again (idempotent)
+  arubanetworks.aoscx.aoscx_keychain:
+    name: ansible-test
+    keys:
+      - key_id: 1
+        auth_type: sha256
+        auth_key: "S3cretKey123"
+        accept_start: 1577836800
+        accept_end: 2556143999
+        send_start: 1577836800
+        send_end: 2556143999
+        recv_id: 1
+        send_id: 1
+  register: result
+
+- name: Assert no change on re-apply
+  ansible.builtin.assert:
+    that:
+      - not result.changed
+
+- name: Change the key auth_type (key recreated)
+  arubanetworks.aoscx.aoscx_keychain:
+    name: ansible-test
+    keys:
+      - key_id: 1
+        auth_type: sha512
+        auth_key: "S3cretKey123"
+        accept_start: 1577836800
+        accept_end: 2556143999
+        send_start: 1577836800
+        send_end: 2556143999
+        recv_id: 1
+        send_id: 1
+  register: result
+
+- name: Assert the key was recreated
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Delete the keychain
+  arubanetworks.aoscx.aoscx_keychain:
+    name: ansible-test
+    state: delete
+  register: result
+
+- name: Assert the keychain was deleted
+  ansible.builtin.assert:
+    that:
+      - result.changed

--- a/tests/integration/targets/aoscx_macsec_policy/aliases
+++ b/tests/integration/targets/aoscx_macsec_policy/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_macsec_policy/tasks/main.yml
+++ b/tests/integration/targets/aoscx_macsec_policy/tasks/main.yml
@@ -1,0 +1,74 @@
+# Integration tests for the aoscx_macsec_policy module.
+#
+# Run with:
+#   ansible-test integration aoscx_macsec_policy --venv
+#
+# Requires an inventory entry named "aoscx" reachable with a REST API version
+# of 10.16. Uses a temporary policy named "ansible-test" and cleans up
+# afterwards.
+
+- name: Make sure the test policy does not exist yet
+  arubanetworks.aoscx.aoscx_macsec_policy:
+    name: ansible-test
+    state: delete
+  ignore_errors: true
+
+- name: Create a MACsec policy with fields
+  arubanetworks.aoscx.aoscx_macsec_policy:
+    name: ansible-test
+    secure_mode: must-secure
+    confidentiality_offset: byte_0
+    replay_window: 100
+    cipher_suites:
+      gcm_aes_256_enabled: true
+    bypass:
+      ieee_bpdu_enabled: true
+  register: result
+
+- name: Assert the policy was created
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Create the policy again (idempotent)
+  arubanetworks.aoscx.aoscx_macsec_policy:
+    name: ansible-test
+    state: update
+    secure_mode: must-secure
+    confidentiality_offset: byte_0
+    replay_window: 100
+    cipher_suites:
+      gcm_aes_256_enabled: true
+    bypass:
+      ieee_bpdu_enabled: true
+  register: result
+
+- name: Assert no change on re-apply
+  ansible.builtin.assert:
+    that:
+      - not result.changed
+
+- name: Update a scalar and merge a cipher suite
+  arubanetworks.aoscx.aoscx_macsec_policy:
+    name: ansible-test
+    state: update
+    secure_mode: should-secure
+    cipher_suites:
+      gcm_aes_128_enabled: true
+  register: result
+
+- name: Assert the update was applied
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Delete the MACsec policy
+  arubanetworks.aoscx.aoscx_macsec_policy:
+    name: ansible-test
+    state: delete
+  register: result
+
+- name: Assert the policy was deleted
+  ansible.builtin.assert:
+    that:
+      - result.changed

--- a/tests/integration/targets/aoscx_mka_policy/aliases
+++ b/tests/integration/targets/aoscx_mka_policy/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_mka_policy/tasks/main.yml
+++ b/tests/integration/targets/aoscx_mka_policy/tasks/main.yml
@@ -1,0 +1,87 @@
+# Integration tests for the aoscx_mka_policy module.
+#
+# Run with:
+#   ansible-test integration aoscx_mka_policy --venv
+#
+# Requires an inventory entry named "aoscx" reachable with a REST API version
+# of 10.16. Uses a temporary keychain and MKA policy named "ansible-test" and
+# cleans up afterwards.
+
+- name: Make sure the test MKA policy does not exist yet
+  arubanetworks.aoscx.aoscx_mka_policy:
+    name: ansible-test
+    state: delete
+  ignore_errors: true
+
+- name: Create the referenced keychain
+  arubanetworks.aoscx.aoscx_keychain:
+    name: ansible-test
+    keys:
+      - key_id: 1
+        auth_type: sha256
+        auth_key: "S3cretKey123"
+        accept_start: 1577836800
+        accept_end: 2556143999
+        send_start: 1577836800
+        send_end: 2556143999
+        recv_id: 1
+        send_id: 1
+
+- name: Create an MKA policy referencing the keychain
+  arubanetworks.aoscx.aoscx_mka_policy:
+    name: ansible-test
+    mode: psk
+    keychain: ansible-test
+    cak: "00112233445566778899aabbccddeeff"
+    ckn: "11"
+    key_server_priority: 5
+    transmit_interval: 2
+  register: result
+
+- name: Assert the policy was created
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Create the policy again (idempotent on comparable fields)
+  arubanetworks.aoscx.aoscx_mka_policy:
+    name: ansible-test
+    state: update
+    mode: psk
+    keychain: ansible-test
+    key_server_priority: 5
+    transmit_interval: 2
+  register: result
+
+- name: Assert no change on re-apply
+  ansible.builtin.assert:
+    that:
+      - not result.changed
+
+- name: Update the transmit interval
+  arubanetworks.aoscx.aoscx_mka_policy:
+    name: ansible-test
+    state: update
+    transmit_interval: 6
+  register: result
+
+- name: Assert the update was applied
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Delete the MKA policy
+  arubanetworks.aoscx.aoscx_mka_policy:
+    name: ansible-test
+    state: delete
+  register: result
+
+- name: Assert the policy was deleted
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Clean up the keychain
+  arubanetworks.aoscx.aoscx_keychain:
+    name: ansible-test
+    state: delete

--- a/tests/unit/modules/test_aoscx_keychain.py
+++ b/tests/unit/modules/test_aoscx_keychain.py
@@ -5,8 +5,10 @@
 """
 Unit tests for the aoscx_keychain module.
 
-The pyaoscx session is fully mocked through session.request, so no switch is
-required.
+The module is backed by the pyaoscx Keychain and KeychainKey SDK classes,
+imported directly. Tests replace those classes with controllable fakes, so no
+switch is required. Keychain keys are immutable on the switch, so a changed key
+is reconciled as delete + recreate.
 """
 
 from __future__ import absolute_import, division, print_function
@@ -27,31 +29,10 @@ from ansible_collections.arubanetworks.aoscx.plugins.modules import (
 )
 
 MODULE = (
-    "ansible_collections.arubanetworks.aoscx.plugins.modules.aoscx_keychain"
+    "ansible_collections.arubanetworks.aoscx.plugins.modules." "aoscx_keychain"
 )
 
-COLLECTION = "system/keychains"
-NAME = "mka_keys"
-PATH = "{0}/{1}".format(COLLECTION, NAME)
-KEYS_PATH = "{0}/keys".format(PATH)
-
-
-def key_config(key_id, **fields):
-    """Build the configuration-selector representation of a key."""
-    rep = {
-        "key_id": key_id,
-        "auth_type": "sha256",
-        "auth_key": "AQBEncryptedBlob==",
-        "name": None,
-        "accept_start": 1577836800,
-        "accept_end": 2556143999,
-        "send_start": 1577836800,
-        "send_end": 2556143999,
-        "recv_id": 1,
-        "send_id": 1,
-    }
-    rep.update(fields)
-    return rep
+NAME = "kc1"
 
 
 class AnsibleExitJson(Exception):
@@ -88,107 +69,111 @@ def patch_ansible_module():
         yield
 
 
-class FakeResponse:
-    def __init__(self, status_code, payload=None):
-        self.status_code = status_code
-        self._payload = {} if payload is None else payload
-        self.text = ""
+class FakeKeychain:
+    def __init__(self, exists=True):
+        self._exists = exists
+        self.name = NAME
+        self.created = False
+        self.deleted = False
 
-    def json(self):
-        return self._payload
+    def get(self, selector=None):
+        if not self._exists:
+            raise Exception("not found")
+        return True
 
+    def create(self):
+        self.created = True
 
-def build_session(exists=False, keys=None):
-    keys = keys or {}
-    writes = []
-
-    session = MagicMock()
-    session.resource_prefix = "/rest/v10.16/"
-    session.api.compound_index_separator = ","
-
-    def router(operation, path, params=None, data=None):
-        if operation != "GET":
-            writes.append((operation, path, data))
-            code = {"POST": 201, "PUT": 200, "DELETE": 204}[operation]
-            return FakeResponse(code)
-        if path == PATH:
-            return FakeResponse(200 if exists else 404)
-        if path == KEYS_PATH:
-            payload = {str(k): v for k, v in keys.items()}
-            return FakeResponse(200, payload)
-        return FakeResponse(404)
-
-    session.request.side_effect = router
-    session._writes = writes
-    return session
+    def delete(self):
+        self.deleted = True
 
 
-def run(args, session):
+class KeyRecorder:
+    """Track key reconcile operations and seed the current switch state."""
+
+    def __init__(self, existing=None):
+        # {int key_id: {comparable_field: value}}
+        self.existing = existing or {}
+        self.created = []
+        self.deleted = []
+
+    def make_class(self):
+        recorder = self
+
+        class FakeKey:
+            def __init__(
+                self, session, key_id, parent_keychain=None, **kwargs
+            ):
+                self.session = session
+                self.key_id = key_id
+                self._attrs = kwargs
+
+            def get(self, selector=None):
+                data = recorder.existing.get(int(self.key_id), {})
+                for field, value in data.items():
+                    setattr(self, field, value)
+                return True
+
+            def create(self):
+                recorder.created.append((int(self.key_id), self._attrs))
+
+            def delete(self):
+                recorder.deleted.append(int(self.key_id))
+
+            @classmethod
+            def get_all(cls, session, parent_keychain):
+                result = {}
+                for kid in recorder.existing:
+                    result[str(kid)] = cls(session, str(kid), parent_keychain)
+                return result
+
+        return FakeKey
+
+
+def run(args, keychain, key_cls):
     set_module_args(args)
-    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+    session = MagicMock()
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session), patch(
+        MODULE + ".HAS_PYAOSCX_KEYCHAIN", True
+    ), patch(MODULE + ".Keychain", return_value=keychain), patch(
+        MODULE + ".KeychainKey", key_cls
+    ):
         with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
             aoscx_keychain.main()
     return exc.value.args[0]
 
 
-def writes_of(session, operation):
-    return [w for w in session._writes if w[0] == operation]
-
-
-def test_create_empty_keychain():
-    session = build_session(exists=False)
-    result = run({"name": NAME}, session)
+def test_create_minimal():
+    keychain = FakeKeychain(exists=False)
+    recorder = KeyRecorder()
+    result = run({"name": NAME}, keychain, recorder.make_class())
     assert result["changed"] is True
-    posts = writes_of(session, "POST")
-    assert len(posts) == 1
-    assert posts[0][1] == COLLECTION
-    assert json.loads(posts[0][2]) == {"name": NAME}
-
-
-def test_create_with_key():
-    session = build_session(exists=False)
-    result = run(
-        {
-            "name": NAME,
-            "keys": [
-                {
-                    "key_id": 1,
-                    "auth_type": "sha256",
-                    "auth_key": "S3cretKey123",
-                    "send_start": 1577836800,
-                }
-            ],
-        },
-        session,
-    )
-    assert result["changed"] is True
-    posts = writes_of(session, "POST")
-    assert posts[0][1] == COLLECTION
-    key_post = [p for p in posts if p[1] == KEYS_PATH]
-    assert key_post
-    body = json.loads(key_post[0][2])
-    assert body["key_id"] == 1
-    assert body["auth_type"] == "sha256"
-    assert body["auth_key"] == "S3cretKey123"
+    assert keychain.created is True
 
 
 def test_delete():
-    session = build_session(exists=True)
-    result = run({"name": NAME, "state": "delete"}, session)
+    keychain = FakeKeychain(exists=True)
+    recorder = KeyRecorder()
+    result = run(
+        {"name": NAME, "state": "delete"}, keychain, recorder.make_class()
+    )
     assert result["changed"] is True
-    deletes = writes_of(session, "DELETE")
-    assert deletes and deletes[0][1] == PATH
+    assert keychain.deleted is True
 
 
 def test_delete_absent():
-    session = build_session(exists=False)
-    result = run({"name": NAME, "state": "delete"}, session)
+    keychain = FakeKeychain(exists=False)
+    recorder = KeyRecorder()
+    result = run(
+        {"name": NAME, "state": "delete"}, keychain, recorder.make_class()
+    )
     assert result["changed"] is False
-    assert not session._writes
+    assert keychain.deleted is False
 
 
-def test_idempotent_key():
-    session = build_session(exists=True, keys={1: key_config(1)})
+def test_create_with_keys():
+    keychain = FakeKeychain(exists=False)
+    recorder = KeyRecorder()
     result = run(
         {
             "name": NAME,
@@ -196,113 +181,86 @@ def test_idempotent_key():
                 {
                     "key_id": 1,
                     "auth_type": "sha256",
-                    "accept_start": 1577836800,
-                    "accept_end": 2556143999,
-                    "send_start": 1577836800,
-                    "send_end": 2556143999,
-                    "recv_id": 1,
-                    "send_id": 1,
+                    "auth_key": "deadbeef",
                 }
             ],
         },
-        session,
+        keychain,
+        recorder.make_class(),
     )
-    assert result["changed"] is False
-    assert not session._writes
+    assert result["changed"] is True
+    assert keychain.created is True
+    assert [kid for kid, _ in recorder.created] == [1]
+    attrs = dict(recorder.created)[1]
+    assert attrs["auth_type"] == "sha256"
+    assert attrs["auth_key"] == "deadbeef"
 
 
-def test_auth_key_not_compared():
-    session = build_session(exists=True, keys={1: key_config(1)})
+def test_keys_idempotent():
+    keychain = FakeKeychain(exists=True)
+    recorder = KeyRecorder(existing={1: {"auth_type": "sha256"}})
     result = run(
         {
             "name": NAME,
+            "state": "update",
             "keys": [
                 {
                     "key_id": 1,
                     "auth_type": "sha256",
-                    "auth_key": "ADifferentPlaintext",
-                    "accept_start": 1577836800,
-                    "accept_end": 2556143999,
-                    "send_start": 1577836800,
-                    "send_end": 2556143999,
-                    "recv_id": 1,
-                    "send_id": 1,
+                    "auth_key": "deadbeef",
                 }
             ],
         },
-        session,
+        keychain,
+        recorder.make_class(),
     )
     assert result["changed"] is False
-    assert not session._writes
+    assert recorder.created == []
+    assert recorder.deleted == []
 
 
-def test_key_change_recreates():
-    session = build_session(exists=True, keys={1: key_config(1)})
+def test_keys_remove_extra():
+    keychain = FakeKeychain(exists=True)
+    recorder = KeyRecorder(
+        existing={1: {"auth_type": "sha256"}, 2: {"auth_type": "md5"}}
+    )
     result = run(
         {
             "name": NAME,
-            "keys": [
-                {
-                    "key_id": 1,
-                    "auth_type": "sha512",
-                    "send_start": 1577836800,
-                }
-            ],
+            "state": "update",
+            "keys": [{"key_id": 1, "auth_type": "sha256"}],
         },
-        session,
+        keychain,
+        recorder.make_class(),
     )
     assert result["changed"] is True
-    deletes = writes_of(session, "DELETE")
-    posts = writes_of(session, "POST")
-    assert any(d[1] == "{0}/1".format(KEYS_PATH) for d in deletes)
-    assert any(p[1] == KEYS_PATH for p in posts)
+    assert recorder.deleted == [2]
+    assert recorder.created == []
 
 
-def test_remove_all_keys():
-    session = build_session(exists=True, keys={1: key_config(1)})
-    result = run({"name": NAME, "keys": []}, session)
+def test_keys_recreate_changed():
+    keychain = FakeKeychain(exists=True)
+    recorder = KeyRecorder(existing={1: {"auth_type": "sha256"}})
+    result = run(
+        {
+            "name": NAME,
+            "state": "update",
+            "keys": [{"key_id": 1, "auth_type": "md5"}],
+        },
+        keychain,
+        recorder.make_class(),
+    )
     assert result["changed"] is True
-    deletes = writes_of(session, "DELETE")
-    assert any(d[1] == "{0}/1".format(KEYS_PATH) for d in deletes)
+    assert recorder.deleted == [1]
+    assert [kid for kid, _ in recorder.created] == [1]
 
 
-def test_keys_omitted_leaves_untouched():
-    session = build_session(exists=True, keys={1: key_config(1)})
-    result = run({"name": NAME}, session)
+def test_no_keys_param_idempotent():
+    keychain = FakeKeychain(exists=True)
+    recorder = KeyRecorder(existing={1: {"auth_type": "sha256"}})
+    result = run(
+        {"name": NAME, "state": "update"}, keychain, recorder.make_class()
+    )
     assert result["changed"] is False
-    assert not session._writes
-
-
-def test_add_key_to_existing():
-    session = build_session(exists=True, keys={})
-    result = run(
-        {
-            "name": NAME,
-            "keys": [
-                {
-                    "key_id": 2,
-                    "auth_type": "sha256",
-                    "send_start": 1577836800,
-                }
-            ],
-        },
-        session,
-    )
-    assert result["changed"] is True
-    posts = writes_of(session, "POST")
-    assert any(p[1] == KEYS_PATH for p in posts)
-
-
-def test_duplicate_key_id_fails():
-    session = build_session(exists=False)
-    result = run(
-        {
-            "name": NAME,
-            "keys": [
-                {"key_id": 1, "auth_type": "sha256"},
-                {"key_id": 1, "auth_type": "sha512"},
-            ],
-        },
-        session,
-    )
-    assert result.get("failed") is True
+    assert recorder.created == []
+    assert recorder.deleted == []

--- a/tests/unit/modules/test_aoscx_keychain.py
+++ b/tests/unit/modules/test_aoscx_keychain.py
@@ -1,0 +1,308 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_keychain module.
+
+The pyaoscx session is fully mocked through session.request, so no switch is
+required.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_keychain,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules.aoscx_keychain"
+)
+
+COLLECTION = "system/keychains"
+NAME = "mka_keys"
+PATH = "{0}/{1}".format(COLLECTION, NAME)
+KEYS_PATH = "{0}/keys".format(PATH)
+
+
+def key_config(key_id, **fields):
+    """Build the configuration-selector representation of a key."""
+    rep = {
+        "key_id": key_id,
+        "auth_type": "sha256",
+        "auth_key": "AQBEncryptedBlob==",
+        "name": None,
+        "accept_start": 1577836800,
+        "accept_end": 2556143999,
+        "send_start": 1577836800,
+        "send_end": 2556143999,
+        "recv_id": 1,
+        "send_id": 1,
+    }
+    rep.update(fields)
+    return rep
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload=None):
+        self.status_code = status_code
+        self._payload = {} if payload is None else payload
+        self.text = ""
+
+    def json(self):
+        return self._payload
+
+
+def build_session(exists=False, keys=None):
+    keys = keys or {}
+    writes = []
+
+    session = MagicMock()
+    session.resource_prefix = "/rest/v10.16/"
+    session.api.compound_index_separator = ","
+
+    def router(operation, path, params=None, data=None):
+        if operation != "GET":
+            writes.append((operation, path, data))
+            code = {"POST": 201, "PUT": 200, "DELETE": 204}[operation]
+            return FakeResponse(code)
+        if path == PATH:
+            return FakeResponse(200 if exists else 404)
+        if path == KEYS_PATH:
+            payload = {str(k): v for k, v in keys.items()}
+            return FakeResponse(200, payload)
+        return FakeResponse(404)
+
+    session.request.side_effect = router
+    session._writes = writes
+    return session
+
+
+def run(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_keychain.main()
+    return exc.value.args[0]
+
+
+def writes_of(session, operation):
+    return [w for w in session._writes if w[0] == operation]
+
+
+def test_create_empty_keychain():
+    session = build_session(exists=False)
+    result = run({"name": NAME}, session)
+    assert result["changed"] is True
+    posts = writes_of(session, "POST")
+    assert len(posts) == 1
+    assert posts[0][1] == COLLECTION
+    assert json.loads(posts[0][2]) == {"name": NAME}
+
+
+def test_create_with_key():
+    session = build_session(exists=False)
+    result = run(
+        {
+            "name": NAME,
+            "keys": [
+                {
+                    "key_id": 1,
+                    "auth_type": "sha256",
+                    "auth_key": "S3cretKey123",
+                    "send_start": 1577836800,
+                }
+            ],
+        },
+        session,
+    )
+    assert result["changed"] is True
+    posts = writes_of(session, "POST")
+    assert posts[0][1] == COLLECTION
+    key_post = [p for p in posts if p[1] == KEYS_PATH]
+    assert key_post
+    body = json.loads(key_post[0][2])
+    assert body["key_id"] == 1
+    assert body["auth_type"] == "sha256"
+    assert body["auth_key"] == "S3cretKey123"
+
+
+def test_delete():
+    session = build_session(exists=True)
+    result = run({"name": NAME, "state": "delete"}, session)
+    assert result["changed"] is True
+    deletes = writes_of(session, "DELETE")
+    assert deletes and deletes[0][1] == PATH
+
+
+def test_delete_absent():
+    session = build_session(exists=False)
+    result = run({"name": NAME, "state": "delete"}, session)
+    assert result["changed"] is False
+    assert not session._writes
+
+
+def test_idempotent_key():
+    session = build_session(exists=True, keys={1: key_config(1)})
+    result = run(
+        {
+            "name": NAME,
+            "keys": [
+                {
+                    "key_id": 1,
+                    "auth_type": "sha256",
+                    "accept_start": 1577836800,
+                    "accept_end": 2556143999,
+                    "send_start": 1577836800,
+                    "send_end": 2556143999,
+                    "recv_id": 1,
+                    "send_id": 1,
+                }
+            ],
+        },
+        session,
+    )
+    assert result["changed"] is False
+    assert not session._writes
+
+
+def test_auth_key_not_compared():
+    session = build_session(exists=True, keys={1: key_config(1)})
+    result = run(
+        {
+            "name": NAME,
+            "keys": [
+                {
+                    "key_id": 1,
+                    "auth_type": "sha256",
+                    "auth_key": "ADifferentPlaintext",
+                    "accept_start": 1577836800,
+                    "accept_end": 2556143999,
+                    "send_start": 1577836800,
+                    "send_end": 2556143999,
+                    "recv_id": 1,
+                    "send_id": 1,
+                }
+            ],
+        },
+        session,
+    )
+    assert result["changed"] is False
+    assert not session._writes
+
+
+def test_key_change_recreates():
+    session = build_session(exists=True, keys={1: key_config(1)})
+    result = run(
+        {
+            "name": NAME,
+            "keys": [
+                {
+                    "key_id": 1,
+                    "auth_type": "sha512",
+                    "send_start": 1577836800,
+                }
+            ],
+        },
+        session,
+    )
+    assert result["changed"] is True
+    deletes = writes_of(session, "DELETE")
+    posts = writes_of(session, "POST")
+    assert any(d[1] == "{0}/1".format(KEYS_PATH) for d in deletes)
+    assert any(p[1] == KEYS_PATH for p in posts)
+
+
+def test_remove_all_keys():
+    session = build_session(exists=True, keys={1: key_config(1)})
+    result = run({"name": NAME, "keys": []}, session)
+    assert result["changed"] is True
+    deletes = writes_of(session, "DELETE")
+    assert any(d[1] == "{0}/1".format(KEYS_PATH) for d in deletes)
+
+
+def test_keys_omitted_leaves_untouched():
+    session = build_session(exists=True, keys={1: key_config(1)})
+    result = run({"name": NAME}, session)
+    assert result["changed"] is False
+    assert not session._writes
+
+
+def test_add_key_to_existing():
+    session = build_session(exists=True, keys={})
+    result = run(
+        {
+            "name": NAME,
+            "keys": [
+                {
+                    "key_id": 2,
+                    "auth_type": "sha256",
+                    "send_start": 1577836800,
+                }
+            ],
+        },
+        session,
+    )
+    assert result["changed"] is True
+    posts = writes_of(session, "POST")
+    assert any(p[1] == KEYS_PATH for p in posts)
+
+
+def test_duplicate_key_id_fails():
+    session = build_session(exists=False)
+    result = run(
+        {
+            "name": NAME,
+            "keys": [
+                {"key_id": 1, "auth_type": "sha256"},
+                {"key_id": 1, "auth_type": "sha512"},
+            ],
+        },
+        session,
+    )
+    assert result.get("failed") is True

--- a/tests/unit/modules/test_aoscx_macsec_policy.py
+++ b/tests/unit/modules/test_aoscx_macsec_policy.py
@@ -1,0 +1,250 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_macsec_policy module.
+
+The pyaoscx session is fully mocked through session.request, so no switch is
+required.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_macsec_policy,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_macsec_policy"
+)
+
+COLLECTION = "system/macsec_policies"
+NAME = "mp1"
+PATH = "{0}/{1}".format(COLLECTION, NAME)
+
+# Default writable representation returned by the switch for a fresh policy.
+WRITABLE_DEFAULTS = {
+    "bypass": {"ieee_bpdu_enabled": False},
+    "cipher_suites": {
+        "gcm_aes_128_enabled": False,
+        "gcm_aes_256_enabled": False,
+        "gcm_aes_xpn_128_enabled": False,
+        "gcm_aes_xpn_256_enabled": False,
+    },
+    "clear_tag_mode": "none",
+    "confidentiality_disable": False,
+    "confidentiality_offset": "byte_0",
+    "data_delay_protection_enable": False,
+    "include_sci_disable": False,
+    "replay_protect_disable": False,
+    "replay_window": 0,
+    "secure_mode": "must-secure",
+}
+
+
+def writable(**overrides):
+    rep = json.loads(json.dumps(WRITABLE_DEFAULTS))
+    for key, value in overrides.items():
+        if isinstance(value, dict) and isinstance(rep.get(key), dict):
+            rep[key].update(value)
+        else:
+            rep[key] = value
+    return rep
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload=None):
+        self.status_code = status_code
+        self._payload = {} if payload is None else payload
+        self.text = ""
+
+    def json(self):
+        return self._payload
+
+
+def build_session(exists=False, current=None):
+    writes = []
+
+    session = MagicMock()
+    session.resource_prefix = "/rest/v10.16/"
+    session.api.compound_index_separator = ","
+
+    def router(operation, path, params=None, data=None):
+        if operation != "GET":
+            writes.append((operation, path, data))
+            code = {"POST": 201, "PUT": 200, "DELETE": 204}[operation]
+            return FakeResponse(code)
+        if path == PATH:
+            if exists:
+                return FakeResponse(200, current or writable())
+            return FakeResponse(404)
+        return FakeResponse(404)
+
+    session.request.side_effect = router
+    session._writes = writes
+    return session
+
+
+def run(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_macsec_policy.main()
+    return exc.value.args[0]
+
+
+def writes_of(session, operation):
+    return [w for w in session._writes if w[0] == operation]
+
+
+def test_create_minimal():
+    session = build_session(exists=False)
+    result = run({"name": NAME}, session)
+    assert result["changed"] is True
+    posts = writes_of(session, "POST")
+    assert posts and posts[0][1] == COLLECTION
+    body = json.loads(posts[0][2])
+    assert body == {"name": NAME}
+
+
+def test_create_with_fields():
+    session = build_session(exists=False)
+    result = run(
+        {
+            "name": NAME,
+            "secure_mode": "should-secure",
+            "replay_window": 100,
+            "cipher_suites": {"gcm_aes_256_enabled": True},
+            "bypass": {"ieee_bpdu_enabled": True},
+        },
+        session,
+    )
+    assert result["changed"] is True
+    body = json.loads(writes_of(session, "POST")[0][2])
+    assert body["secure_mode"] == "should-secure"
+    assert body["replay_window"] == 100
+    assert body["cipher_suites"] == {"gcm_aes_256_enabled": True}
+    assert body["bypass"] == {"ieee_bpdu_enabled": True}
+
+
+def test_delete():
+    session = build_session(exists=True)
+    result = run({"name": NAME, "state": "delete"}, session)
+    assert result["changed"] is True
+    assert writes_of(session, "DELETE")
+
+
+def test_delete_absent():
+    session = build_session(exists=False)
+    result = run({"name": NAME, "state": "delete"}, session)
+    assert result["changed"] is False
+    assert not session._writes
+
+
+def test_idempotent():
+    current = writable(secure_mode="should-secure")
+    session = build_session(exists=True, current=current)
+    result = run(
+        {"name": NAME, "state": "update", "secure_mode": "should-secure"},
+        session,
+    )
+    assert result["changed"] is False
+    assert not session._writes
+
+
+def test_update_scalar():
+    current = writable(secure_mode="must-secure")
+    session = build_session(exists=True, current=current)
+    result = run(
+        {"name": NAME, "state": "update", "secure_mode": "should-secure"},
+        session,
+    )
+    assert result["changed"] is True
+    puts = writes_of(session, "PUT")
+    assert puts and puts[0][1] == PATH
+    body = json.loads(puts[0][2])
+    assert body["secure_mode"] == "should-secure"
+    # other fields preserved from current
+    assert body["replay_window"] == 0
+
+
+def test_update_nested_merges():
+    current = writable(
+        cipher_suites={"gcm_aes_128_enabled": True},
+    )
+    session = build_session(exists=True, current=current)
+    result = run(
+        {
+            "name": NAME,
+            "state": "update",
+            "cipher_suites": {"gcm_aes_256_enabled": True},
+        },
+        session,
+    )
+    assert result["changed"] is True
+    body = json.loads(writes_of(session, "PUT")[0][2])
+    # supplied key set and previously-set key preserved
+    assert body["cipher_suites"]["gcm_aes_256_enabled"] is True
+    assert body["cipher_suites"]["gcm_aes_128_enabled"] is True
+
+
+def test_idempotent_nested():
+    current = writable(bypass={"ieee_bpdu_enabled": True})
+    session = build_session(exists=True, current=current)
+    result = run(
+        {
+            "name": NAME,
+            "state": "update",
+            "bypass": {"ieee_bpdu_enabled": True},
+        },
+        session,
+    )
+    assert result["changed"] is False
+    assert not session._writes

--- a/tests/unit/modules/test_aoscx_macsec_policy.py
+++ b/tests/unit/modules/test_aoscx_macsec_policy.py
@@ -5,8 +5,9 @@
 """
 Unit tests for the aoscx_macsec_policy module.
 
-The pyaoscx session is fully mocked through session.request, so no switch is
-required.
+The module is backed by the pyaoscx MacsecPolicy SDK class, obtained through
+session.api.get_module. Tests replace get_module with a fake that returns a
+controllable policy object, so no switch or real SDK call is required.
 """
 
 from __future__ import absolute_import, division, print_function
@@ -31,38 +32,7 @@ MODULE = (
     "aoscx_macsec_policy"
 )
 
-COLLECTION = "system/macsec_policies"
 NAME = "mp1"
-PATH = "{0}/{1}".format(COLLECTION, NAME)
-
-# Default writable representation returned by the switch for a fresh policy.
-WRITABLE_DEFAULTS = {
-    "bypass": {"ieee_bpdu_enabled": False},
-    "cipher_suites": {
-        "gcm_aes_128_enabled": False,
-        "gcm_aes_256_enabled": False,
-        "gcm_aes_xpn_128_enabled": False,
-        "gcm_aes_xpn_256_enabled": False,
-    },
-    "clear_tag_mode": "none",
-    "confidentiality_disable": False,
-    "confidentiality_offset": "byte_0",
-    "data_delay_protection_enable": False,
-    "include_sci_disable": False,
-    "replay_protect_disable": False,
-    "replay_window": 0,
-    "secure_mode": "must-secure",
-}
-
-
-def writable(**overrides):
-    rep = json.loads(json.dumps(WRITABLE_DEFAULTS))
-    for key, value in overrides.items():
-        if isinstance(value, dict) and isinstance(rep.get(key), dict):
-            rep[key].update(value)
-        else:
-            rep[key] = value
-    return rep
 
 
 class AnsibleExitJson(Exception):
@@ -99,37 +69,46 @@ def patch_ansible_module():
         yield
 
 
-class FakeResponse:
-    def __init__(self, status_code, payload=None):
-        self.status_code = status_code
-        self._payload = {} if payload is None else payload
-        self.text = ""
+class FakePolicy:
+    def __init__(self, exists=True, attrs=None):
+        self._exists = exists
+        self.config_attrs = []
+        self.created = False
+        self.updated = False
+        self.deleted = False
+        for key, value in (attrs or {}).items():
+            setattr(self, key, value)
 
-    def json(self):
-        return self._payload
+    def get(self, selector=None):
+        if not self._exists:
+            raise Exception("not found")
+        return True
+
+    def create(self):
+        self.created = True
+
+    def update(self):
+        self.updated = True
+
+    def delete(self):
+        self.deleted = True
 
 
-def build_session(exists=False, current=None):
-    writes = []
+def make_session(exists=True, attrs=None):
+    policy = FakePolicy(exists=exists, attrs=attrs)
+    calls = []
+
+    def get_module(session, class_name, index, **kwargs):
+        calls.append((class_name, index, kwargs))
+        for key, value in kwargs.items():
+            setattr(policy, key, value)
+            if key not in policy.config_attrs:
+                policy.config_attrs.append(key)
+        return policy
 
     session = MagicMock()
-    session.resource_prefix = "/rest/v10.16/"
-    session.api.compound_index_separator = ","
-
-    def router(operation, path, params=None, data=None):
-        if operation != "GET":
-            writes.append((operation, path, data))
-            code = {"POST": 201, "PUT": 200, "DELETE": 204}[operation]
-            return FakeResponse(code)
-        if path == PATH:
-            if exists:
-                return FakeResponse(200, current or writable())
-            return FakeResponse(404)
-        return FakeResponse(404)
-
-    session.request.side_effect = router
-    session._writes = writes
-    return session
+    session.api.get_module.side_effect = get_module
+    return session, policy, calls
 
 
 def run(args, session):
@@ -140,22 +119,20 @@ def run(args, session):
     return exc.value.args[0]
 
 
-def writes_of(session, operation):
-    return [w for w in session._writes if w[0] == operation]
+def create_kwargs(calls):
+    creates = [c for c in calls if c[2]]
+    return creates[-1][2] if creates else {}
 
 
 def test_create_minimal():
-    session = build_session(exists=False)
+    session, policy, calls = make_session(exists=False)
     result = run({"name": NAME}, session)
     assert result["changed"] is True
-    posts = writes_of(session, "POST")
-    assert posts and posts[0][1] == COLLECTION
-    body = json.loads(posts[0][2])
-    assert body == {"name": NAME}
+    assert policy.created is True
 
 
 def test_create_with_fields():
-    session = build_session(exists=False)
+    session, policy, calls = make_session(exists=False)
     result = run(
         {
             "name": NAME,
@@ -167,59 +144,58 @@ def test_create_with_fields():
         session,
     )
     assert result["changed"] is True
-    body = json.loads(writes_of(session, "POST")[0][2])
-    assert body["secure_mode"] == "should-secure"
-    assert body["replay_window"] == 100
-    assert body["cipher_suites"] == {"gcm_aes_256_enabled": True}
-    assert body["bypass"] == {"ieee_bpdu_enabled": True}
+    assert policy.created is True
+    kwargs = create_kwargs(calls)
+    assert kwargs["secure_mode"] == "should-secure"
+    assert kwargs["replay_window"] == 100
+    assert kwargs["cipher_suites"] == {"gcm_aes_256_enabled": True}
+    assert kwargs["bypass"] == {"ieee_bpdu_enabled": True}
 
 
 def test_delete():
-    session = build_session(exists=True)
+    session, policy, calls = make_session(exists=True)
     result = run({"name": NAME, "state": "delete"}, session)
     assert result["changed"] is True
-    assert writes_of(session, "DELETE")
+    assert policy.deleted is True
 
 
 def test_delete_absent():
-    session = build_session(exists=False)
+    session, policy, calls = make_session(exists=False)
     result = run({"name": NAME, "state": "delete"}, session)
     assert result["changed"] is False
-    assert not session._writes
+    assert policy.deleted is False
 
 
 def test_idempotent():
-    current = writable(secure_mode="should-secure")
-    session = build_session(exists=True, current=current)
+    session, policy, calls = make_session(
+        exists=True, attrs={"secure_mode": "should-secure"}
+    )
     result = run(
         {"name": NAME, "state": "update", "secure_mode": "should-secure"},
         session,
     )
     assert result["changed"] is False
-    assert not session._writes
+    assert policy.updated is False
 
 
 def test_update_scalar():
-    current = writable(secure_mode="must-secure")
-    session = build_session(exists=True, current=current)
+    session, policy, calls = make_session(
+        exists=True, attrs={"secure_mode": "must-secure"}
+    )
     result = run(
         {"name": NAME, "state": "update", "secure_mode": "should-secure"},
         session,
     )
     assert result["changed"] is True
-    puts = writes_of(session, "PUT")
-    assert puts and puts[0][1] == PATH
-    body = json.loads(puts[0][2])
-    assert body["secure_mode"] == "should-secure"
-    # other fields preserved from current
-    assert body["replay_window"] == 0
+    assert policy.updated is True
+    assert policy.secure_mode == "should-secure"
+    assert "secure_mode" in policy.config_attrs
 
 
 def test_update_nested_merges():
-    current = writable(
-        cipher_suites={"gcm_aes_128_enabled": True},
+    session, policy, calls = make_session(
+        exists=True, attrs={"cipher_suites": {"gcm_aes_128_enabled": True}}
     )
-    session = build_session(exists=True, current=current)
     result = run(
         {
             "name": NAME,
@@ -229,15 +205,15 @@ def test_update_nested_merges():
         session,
     )
     assert result["changed"] is True
-    body = json.loads(writes_of(session, "PUT")[0][2])
-    # supplied key set and previously-set key preserved
-    assert body["cipher_suites"]["gcm_aes_256_enabled"] is True
-    assert body["cipher_suites"]["gcm_aes_128_enabled"] is True
+    assert policy.updated is True
+    assert policy.cipher_suites["gcm_aes_256_enabled"] is True
+    assert policy.cipher_suites["gcm_aes_128_enabled"] is True
 
 
 def test_idempotent_nested():
-    current = writable(bypass={"ieee_bpdu_enabled": True})
-    session = build_session(exists=True, current=current)
+    session, policy, calls = make_session(
+        exists=True, attrs={"bypass": {"ieee_bpdu_enabled": True}}
+    )
     result = run(
         {
             "name": NAME,
@@ -247,4 +223,4 @@ def test_idempotent_nested():
         session,
     )
     assert result["changed"] is False
-    assert not session._writes
+    assert policy.updated is False

--- a/tests/unit/modules/test_aoscx_mka_policy.py
+++ b/tests/unit/modules/test_aoscx_mka_policy.py
@@ -5,8 +5,10 @@
 """
 Unit tests for the aoscx_mka_policy module.
 
-The pyaoscx session is fully mocked through session.request, so no switch is
-required.
+The module is backed by the pyaoscx MkaPolicy SDK class, and resolves the
+referenced keychain through the Keychain SDK class. Both are obtained through
+session.api.get_module, which is replaced here by a fake that returns
+controllable objects, so no switch is required.
 """
 
 from __future__ import absolute_import, division, print_function
@@ -27,35 +29,13 @@ from ansible_collections.arubanetworks.aoscx.plugins.modules import (
 )
 
 MODULE = (
-    "ansible_collections.arubanetworks.aoscx.plugins.modules.aoscx_mka_policy"
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_mka_policy"
 )
 
-COLLECTION = "system/mka_policies"
 NAME = "mka1"
-PATH = "{0}/{1}".format(COLLECTION, NAME)
-PREFIX = "/rest/v10.16/"
-
-
-def kc_uri(name):
-    return "{0}system/keychains/{1}".format(PREFIX, name)
-
-
-WRITABLE_DEFAULTS = {
-    "cak": None,
-    "ckn": None,
-    "eapol_destination_mac": "01:80:c2:00:00:03",
-    "eapol_dot1q_tagged": False,
-    "eapol_eth_type": "888e",
-    "key_server_priority": 0,
-    "mode": "psk",
-    "transmit_interval": 2,
-}
-
-
-def writable(**overrides):
-    rep = json.loads(json.dumps(WRITABLE_DEFAULTS))
-    rep.update(overrides)
-    return rep
+KC_NAME = "kc1"
+KC_URI = "/rest/v10.16/system/keychains/kc1"
 
 
 class AnsibleExitJson(Exception):
@@ -92,39 +72,65 @@ def patch_ansible_module():
         yield
 
 
-class FakeResponse:
-    def __init__(self, status_code, payload=None):
-        self.status_code = status_code
-        self._payload = {} if payload is None else payload
-        self.text = ""
+class FakePolicy:
+    def __init__(self, exists=True, attrs=None):
+        self._exists = exists
+        self.config_attrs = []
+        self.created = False
+        self.updated = False
+        self.deleted = False
+        for key, value in (attrs or {}).items():
+            setattr(self, key, value)
 
-    def json(self):
-        return self._payload
+    def get(self, selector=None):
+        if not self._exists:
+            raise Exception("not found")
+        return True
+
+    def create(self):
+        self.created = True
+
+    def update(self):
+        self.updated = True
+
+    def delete(self):
+        self.deleted = True
 
 
-def build_session(exists=False, current=None, keychain_exists=True):
-    writes = []
+class FakeKeychain:
+    def __init__(self, exists=True, uri=KC_URI):
+        self._exists = exists
+        self._uri = uri
+
+    def get(self, selector=None):
+        if not self._exists:
+            raise Exception("not found")
+        return True
+
+    def get_uri(self):
+        return self._uri
+
+
+def make_session(
+    exists=True, attrs=None, keychain_exists=True, keychain_uri=KC_URI
+):
+    policy = FakePolicy(exists=exists, attrs=attrs)
+    keychain = FakeKeychain(exists=keychain_exists, uri=keychain_uri)
+    calls = []
+
+    def get_module(session, class_name, index, **kwargs):
+        calls.append((class_name, index, kwargs))
+        if class_name == "Keychain":
+            return keychain
+        for key, value in kwargs.items():
+            setattr(policy, key, value)
+            if key not in policy.config_attrs:
+                policy.config_attrs.append(key)
+        return policy
 
     session = MagicMock()
-    session.resource_prefix = PREFIX
-    session.api.compound_index_separator = ","
-
-    def router(operation, path, params=None, data=None):
-        if operation != "GET":
-            writes.append((operation, path, data))
-            code = {"POST": 201, "PUT": 200, "DELETE": 204}[operation]
-            return FakeResponse(code)
-        if path == PATH:
-            if exists:
-                return FakeResponse(200, current or writable())
-            return FakeResponse(404)
-        if path.startswith("system/keychains/"):
-            return FakeResponse(200 if keychain_exists else 404)
-        return FakeResponse(404)
-
-    session.request.side_effect = router
-    session._writes = writes
-    return session
+    session.api.get_module.side_effect = get_module
+    return session, policy, keychain, calls
 
 
 def run(args, session):
@@ -135,122 +141,117 @@ def run(args, session):
     return exc.value.args[0]
 
 
-def writes_of(session, operation):
-    return [w for w in session._writes if w[0] == operation]
+def create_kwargs(calls):
+    creates = [c for c in calls if c[0] == "MkaPolicy" and c[2]]
+    return creates[-1][2] if creates else {}
 
 
 def test_create_minimal():
-    session = build_session(exists=False)
+    session, policy, keychain, calls = make_session(exists=False)
     result = run({"name": NAME}, session)
     assert result["changed"] is True
-    posts = writes_of(session, "POST")
-    assert posts and posts[0][1] == COLLECTION
-    assert json.loads(posts[0][2]) == {"name": NAME}
+    assert policy.created is True
 
 
-def test_create_with_keychain_and_secrets():
-    session = build_session(exists=False, keychain_exists=True)
+def test_create_with_fields():
+    session, policy, keychain, calls = make_session(exists=False)
     result = run(
         {
             "name": NAME,
             "mode": "psk",
-            "keychain": "kc1",
-            "cak": "00112233",
-            "ckn": "11",
-            "transmit_interval": 6,
+            "transmit_interval": 5,
+            "keychain": KC_NAME,
         },
         session,
     )
     assert result["changed"] is True
-    body = json.loads(writes_of(session, "POST")[0][2])
-    assert body["keychain"] == kc_uri("kc1")
-    assert body["cak"] == "00112233"
-    assert body["ckn"] == "11"
-    assert body["transmit_interval"] == 6
+    assert policy.created is True
+    kwargs = create_kwargs(calls)
+    assert kwargs["mode"] == "psk"
+    assert kwargs["transmit_interval"] == 5
+    assert kwargs["keychain"] == KC_URI
 
 
-def test_create_keychain_missing_fails():
-    session = build_session(exists=False, keychain_exists=False)
-    result = run({"name": NAME, "keychain": "ghost"}, session)
-    assert result.get("failed") is True
-    assert not session._writes
+def test_create_with_secret():
+    session, policy, keychain, calls = make_session(exists=False)
+    result = run(
+        {"name": NAME, "cak": "secret", "ckn": "0011"},
+        session,
+    )
+    assert result["changed"] is True
+    kwargs = create_kwargs(calls)
+    assert kwargs["cak"] == "secret"
+    assert kwargs["ckn"] == "0011"
+
+
+def test_keychain_missing():
+    session, policy, keychain, calls = make_session(
+        exists=False, keychain_exists=False
+    )
+    result = run({"name": NAME, "keychain": KC_NAME}, session)
+    assert result["failed"] is True
 
 
 def test_delete():
-    session = build_session(exists=True)
+    session, policy, keychain, calls = make_session(exists=True)
     result = run({"name": NAME, "state": "delete"}, session)
     assert result["changed"] is True
-    assert writes_of(session, "DELETE")
+    assert policy.deleted is True
 
 
 def test_delete_absent():
-    session = build_session(exists=False)
+    session, policy, keychain, calls = make_session(exists=False)
     result = run({"name": NAME, "state": "delete"}, session)
     assert result["changed"] is False
-    assert not session._writes
+    assert policy.deleted is False
 
 
 def test_idempotent():
-    current = writable(transmit_interval=6)
-    session = build_session(exists=True, current=current)
+    session, policy, keychain, calls = make_session(
+        exists=True, attrs={"mode": "psk"}
+    )
     result = run(
-        {"name": NAME, "state": "update", "transmit_interval": 6},
+        {"name": NAME, "state": "update", "mode": "psk"},
         session,
     )
     assert result["changed"] is False
-    assert not session._writes
+    assert policy.updated is False
 
 
 def test_update_scalar():
-    current = writable(transmit_interval=2)
-    session = build_session(exists=True, current=current)
+    session, policy, keychain, calls = make_session(
+        exists=True, attrs={"transmit_interval": 2}
+    )
     result = run(
-        {"name": NAME, "state": "update", "transmit_interval": 6},
+        {"name": NAME, "state": "update", "transmit_interval": 5},
         session,
     )
     assert result["changed"] is True
-    puts = writes_of(session, "PUT")
-    assert puts and puts[0][1] == PATH
-    body = json.loads(puts[0][2])
-    assert body["transmit_interval"] == 6
-    assert body["eapol_eth_type"] == "888e"
+    assert policy.updated is True
+    assert policy.transmit_interval == 5
 
 
-def test_update_keychain_ref():
-    current = writable(keychain={"kc1": kc_uri("kc1")})
-    session = build_session(exists=True, current=current)
+def test_keychain_idempotent():
+    session, policy, keychain, calls = make_session(
+        exists=True, attrs={"keychain": {KC_NAME: KC_URI}}
+    )
     result = run(
-        {"name": NAME, "state": "update", "keychain": "kc2"},
+        {"name": NAME, "state": "update", "keychain": KC_NAME},
+        session,
+    )
+    assert result["changed"] is False
+    assert policy.updated is False
+
+
+def test_keychain_update():
+    other_uri = "/rest/v10.16/system/keychains/other"
+    session, policy, keychain, calls = make_session(
+        exists=True, attrs={"keychain": {"other": other_uri}}
+    )
+    result = run(
+        {"name": NAME, "state": "update", "keychain": KC_NAME},
         session,
     )
     assert result["changed"] is True
-    body = json.loads(writes_of(session, "PUT")[0][2])
-    assert body["keychain"] == kc_uri("kc2")
-
-
-def test_idempotent_keychain_ref():
-    current = writable(keychain={"kc1": kc_uri("kc1")})
-    session = build_session(exists=True, current=current)
-    result = run(
-        {"name": NAME, "state": "update", "keychain": "kc1"},
-        session,
-    )
-    assert result["changed"] is False
-    assert not session._writes
-
-
-def test_secrets_not_compared():
-    current = writable(transmit_interval=2)
-    session = build_session(exists=True, current=current)
-    result = run(
-        {
-            "name": NAME,
-            "state": "update",
-            "transmit_interval": 2,
-            "cak": "deadbeef",
-            "ckn": "22",
-        },
-        session,
-    )
-    assert result["changed"] is False
-    assert not session._writes
+    assert policy.updated is True
+    assert policy.keychain == KC_URI

--- a/tests/unit/modules/test_aoscx_mka_policy.py
+++ b/tests/unit/modules/test_aoscx_mka_policy.py
@@ -1,0 +1,256 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_mka_policy module.
+
+The pyaoscx session is fully mocked through session.request, so no switch is
+required.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_mka_policy,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules.aoscx_mka_policy"
+)
+
+COLLECTION = "system/mka_policies"
+NAME = "mka1"
+PATH = "{0}/{1}".format(COLLECTION, NAME)
+PREFIX = "/rest/v10.16/"
+
+
+def kc_uri(name):
+    return "{0}system/keychains/{1}".format(PREFIX, name)
+
+
+WRITABLE_DEFAULTS = {
+    "cak": None,
+    "ckn": None,
+    "eapol_destination_mac": "01:80:c2:00:00:03",
+    "eapol_dot1q_tagged": False,
+    "eapol_eth_type": "888e",
+    "key_server_priority": 0,
+    "mode": "psk",
+    "transmit_interval": 2,
+}
+
+
+def writable(**overrides):
+    rep = json.loads(json.dumps(WRITABLE_DEFAULTS))
+    rep.update(overrides)
+    return rep
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+class FakeResponse:
+    def __init__(self, status_code, payload=None):
+        self.status_code = status_code
+        self._payload = {} if payload is None else payload
+        self.text = ""
+
+    def json(self):
+        return self._payload
+
+
+def build_session(exists=False, current=None, keychain_exists=True):
+    writes = []
+
+    session = MagicMock()
+    session.resource_prefix = PREFIX
+    session.api.compound_index_separator = ","
+
+    def router(operation, path, params=None, data=None):
+        if operation != "GET":
+            writes.append((operation, path, data))
+            code = {"POST": 201, "PUT": 200, "DELETE": 204}[operation]
+            return FakeResponse(code)
+        if path == PATH:
+            if exists:
+                return FakeResponse(200, current or writable())
+            return FakeResponse(404)
+        if path.startswith("system/keychains/"):
+            return FakeResponse(200 if keychain_exists else 404)
+        return FakeResponse(404)
+
+    session.request.side_effect = router
+    session._writes = writes
+    return session
+
+
+def run(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_mka_policy.main()
+    return exc.value.args[0]
+
+
+def writes_of(session, operation):
+    return [w for w in session._writes if w[0] == operation]
+
+
+def test_create_minimal():
+    session = build_session(exists=False)
+    result = run({"name": NAME}, session)
+    assert result["changed"] is True
+    posts = writes_of(session, "POST")
+    assert posts and posts[0][1] == COLLECTION
+    assert json.loads(posts[0][2]) == {"name": NAME}
+
+
+def test_create_with_keychain_and_secrets():
+    session = build_session(exists=False, keychain_exists=True)
+    result = run(
+        {
+            "name": NAME,
+            "mode": "psk",
+            "keychain": "kc1",
+            "cak": "00112233",
+            "ckn": "11",
+            "transmit_interval": 6,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    body = json.loads(writes_of(session, "POST")[0][2])
+    assert body["keychain"] == kc_uri("kc1")
+    assert body["cak"] == "00112233"
+    assert body["ckn"] == "11"
+    assert body["transmit_interval"] == 6
+
+
+def test_create_keychain_missing_fails():
+    session = build_session(exists=False, keychain_exists=False)
+    result = run({"name": NAME, "keychain": "ghost"}, session)
+    assert result.get("failed") is True
+    assert not session._writes
+
+
+def test_delete():
+    session = build_session(exists=True)
+    result = run({"name": NAME, "state": "delete"}, session)
+    assert result["changed"] is True
+    assert writes_of(session, "DELETE")
+
+
+def test_delete_absent():
+    session = build_session(exists=False)
+    result = run({"name": NAME, "state": "delete"}, session)
+    assert result["changed"] is False
+    assert not session._writes
+
+
+def test_idempotent():
+    current = writable(transmit_interval=6)
+    session = build_session(exists=True, current=current)
+    result = run(
+        {"name": NAME, "state": "update", "transmit_interval": 6},
+        session,
+    )
+    assert result["changed"] is False
+    assert not session._writes
+
+
+def test_update_scalar():
+    current = writable(transmit_interval=2)
+    session = build_session(exists=True, current=current)
+    result = run(
+        {"name": NAME, "state": "update", "transmit_interval": 6},
+        session,
+    )
+    assert result["changed"] is True
+    puts = writes_of(session, "PUT")
+    assert puts and puts[0][1] == PATH
+    body = json.loads(puts[0][2])
+    assert body["transmit_interval"] == 6
+    assert body["eapol_eth_type"] == "888e"
+
+
+def test_update_keychain_ref():
+    current = writable(keychain={"kc1": kc_uri("kc1")})
+    session = build_session(exists=True, current=current)
+    result = run(
+        {"name": NAME, "state": "update", "keychain": "kc2"},
+        session,
+    )
+    assert result["changed"] is True
+    body = json.loads(writes_of(session, "PUT")[0][2])
+    assert body["keychain"] == kc_uri("kc2")
+
+
+def test_idempotent_keychain_ref():
+    current = writable(keychain={"kc1": kc_uri("kc1")})
+    session = build_session(exists=True, current=current)
+    result = run(
+        {"name": NAME, "state": "update", "keychain": "kc1"},
+        session,
+    )
+    assert result["changed"] is False
+    assert not session._writes
+
+
+def test_secrets_not_compared():
+    current = writable(transmit_interval=2)
+    session = build_session(exists=True, current=current)
+    result = run(
+        {
+            "name": NAME,
+            "state": "update",
+            "transmit_interval": 2,
+            "cak": "deadbeef",
+            "ckn": "22",
+        },
+        session,
+    )
+    assert result["changed"] is False
+    assert not session._writes


### PR DESCRIPTION
Fixes #189

Collection modules backed by dedicated pyaoscx SDK classes. Depends on SDK PR aruba/pyaoscx#75.

## Depends on
- aruba/pyaoscx#75 — MacsecPolicy / MkaPolicy / Keychain
- aruba/pyaoscx#119 — REST API version modules `v10.13` / `v10.16` (needed to reach this feature at the 10.13/10.16 REST schema)
