### PR TITLE
Add aoscx_sflow and aoscx_sflow_collector modules

### DIFF
--- a/changelogs/fragments/aoscx_sflow.yml
+++ b/changelogs/fragments/aoscx_sflow.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Add ``aoscx_sflow`` module to manage sFlow (traffic sampling) instances.
+  - Add ``aoscx_sflow_collector`` module to manage sFlow collectors.

--- a/changelogs/fragments/sflow_reachability_check.yml
+++ b/changelogs/fragments/sflow_reachability_check.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - aoscx_sflow - add the C(reachability_check) option so the device only sends
+    sFlow datagrams to collectors that respond to its periodic ICMP echo
+    probes.

--- a/docs/aoscx_sflow.md
+++ b/docs/aoscx_sflow.md
@@ -1,0 +1,99 @@
+# module: aoscx_sflow
+
+description: This module provides configuration management of sFlow (traffic
+sampling) instances on AOS-CX devices. An sFlow instance controls how the
+device samples traffic and exports flow records to collectors.
+
+##### ARGUMENTS
+
+```YAML
+  name:
+    description: >
+      Name of the sFlow instance. This is the index of the resource under
+      system/sflows.
+    required: true
+    type: str
+  agent_address:
+    description: >
+      Source IP address (IPv4 or IPv6) used by the sFlow agent in exported
+      datagrams. When omitted it is left unchanged.
+    required: false
+    type: str
+  enabled:
+    description: >
+      Whether the sFlow instance is enabled. When omitted it is left
+      unchanged.
+    required: false
+    type: bool
+  header:
+    description: >
+      Maximum number of bytes copied from each sampled packet header. When
+      omitted it is left unchanged.
+    required: false
+    type: int
+  max_datagram:
+    description: >
+      Maximum size in bytes of an exported sFlow datagram. When omitted it is
+      left unchanged.
+    required: false
+    type: int
+  mode:
+    description: >
+      Direction of traffic that is sampled. When omitted it is left unchanged.
+    required: false
+    choices:
+      - both
+      - egress
+      - ingress
+    type: str
+  polling:
+    description: >
+      Counter polling interval in seconds. When omitted it is left unchanged.
+    required: false
+    type: int
+  sampling:
+    description: >
+      Packet sampling rate (one in N packets). When omitted it is left
+      unchanged.
+    required: false
+    type: int
+  state:
+    description: Create, update or delete the sFlow instance.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create an sFlow instance sampling both directions
+  aoscx_sflow:
+    name: global
+    enabled: true
+    mode: both
+    sampling: 4096
+    polling: 30
+    agent_address: 10.0.0.1
+
+- name: Update the sFlow sampling rate
+  aoscx_sflow:
+    name: global
+    state: update
+    sampling: 2048
+
+- name: Disable an sFlow instance
+  aoscx_sflow:
+    name: global
+    state: update
+    enabled: false
+
+- name: Delete an sFlow instance
+  aoscx_sflow:
+    name: global
+    state: delete
+```

--- a/docs/aoscx_sflow_collector.md
+++ b/docs/aoscx_sflow_collector.md
@@ -1,0 +1,61 @@
+# module: aoscx_sflow_collector
+
+description: This module provides configuration management of sFlow collectors
+on AOS-CX devices. A collector is the destination (IP address, UDP port and
+VRF) to which an sFlow instance exports its flow records. The collector is
+identified by the compound index of VRF, IP address and UDP port, and has no
+configurable attributes beyond that index.
+
+##### ARGUMENTS
+
+```YAML
+  sflow_name:
+    description: >
+      Name of the parent sFlow instance under which the collector is
+      configured. The instance must already exist.
+    required: true
+    type: str
+  vrf:
+    description: >
+      Name of the VRF used to reach the collector. The VRF must already exist
+      on the device.
+    required: false
+    default: default
+    type: str
+  ip_address:
+    description: IP address of the sFlow collector.
+    required: true
+    type: str
+  udp_port:
+    description: UDP port on which the collector receives sFlow datagrams.
+    required: false
+    default: 6343
+    type: int
+  state:
+    description: Create or delete the sFlow collector.
+    required: false
+    default: create
+    choices:
+      - create
+      - delete
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Add a collector to the global sFlow instance
+  aoscx_sflow_collector:
+    sflow_name: global
+    vrf: default
+    ip_address: 10.0.0.50
+    udp_port: 6343
+
+- name: Delete an sFlow collector
+  aoscx_sflow_collector:
+    sflow_name: global
+    vrf: default
+    ip_address: 10.0.0.50
+    udp_port: 6343
+    state: delete
+```

--- a/plugins/modules/aoscx_sflow.py
+++ b/plugins/modules/aoscx_sflow.py
@@ -1,0 +1,230 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_sflow
+version_added: "4.6.0"
+short_description: Create, update or delete an sFlow instance on AOS-CX
+description: >
+  This module provides configuration management of sFlow (traffic sampling)
+  instances on AOS-CX devices. An sFlow instance controls how the device
+  samples traffic and exports flow records to collectors.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: >
+      Name of the sFlow instance. This is the index of the resource under
+      system/sflows.
+    required: true
+    type: str
+  agent_address:
+    description: >
+      Source IP address (IPv4 or IPv6) used by the sFlow agent in exported
+      datagrams.
+    required: false
+    type: str
+  enabled:
+    description: Whether the sFlow instance is enabled.
+    required: false
+    type: bool
+  header:
+    description: >
+      Maximum number of bytes copied from each sampled packet header.
+    required: false
+    type: int
+  max_datagram:
+    description: Maximum size in bytes of an exported sFlow datagram.
+    required: false
+    type: int
+  mode:
+    description: Direction of traffic that is sampled.
+    required: false
+    choices:
+      - both
+      - egress
+      - ingress
+    type: str
+  polling:
+    description: Counter polling interval in seconds.
+    required: false
+    type: int
+  sampling:
+    description: Packet sampling rate (one in N packets).
+    required: false
+    type: int
+  state:
+    description: Create, update or delete the sFlow instance.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create an sFlow instance sampling both directions
+  aoscx_sflow:
+    name: global
+    enabled: true
+    mode: both
+    sampling: 4096
+    polling: 30
+    agent_address: 10.0.0.1
+
+- name: Update the sFlow sampling rate
+  aoscx_sflow:
+    name: global
+    state: update
+    sampling: 2048
+
+- name: Disable an sFlow instance
+  aoscx_sflow:
+    name: global
+    state: update
+    enabled: false
+
+- name: Delete an sFlow instance
+  aoscx_sflow:
+    name: global
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        name=dict(type="str", required=True),
+        agent_address=dict(type="str", required=False, default=None),
+        enabled=dict(type="bool", required=False, default=None),
+        header=dict(type="int", required=False, default=None),
+        max_datagram=dict(type="int", required=False, default=None),
+        mode=dict(
+            type="str",
+            required=False,
+            choices=["both", "egress", "ingress"],
+        ),
+        polling=dict(type="int", required=False, default=None),
+        sampling=dict(type="int", required=False, default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    name = ansible_module.params["name"]
+    state = ansible_module.params["state"]
+
+    # Writable scalar attributes managed by this module.
+    scalar_attrs = [
+        "agent_address",
+        "enabled",
+        "header",
+        "max_datagram",
+        "mode",
+        "polling",
+        "sampling",
+    ]
+    supplied = {
+        attr: ansible_module.params[attr]
+        for attr in scalar_attrs
+        if ansible_module.params[attr] is not None
+    }
+
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        sflow = session.api.get_module(session, "SFlow", name)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support sFlow. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        sflow.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                sflow.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete sFlow instance: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # ------------------------------------------------------- create / update
+    if not exists:
+        sflow = session.api.get_module(session, "SFlow", name, **supplied)
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                sflow.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create sFlow instance: {0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+    for attr, value in supplied.items():
+        if getattr(sflow, attr, None) != value:
+            changed = True
+            setattr(sflow, attr, value)
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            sflow.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update sFlow instance: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_sflow.py
+++ b/plugins/modules/aoscx_sflow.py
@@ -67,6 +67,13 @@ options:
     description: Packet sampling rate (one in N packets).
     required: false
     type: int
+  reachability_check:
+    description: >
+      When enabled, the device periodically probes all configured collectors
+      with ICMP echo and only sends sFlow datagrams to collectors that respond.
+      When disabled, datagrams are sent regardless of the ICMP echo outcome.
+    required: false
+    type: bool
   state:
     description: Create, update or delete the sFlow instance.
     required: false
@@ -128,6 +135,7 @@ def main():
         ),
         polling=dict(type="int", required=False, default=None),
         sampling=dict(type="int", required=False, default=None),
+        reachability_check=dict(type="bool", required=False, default=None),
         state=dict(
             type="str",
             default="create",
@@ -151,6 +159,7 @@ def main():
         "mode",
         "polling",
         "sampling",
+        "reachability_check",
     ]
     supplied = {
         attr: ansible_module.params[attr]

--- a/plugins/modules/aoscx_sflow_collector.py
+++ b/plugins/modules/aoscx_sflow_collector.py
@@ -1,0 +1,188 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_sflow_collector
+version_added: "4.6.0"
+short_description: Create or delete an sFlow collector on AOS-CX
+description: >
+  This module provides configuration management of sFlow collectors on
+  AOS-CX devices. A collector is the destination (IP address, UDP port and
+  VRF) to which an sFlow instance exports its flow records. The collector is
+  identified by the compound index of VRF, IP address and UDP port, and has
+  no configurable attributes beyond that index.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  sflow_name:
+    description: >
+      Name of the parent sFlow instance under which the collector is
+      configured. The instance must already exist.
+    required: true
+    type: str
+  vrf:
+    description: >
+      Name of the VRF used to reach the collector. The VRF must already
+      exist on the device.
+    required: false
+    default: default
+    type: str
+  ip_address:
+    description: IP address of the sFlow collector.
+    required: true
+    type: str
+  udp_port:
+    description: UDP port on which the collector receives sFlow datagrams.
+    required: false
+    default: 6343
+    type: int
+  state:
+    description: Create or delete the sFlow collector.
+    required: false
+    choices:
+      - create
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Add a collector to the global sFlow instance
+  aoscx_sflow_collector:
+    sflow_name: global
+    vrf: default
+    ip_address: 10.0.0.50
+    udp_port: 6343
+
+- name: Delete an sFlow collector
+  aoscx_sflow_collector:
+    sflow_name: global
+    vrf: default
+    ip_address: 10.0.0.50
+    udp_port: 6343
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        sflow_name=dict(type="str", required=True),
+        vrf=dict(type="str", required=False, default="default"),
+        ip_address=dict(type="str", required=True),
+        udp_port=dict(type="int", required=False, default=6343),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    sflow_name = ansible_module.params["sflow_name"]
+    vrf_name = ansible_module.params["vrf"]
+    ip_address = ansible_module.params["ip_address"]
+    udp_port = ansible_module.params["udp_port"]
+    state = ansible_module.params["state"]
+
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        sflow = session.api.get_module(session, "SFlow", sflow_name)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support sFlow. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        sflow.get(selector="writable")
+    except Exception:
+        ansible_module.fail_json(
+            msg="Parent sFlow instance '{0}' does not exist.".format(
+                sflow_name
+            )
+        )
+
+    try:
+        vrf = session.api.get_module(session, "Vrf", vrf_name)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not reference VRF '{0}': {1}".format(vrf_name, str(e))
+        )
+
+    collector = session.api.get_module(
+        session,
+        "SFlowCollector",
+        vrf,
+        ip_address=ip_address,
+        udp_port=udp_port,
+        parent_sflow=sflow,
+    )
+
+    try:
+        collector.get()
+        exists = True
+    except Exception:
+        exists = False
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                collector.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete sFlow collector: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # --------------------------------------------------------------- create
+    if not exists:
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                collector.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create sFlow collector: {0}".format(str(e))
+                )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/aoscx_sflow/aliases
+++ b/tests/integration/targets/aoscx_sflow/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_sflow/tasks/main.yml
+++ b/tests/integration/targets/aoscx_sflow/tasks/main.yml
@@ -1,0 +1,73 @@
+# Integration tests for the aoscx_sflow module.
+#
+# Run with:
+#   ansible-test integration aoscx_sflow --venv
+#
+# Requires an inventory entry named "aoscx" reachable with a pyaoscx release
+# that ships the SFlow class. Uses a temporary sFlow instance named
+# "ansible-test" that is kept disabled, and cleans up afterwards.
+
+- name: Make sure the test sFlow instance does not exist yet
+  arubanetworks.aoscx.aoscx_sflow:
+    name: ansible-test
+    state: delete
+  ignore_errors: true
+
+- name: Create a disabled sFlow instance
+  arubanetworks.aoscx.aoscx_sflow:
+    name: ansible-test
+    enabled: false
+    mode: both
+    polling: 20
+    sampling: 2048
+    agent_address: 10.0.0.9
+    header: 64
+    max_datagram: 1200
+    state: create
+  register: create_result
+
+- name: Assert create changed
+  ansible.builtin.assert:
+    that:
+      - create_result.changed
+
+- name: Re-apply identical values (idempotent)
+  arubanetworks.aoscx.aoscx_sflow:
+    name: ansible-test
+    state: update
+    enabled: false
+    mode: both
+    polling: 20
+    sampling: 2048
+    agent_address: 10.0.0.9
+    header: 64
+    max_datagram: 1200
+  register: idem_result
+
+- name: Assert update is idempotent
+  ansible.builtin.assert:
+    that:
+      - not idem_result.changed
+
+- name: Update the sampling rate
+  arubanetworks.aoscx.aoscx_sflow:
+    name: ansible-test
+    state: update
+    sampling: 4096
+  register: update_result
+
+- name: Assert update changed
+  ansible.builtin.assert:
+    that:
+      - update_result.changed
+
+- name: Delete the sFlow instance
+  arubanetworks.aoscx.aoscx_sflow:
+    name: ansible-test
+    state: delete
+  register: delete_result
+
+- name: Assert delete changed
+  ansible.builtin.assert:
+    that:
+      - delete_result.changed

--- a/tests/integration/targets/aoscx_sflow_collector/aliases
+++ b/tests/integration/targets/aoscx_sflow_collector/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_sflow_collector/tasks/main.yml
+++ b/tests/integration/targets/aoscx_sflow_collector/tasks/main.yml
@@ -1,0 +1,67 @@
+# Integration tests for the aoscx_sflow_collector module.
+#
+# Run with:
+#   ansible-test integration aoscx_sflow_collector --venv
+#
+# Requires an inventory entry named "aoscx" reachable with a pyaoscx release
+# that ships the SFlow and SFlowCollector classes. Creates a temporary sFlow
+# instance and a collector, then cleans up afterwards.
+
+- name: Make sure the test sFlow instance does not exist yet
+  arubanetworks.aoscx.aoscx_sflow:
+    name: ansible-test
+    state: delete
+  ignore_errors: true
+
+- name: Create the parent sFlow instance
+  arubanetworks.aoscx.aoscx_sflow:
+    name: ansible-test
+    enabled: false
+    state: create
+
+- name: Add a collector
+  arubanetworks.aoscx.aoscx_sflow_collector:
+    sflow_name: ansible-test
+    vrf: default
+    ip_address: 10.0.0.50
+    udp_port: 6343
+    state: create
+  register: create_result
+
+- name: Assert collector created
+  ansible.builtin.assert:
+    that:
+      - create_result.changed
+
+- name: Add the same collector again (idempotent)
+  arubanetworks.aoscx.aoscx_sflow_collector:
+    sflow_name: ansible-test
+    vrf: default
+    ip_address: 10.0.0.50
+    udp_port: 6343
+    state: create
+  register: idem_result
+
+- name: Assert collector is idempotent
+  ansible.builtin.assert:
+    that:
+      - not idem_result.changed
+
+- name: Delete the collector
+  arubanetworks.aoscx.aoscx_sflow_collector:
+    sflow_name: ansible-test
+    vrf: default
+    ip_address: 10.0.0.50
+    udp_port: 6343
+    state: delete
+  register: delete_result
+
+- name: Assert collector deleted
+  ansible.builtin.assert:
+    that:
+      - delete_result.changed
+
+- name: Clean up the parent sFlow instance
+  arubanetworks.aoscx.aoscx_sflow:
+    name: ansible-test
+    state: delete

--- a/tests/unit/modules/test_aoscx_sflow.py
+++ b/tests/unit/modules/test_aoscx_sflow.py
@@ -1,0 +1,211 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_sflow module.
+
+The pyaoscx session is fully mocked, so no switch is required.
+
+Run with:
+    PYTHONPATH=/tmp/acoll2x .venv/bin/python -m pytest \
+        tests/unit/modules/test_aoscx_sflow.py -v
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_sflow,
+)
+
+MODULE = "ansible_collections.arubanetworks.aoscx.plugins.modules.aoscx_sflow"
+
+
+class AnsibleExitJson(Exception):
+    """Raised by the mocked exit_json to stop module execution."""
+
+
+class AnsibleFailJson(Exception):
+    """Raised by the mocked fail_json to stop module execution."""
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_sflow(exists, **attrs):
+    sflow = MagicMock()
+    for attr in (
+        "agent_address",
+        "enabled",
+        "header",
+        "max_datagram",
+        "mode",
+        "polling",
+        "sampling",
+    ):
+        setattr(sflow, attr, attrs.get(attr))
+    if exists:
+        sflow.get.return_value = True
+    else:
+        sflow.get.side_effect = Exception("not found")
+    return sflow
+
+
+def build_session(existing, new_sflow=None):
+    session = MagicMock()
+    scalar_attrs = (
+        "agent_address",
+        "enabled",
+        "header",
+        "max_datagram",
+        "mode",
+        "polling",
+        "sampling",
+    )
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "SFlow":
+            if (
+                any(k in kwargs for k in scalar_attrs)
+                and new_sflow is not None
+            ):
+                return new_sflow
+            return existing
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_sflow.main()
+    return exc.value.args[0]
+
+
+# --------------------------------------------------------------------------
+# Create
+# --------------------------------------------------------------------------
+def test_create():
+    existing = build_sflow(False)
+    new = build_sflow(False)
+    session = build_session(existing, new_sflow=new)
+    result = run_module(
+        {
+            "name": "global",
+            "enabled": True,
+            "mode": "both",
+            "sampling": 4096,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_check_mode():
+    existing = build_sflow(False)
+    new = build_sflow(False)
+    session = build_session(existing, new_sflow=new)
+    result = run_module(
+        {"name": "global", "mode": "both", "_ansible_check_mode": True},
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Update
+# --------------------------------------------------------------------------
+def test_update_sampling():
+    existing = build_sflow(True, sampling=4096)
+    session = build_session(existing)
+    result = run_module(
+        {"name": "global", "state": "update", "sampling": 2048}, session
+    )
+    assert result["changed"] is True
+    assert existing.sampling == 2048
+    existing.update.assert_called_once()
+
+
+def test_update_idempotent():
+    existing = build_sflow(True, enabled=True, mode="both", sampling=4096)
+    session = build_session(existing)
+    result = run_module(
+        {
+            "name": "global",
+            "state": "update",
+            "enabled": True,
+            "mode": "both",
+            "sampling": 4096,
+        },
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_update_disable():
+    existing = build_sflow(True, enabled=True)
+    session = build_session(existing)
+    result = run_module(
+        {"name": "global", "state": "update", "enabled": False}, session
+    )
+    assert result["changed"] is True
+    assert existing.enabled is False
+
+
+# --------------------------------------------------------------------------
+# Delete
+# --------------------------------------------------------------------------
+def test_delete():
+    existing = build_sflow(True)
+    session = build_session(existing)
+    result = run_module({"name": "global", "state": "delete"}, session)
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+
+
+def test_delete_absent_noop():
+    existing = build_sflow(False)
+    session = build_session(existing)
+    result = run_module({"name": "global", "state": "delete"}, session)
+    assert result["changed"] is False
+    existing.delete.assert_not_called()

--- a/tests/unit/modules/test_aoscx_sflow_collector.py
+++ b/tests/unit/modules/test_aoscx_sflow_collector.py
@@ -1,0 +1,206 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_sflow_collector module.
+
+The pyaoscx session is fully mocked, so no switch is required.
+
+Run with:
+    PYTHONPATH=/tmp/acoll2x .venv/bin/python -m pytest \
+        tests/unit/modules/test_aoscx_sflow_collector.py -v
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_sflow_collector,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_sflow_collector"
+)
+
+
+class AnsibleExitJson(Exception):
+    """Raised by the mocked exit_json to stop module execution."""
+
+
+class AnsibleFailJson(Exception):
+    """Raised by the mocked fail_json to stop module execution."""
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_collector(exists):
+    collector = MagicMock()
+    if exists:
+        collector.get.return_value = True
+    else:
+        collector.get.side_effect = Exception("not found")
+    return collector
+
+
+def build_session(collector, sflow_exists=True):
+    session = MagicMock()
+    sflow = MagicMock()
+    if sflow_exists:
+        sflow.get.return_value = True
+    else:
+        sflow.get.side_effect = Exception("not found")
+    vrf = MagicMock()
+    vrf.name = "default"
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "SFlow":
+            return sflow
+        if module == "Vrf":
+            return vrf
+        if module == "SFlowCollector":
+            return collector
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_sflow_collector.main()
+    return exc.value.args[0]
+
+
+# --------------------------------------------------------------------------
+# Create
+# --------------------------------------------------------------------------
+def test_create():
+    collector = build_collector(False)
+    session = build_session(collector)
+    result = run_module(
+        {
+            "sflow_name": "global",
+            "ip_address": "10.0.0.50",
+            "udp_port": 6343,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    collector.create.assert_called_once()
+
+
+def test_create_idempotent():
+    collector = build_collector(True)
+    session = build_session(collector)
+    result = run_module(
+        {
+            "sflow_name": "global",
+            "ip_address": "10.0.0.50",
+        },
+        session,
+    )
+    assert result["changed"] is False
+    collector.create.assert_not_called()
+
+
+def test_create_check_mode():
+    collector = build_collector(False)
+    session = build_session(collector)
+    result = run_module(
+        {
+            "sflow_name": "global",
+            "ip_address": "10.0.0.50",
+            "_ansible_check_mode": True,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    collector.create.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Delete
+# --------------------------------------------------------------------------
+def test_delete():
+    collector = build_collector(True)
+    session = build_session(collector)
+    result = run_module(
+        {
+            "sflow_name": "global",
+            "ip_address": "10.0.0.50",
+            "state": "delete",
+        },
+        session,
+    )
+    assert result["changed"] is True
+    collector.delete.assert_called_once()
+
+
+def test_delete_absent_noop():
+    collector = build_collector(False)
+    session = build_session(collector)
+    result = run_module(
+        {
+            "sflow_name": "global",
+            "ip_address": "10.0.0.50",
+            "state": "delete",
+        },
+        session,
+    )
+    assert result["changed"] is False
+    collector.delete.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+def test_missing_parent_fails():
+    collector = build_collector(False)
+    session = build_session(collector, sflow_exists=False)
+    result = run_module(
+        {
+            "sflow_name": "ghost",
+            "ip_address": "10.0.0.50",
+        },
+        session,
+    )
+    assert result["failed"] is True
+    assert "does not exist" in result["msg"]


### PR DESCRIPTION
Fixes #191

Collection modules backed by dedicated pyaoscx SDK classes. Depends on SDK PR aruba/pyaoscx#63.

## Depends on
- aruba/pyaoscx#63 — SFlow / SFlowCollector
