### PR TITLE
Add aoscx_dhcp_relay module

### DIFF
--- a/changelogs/fragments/aoscx_dhcp_relay.yml
+++ b/changelogs/fragments/aoscx_dhcp_relay.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add ``aoscx_dhcp_relay`` module to manage DHCP relays.

--- a/changelogs/fragments/aoscx_udp_bcast_forwarder.yml
+++ b/changelogs/fragments/aoscx_udp_bcast_forwarder.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Add ``aoscx_udp_bcast_forwarder`` module to manage UDP broadcast forwarder
+    servers.

--- a/docs/aoscx_dhcp_relay.md
+++ b/docs/aoscx_dhcp_relay.md
@@ -1,0 +1,88 @@
+# module: aoscx_dhcp_relay
+
+description: This module provides configuration management of DHCP relays on
+AOS-CX devices. A DHCP relay duplicates DHCP broadcast packets received on a
+routed port and forwards them as unicast to a list of DHCP server
+destinations, for a given VRF. A relay is identified by the compound index
+(vrf, port).
+
+##### ARGUMENTS
+
+```YAML
+  port:
+    description: >
+      Name of the routed port on which DHCP broadcast packets are received,
+      for example 1/1/3.
+    required: true
+    type: str
+  vrf:
+    description: VRF through which the configured DHCP servers are reachable.
+    required: false
+    default: default
+    type: str
+  ipv4_ucast_server:
+    description: >
+      List of IPv4 unicast server destinations (up to 8) to which DHCP packets
+      are forwarded. Represents the full desired set: a server present on the
+      switch but not listed here is removed. When omitted the IPv4 server list
+      is left unchanged. Ignored when state is delete.
+    required: false
+    type: list
+    elements: str
+  ipv6_ucast_server:
+    description: >
+      List of IPv6 unicast server destinations (up to 8) to which DHCP packets
+      are forwarded. Represents the full desired set: a server present on the
+      switch but not listed here is removed. When omitted the IPv6 server list
+      is left unchanged. Ignored when state is delete.
+    required: false
+    type: list
+    elements: str
+  bootp_gateway:
+    description: >
+      Gateway IPv4 address the DHCP relay agent uses as the source for relayed
+      packets. When omitted it is left unchanged. Ignored when state is delete.
+    required: false
+    type: str
+  state:
+    description: Create, update or delete the DHCP relay.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create a DHCP relay with two IPv4 servers
+  aoscx_dhcp_relay:
+    port: 1/1/3
+    vrf: default
+    ipv4_ucast_server:
+      - 10.1.1.1
+      - 10.1.1.2
+
+- name: Configure a relay with a BOOTP gateway
+  aoscx_dhcp_relay:
+    port: 1/1/3
+    vrf: default
+    ipv4_ucast_server:
+      - 10.1.1.1
+    bootp_gateway: 10.1.1.254
+
+- name: Update the IPv4 server list of an existing relay
+  aoscx_dhcp_relay:
+    port: 1/1/3
+    state: update
+    ipv4_ucast_server:
+      - 10.1.1.1
+
+- name: Delete a DHCP relay
+  aoscx_dhcp_relay:
+    port: 1/1/3
+    state: delete
+```

--- a/docs/aoscx_udp_bcast_forwarder.md
+++ b/docs/aoscx_udp_bcast_forwarder.md
@@ -1,0 +1,73 @@
+# module: aoscx_udp_bcast_forwarder
+
+description: This module provides configuration management of UDP broadcast
+forwarder servers on AOS-CX devices. A forwarder duplicates UDP broadcast
+packets received on a routed port to a list of unicast server destinations,
+for a given destination UDP port and VRF. A forwarder is identified by the
+compound index (dest_vrf, src_port, udp_dport).
+
+##### ARGUMENTS
+
+```YAML
+  src_port:
+    description: >
+      Name of the routed port on which UDP broadcast packets are received,
+      for example 1/1/1.
+    required: true
+    type: str
+  udp_dport:
+    description: >
+      Destination UDP port used to match and forward the broadcast packets.
+    required: true
+    type: int
+  dest_vrf:
+    description: VRF through which the configured servers are reachable.
+    required: false
+    default: default
+    type: str
+  ipv4_ucast_server:
+    description: >
+      List of IPv4 unicast server destinations (up to 8) to which the UDP
+      broadcast packets are forwarded. Represents the full desired set: a
+      server present on the switch but not listed here is removed. Ignored
+      when state is delete.
+    required: false
+    type: list
+    elements: str
+  state:
+    description: Create, update or delete the UDP broadcast forwarder.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create a UDP broadcast forwarder for DNS (port 53)
+  aoscx_udp_bcast_forwarder:
+    src_port: 1/1/1
+    udp_dport: 53
+    dest_vrf: default
+    ipv4_ucast_server:
+      - 10.0.0.1
+      - 10.0.0.2
+
+- name: Update the server list of an existing forwarder
+  aoscx_udp_bcast_forwarder:
+    src_port: 1/1/1
+    udp_dport: 53
+    state: update
+    ipv4_ucast_server:
+      - 10.0.0.1
+
+- name: Delete a UDP broadcast forwarder
+  aoscx_udp_bcast_forwarder:
+    src_port: 1/1/1
+    udp_dport: 53
+    state: delete
+```

--- a/plugins/modules/aoscx_dhcp_relay.py
+++ b/plugins/modules/aoscx_dhcp_relay.py
@@ -1,0 +1,271 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_dhcp_relay
+version_added: "4.6.0"
+short_description: Create, Update or Delete DHCP relays on AOS-CX
+description: >
+  This module provides configuration management of DHCP relays on AOS-CX
+  devices. A DHCP relay duplicates DHCP broadcast packets received on a
+  routed port and forwards them as unicast to a list of DHCP server
+  destinations, for a given VRF.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  port:
+    description: >
+      Name of the routed port on which DHCP broadcast packets are received,
+      for example C(1/1/3).
+    required: true
+    type: str
+  vrf:
+    description: VRF through which the configured DHCP servers are reachable.
+    required: false
+    default: default
+    type: str
+  ipv4_ucast_server:
+    description: >
+      List of IPv4 unicast server destinations (up to 8) to which DHCP
+      packets are forwarded. Represents the full desired set: a server
+      present on the switch but not listed here is removed. When omitted the
+      IPv4 server list is left unchanged. Ignored when I(state) is C(delete).
+    required: false
+    type: list
+    elements: str
+  ipv6_ucast_server:
+    description: >
+      List of IPv6 unicast server destinations (up to 8) to which DHCP
+      packets are forwarded. Represents the full desired set: a server
+      present on the switch but not listed here is removed. When omitted the
+      IPv6 server list is left unchanged. Ignored when I(state) is C(delete).
+    required: false
+    type: list
+    elements: str
+  bootp_gateway:
+    description: >
+      Gateway IPv4 address the DHCP relay agent uses as the source for relayed
+      packets. When omitted it is left unchanged. Ignored when I(state) is
+      C(delete).
+    required: false
+    type: str
+  state:
+    description: Create, update or delete the DHCP relay.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a DHCP relay with two IPv4 servers
+  aoscx_dhcp_relay:
+    port: 1/1/3
+    vrf: default
+    ipv4_ucast_server:
+      - 10.1.1.1
+      - 10.1.1.2
+
+- name: Configure a relay with a BOOTP gateway
+  aoscx_dhcp_relay:
+    port: 1/1/3
+    vrf: default
+    ipv4_ucast_server:
+      - 10.1.1.1
+    bootp_gateway: 10.1.1.254
+
+- name: Update the IPv4 server list of an existing relay
+  aoscx_dhcp_relay:
+    port: 1/1/3
+    state: update
+    ipv4_ucast_server:
+      - 10.1.1.1
+
+- name: Delete a DHCP relay
+  aoscx_dhcp_relay:
+    port: 1/1/3
+    state: delete
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the DHCP relay was modified.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+# AOS-CX accepts at most 8 unicast servers per relay and per address family.
+MAX_SERVERS = 8
+
+
+def main():
+    module_args = dict(
+        port=dict(type="str", required=True),
+        vrf=dict(type="str", default="default"),
+        ipv4_ucast_server=dict(type="list", elements="str", default=None),
+        ipv6_ucast_server=dict(type="list", elements="str", default=None),
+        bootp_gateway=dict(type="str", default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    port = ansible_module.params["port"]
+    vrf = ansible_module.params["vrf"]
+    ipv4_ucast_server = ansible_module.params["ipv4_ucast_server"]
+    ipv6_ucast_server = ansible_module.params["ipv6_ucast_server"]
+    bootp_gateway = ansible_module.params["bootp_gateway"]
+    state = ansible_module.params["state"]
+
+    result = dict(changed=False)
+
+    # Defense in depth: port and vrf are interpolated into the REST URI,
+    # reject values that could escape the resource path.
+    for label, value in (("port", port), ("vrf", vrf)):
+        if value in ("", ".", "..") or "," in value:
+            ansible_module.fail_json(
+                msg="Invalid {0}: {1}".format(label, value)
+            )
+    if "/" in vrf:
+        ansible_module.fail_json(msg="Invalid vrf: {0}".format(vrf))
+
+    for label, servers in (
+        ("ipv4_ucast_server", ipv4_ucast_server),
+        ("ipv6_ucast_server", ipv6_ucast_server),
+    ):
+        if servers is not None and len(servers) > MAX_SERVERS:
+            ansible_module.fail_json(
+                msg="{0} accepts at most {1} entries.".format(
+                    label, MAX_SERVERS
+                )
+            )
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        vrf_obj = session.api.get_module(session, "Vrf", vrf)
+        port_obj = session.api.get_module(session, "Interface", port)
+        relay = session.api.get_module(
+            session, "DhcpRelay", vrf_obj, port=port_obj
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support DHCP relays. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        relay.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                relay.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete DHCP relay: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # ------------------------------------------------------- create / update
+    if not exists:
+        kwargs = {}
+        if ipv4_ucast_server is not None:
+            kwargs["ipv4_ucast_server"] = ipv4_ucast_server
+        if ipv6_ucast_server is not None:
+            kwargs["ipv6_ucast_server"] = ipv6_ucast_server
+        if bootp_gateway is not None:
+            kwargs["other_config"] = {"bootp_gateway": bootp_gateway}
+        relay = session.api.get_module(
+            session, "DhcpRelay", vrf_obj, port=port_obj, **kwargs
+        )
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                relay.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create DHCP relay: {0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+
+    def stage(attr, value):
+        setattr(relay, attr, value)
+        if attr not in relay.config_attrs:
+            relay.config_attrs.append(attr)
+
+    if ipv4_ucast_server is not None:
+        current = getattr(relay, "ipv4_ucast_server", []) or []
+        if sorted(current) != sorted(ipv4_ucast_server):
+            changed = True
+            stage("ipv4_ucast_server", ipv4_ucast_server)
+
+    if ipv6_ucast_server is not None:
+        current = getattr(relay, "ipv6_ucast_server", []) or []
+        if sorted(current) != sorted(ipv6_ucast_server):
+            changed = True
+            stage("ipv6_ucast_server", ipv6_ucast_server)
+
+    if bootp_gateway is not None:
+        current_oc = getattr(relay, "other_config", {}) or {}
+        if current_oc.get("bootp_gateway") != bootp_gateway:
+            changed = True
+            new_oc = dict(current_oc)
+            new_oc["bootp_gateway"] = bootp_gateway
+            stage("other_config", new_oc)
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            relay.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update DHCP relay: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_udp_bcast_forwarder.py
+++ b/plugins/modules/aoscx_udp_bcast_forwarder.py
@@ -1,0 +1,237 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_udp_bcast_forwarder
+version_added: "4.6.0"
+short_description: Create, Update or Delete UDP broadcast forwarders on AOS-CX
+description: >
+  This module provides configuration management of UDP broadcast forwarder
+  servers on AOS-CX devices. A forwarder duplicates UDP broadcast packets
+  received on a routed port to a list of unicast server destinations, for a
+  given destination UDP port and VRF.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  src_port:
+    description: >
+      Name of the routed port on which UDP broadcast packets are received,
+      for example C(1/1/1).
+    required: true
+    type: str
+  udp_dport:
+    description: >
+      Destination UDP port used to match and forward the broadcast packets.
+    required: true
+    type: int
+  dest_vrf:
+    description: VRF through which the configured servers are reachable.
+    required: false
+    default: default
+    type: str
+  ipv4_ucast_server:
+    description: >
+      List of IPv4 unicast server destinations (up to 8) to which the UDP
+      broadcast packets are forwarded. Represents the full desired set: a
+      server present on the switch but not listed here is removed. Ignored
+      when I(state) is C(delete).
+    required: false
+    type: list
+    elements: str
+  state:
+    description: Create, update or delete the UDP broadcast forwarder.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a UDP broadcast forwarder for DNS (port 53)
+  aoscx_udp_bcast_forwarder:
+    src_port: 1/1/1
+    udp_dport: 53
+    dest_vrf: default
+    ipv4_ucast_server:
+      - 10.0.0.1
+      - 10.0.0.2
+
+- name: Update the server list of an existing forwarder
+  aoscx_udp_bcast_forwarder:
+    src_port: 1/1/1
+    udp_dport: 53
+    state: update
+    ipv4_ucast_server:
+      - 10.0.0.1
+
+- name: Delete a UDP broadcast forwarder
+  aoscx_udp_bcast_forwarder:
+    src_port: 1/1/1
+    udp_dport: 53
+    state: delete
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the UDP broadcast forwarder was modified.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+# AOS-CX accepts at most 8 IPv4 unicast servers per forwarder.
+MAX_SERVERS = 8
+
+
+def main():
+    module_args = dict(
+        src_port=dict(type="str", required=True),
+        udp_dport=dict(type="int", required=True),
+        dest_vrf=dict(type="str", default="default"),
+        ipv4_ucast_server=dict(type="list", elements="str", default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    src_port = ansible_module.params["src_port"]
+    udp_dport = ansible_module.params["udp_dport"]
+    dest_vrf = ansible_module.params["dest_vrf"]
+    ipv4_ucast_server = ansible_module.params["ipv4_ucast_server"]
+    state = ansible_module.params["state"]
+
+    result = dict(changed=False)
+
+    # Defense in depth: src_port and dest_vrf are interpolated into the REST
+    # URI, reject values that could escape the resource path.
+    for label, value in (("src_port", src_port), ("dest_vrf", dest_vrf)):
+        if value in ("", ".", "..") or "," in value:
+            ansible_module.fail_json(
+                msg="Invalid {0}: {1}".format(label, value)
+            )
+    if dest_vrf == "" or "/" in dest_vrf:
+        ansible_module.fail_json(msg="Invalid dest_vrf: {0}".format(dest_vrf))
+
+    if udp_dport < 0 or udp_dport > 65535:
+        ansible_module.fail_json(msg="udp_dport must be between 0 and 65535.")
+
+    if ipv4_ucast_server is not None and len(ipv4_ucast_server) > MAX_SERVERS:
+        ansible_module.fail_json(
+            msg="ipv4_ucast_server accepts at most {0} entries.".format(
+                MAX_SERVERS
+            )
+        )
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        vrf = session.api.get_module(session, "Vrf", dest_vrf)
+        port = session.api.get_module(session, "Interface", src_port)
+        forwarder = session.api.get_module(
+            session,
+            "UdpBcastForwarderServer",
+            vrf,
+            src_port=port,
+            udp_dport=udp_dport,
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support UDP broadcast "
+                "forwarders. Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        forwarder.get()
+        exists = True
+    except Exception:
+        exists = False
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                forwarder.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete UDP forwarder: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    desired = ipv4_ucast_server if ipv4_ucast_server is not None else []
+
+    # ------------------------------------------------------- create / update
+    if not exists:
+        forwarder = session.api.get_module(
+            session,
+            "UdpBcastForwarderServer",
+            vrf,
+            src_port=port,
+            udp_dport=udp_dport,
+            ipv4_ucast_server=desired,
+        )
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                forwarder.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create UDP forwarder: {0}".format(str(e))
+                )
+    else:
+        current = getattr(forwarder, "ipv4_ucast_server", []) or []
+        if ipv4_ucast_server is not None and sorted(current) != sorted(
+            desired
+        ):
+            result["changed"] = True
+            forwarder.ipv4_ucast_server = desired
+            if "ipv4_ucast_server" not in forwarder.config_attrs:
+                forwarder.config_attrs.append("ipv4_ucast_server")
+            if not ansible_module.check_mode:
+                try:
+                    forwarder.update()
+                except Exception as e:
+                    ansible_module.fail_json(
+                        msg="Could not update UDP forwarder: {0}".format(
+                            str(e)
+                        )
+                    )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/aoscx_dhcp_relay/aliases
+++ b/tests/integration/targets/aoscx_dhcp_relay/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_dhcp_relay/tasks/main.yml
+++ b/tests/integration/targets/aoscx_dhcp_relay/tasks/main.yml
@@ -1,0 +1,79 @@
+# Integration tests for the aoscx_dhcp_relay module.
+#
+# Run with:
+#   ansible-test integration aoscx_dhcp_relay --venv
+#
+# Requires an inventory entry named "aoscx" reachable over httpapi with a
+# pyaoscx release that ships the DhcpRelay class.
+
+- name: Make sure the test relay does not exist yet
+  arubanetworks.aoscx.aoscx_dhcp_relay:
+    port: 1/1/3
+    state: delete
+  ignore_errors: true
+
+- name: Create a DHCP relay with two IPv4 servers
+  arubanetworks.aoscx.aoscx_dhcp_relay:
+    port: 1/1/3
+    vrf: default
+    ipv4_ucast_server:
+      - 10.1.1.1
+      - 10.1.1.2
+    state: create
+  register: create_result
+
+- name: Assert create changed
+  ansible.builtin.assert:
+    that:
+      - create_result is changed
+
+- name: Re-apply identical configuration
+  arubanetworks.aoscx.aoscx_dhcp_relay:
+    port: 1/1/3
+    vrf: default
+    ipv4_ucast_server:
+      - 10.1.1.1
+      - 10.1.1.2
+    state: create
+  register: idem_result
+
+- name: Assert re-apply did not change
+  ansible.builtin.assert:
+    that:
+      - idem_result is not changed
+
+- name: Update the IPv4 server list
+  arubanetworks.aoscx.aoscx_dhcp_relay:
+    port: 1/1/3
+    state: update
+    ipv4_ucast_server:
+      - 10.1.1.1
+  register: update_result
+
+- name: Assert update changed
+  ansible.builtin.assert:
+    that:
+      - update_result is changed
+
+- name: Add a BOOTP gateway
+  arubanetworks.aoscx.aoscx_dhcp_relay:
+    port: 1/1/3
+    state: update
+    bootp_gateway: 10.1.1.254
+  register: gw_result
+
+- name: Assert BOOTP gateway change
+  ansible.builtin.assert:
+    that:
+      - gw_result is changed
+
+- name: Delete the relay
+  arubanetworks.aoscx.aoscx_dhcp_relay:
+    port: 1/1/3
+    state: delete
+  register: delete_result
+
+- name: Assert delete changed
+  ansible.builtin.assert:
+    that:
+      - delete_result is changed

--- a/tests/integration/targets/aoscx_udp_bcast_forwarder/aliases
+++ b/tests/integration/targets/aoscx_udp_bcast_forwarder/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_udp_bcast_forwarder/tasks/main.yml
+++ b/tests/integration/targets/aoscx_udp_bcast_forwarder/tasks/main.yml
@@ -1,0 +1,72 @@
+# Integration tests for the aoscx_udp_bcast_forwarder module.
+#
+# Run with:
+#   ansible-test integration aoscx_udp_bcast_forwarder --venv
+#
+# Requires an inventory entry named "aoscx" reachable over httpapi with a
+# pyaoscx release that ships the UdpBcastForwarderServer class.
+
+- name: Make sure the test forwarder does not exist yet
+  arubanetworks.aoscx.aoscx_udp_bcast_forwarder:
+    src_port: 1/1/1
+    udp_dport: 53
+    state: delete
+  ignore_errors: true
+
+- name: Create a UDP broadcast forwarder with two servers
+  arubanetworks.aoscx.aoscx_udp_bcast_forwarder:
+    src_port: 1/1/1
+    udp_dport: 53
+    dest_vrf: default
+    ipv4_ucast_server:
+      - 10.0.0.1
+      - 10.0.0.2
+    state: create
+  register: create_result
+
+- name: Assert create changed
+  ansible.builtin.assert:
+    that:
+      - create_result is changed
+
+- name: Re-apply identical configuration
+  arubanetworks.aoscx.aoscx_udp_bcast_forwarder:
+    src_port: 1/1/1
+    udp_dport: 53
+    dest_vrf: default
+    ipv4_ucast_server:
+      - 10.0.0.1
+      - 10.0.0.2
+    state: create
+  register: idem_result
+
+- name: Assert re-apply did not change
+  ansible.builtin.assert:
+    that:
+      - idem_result is not changed
+
+- name: Update the server list
+  arubanetworks.aoscx.aoscx_udp_bcast_forwarder:
+    src_port: 1/1/1
+    udp_dport: 53
+    state: update
+    ipv4_ucast_server:
+      - 10.0.0.1
+  register: update_result
+
+- name: Assert update changed
+  ansible.builtin.assert:
+    that:
+      - update_result is changed
+
+- name: Delete the forwarder
+  arubanetworks.aoscx.aoscx_udp_bcast_forwarder:
+    src_port: 1/1/1
+    udp_dport: 53
+    state: delete
+  register: delete_result
+
+- name: Assert delete changed
+  ansible.builtin.assert:
+    that:
+      - delete_result is changed

--- a/tests/unit/modules/test_aoscx_dhcp_relay.py
+++ b/tests/unit/modules/test_aoscx_dhcp_relay.py
@@ -1,0 +1,306 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_dhcp_relay module.
+
+The pyaoscx session is fully mocked, so no switch is required. The tests
+cover input validation, check mode, idempotency, create, update, delete and
+error handling.
+
+Run with:
+    PYTHONPATH=/tmp/acoll2x .venv/bin/python -m pytest \
+        tests/unit/modules/test_aoscx_dhcp_relay.py -v
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+import pytest
+
+from unittest.mock import MagicMock, patch
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_dhcp_relay,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_dhcp_relay"
+)
+
+
+class AnsibleExitJson(Exception):
+    """Raised by the mocked exit_json to stop module execution."""
+
+
+class AnsibleFailJson(Exception):
+    """Raised by the mocked fail_json to stop module execution."""
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_relay(exists, ipv4=None, ipv6=None, other_config=None):
+    relay = MagicMock()
+    relay.config_attrs = []
+    relay.ipv4_ucast_server = ipv4 if ipv4 is not None else []
+    relay.ipv6_ucast_server = ipv6 if ipv6 is not None else []
+    relay.other_config = other_config if other_config is not None else {}
+    if exists:
+        relay.get.return_value = True
+    else:
+        relay.get.side_effect = Exception("not found")
+    return relay
+
+
+def build_session(existing, new_relay=None):
+    session = MagicMock()
+    create_kwargs = (
+        "ipv4_ucast_server",
+        "ipv6_ucast_server",
+        "other_config",
+    )
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module in ("Vrf", "Interface"):
+            return MagicMock(name=module)
+        if module == "DhcpRelay":
+            if (
+                any(k in kwargs for k in create_kwargs)
+                and new_relay is not None
+            ):
+                return new_relay
+            return existing
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_dhcp_relay.main()
+    return exc.value.args[0]
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+def test_invalid_port_rejected():
+    session = build_session(build_relay(False))
+    result = run_module({"port": "a,b"}, session)
+    assert result["failed"] is True
+    assert "Invalid port" in result["msg"]
+
+
+def test_invalid_vrf_rejected():
+    session = build_session(build_relay(False))
+    result = run_module({"port": "1/1/3", "vrf": "a/b"}, session)
+    assert result["failed"] is True
+    assert "Invalid vrf" in result["msg"]
+
+
+def test_too_many_ipv4_servers_rejected():
+    session = build_session(build_relay(False))
+    result = run_module(
+        {
+            "port": "1/1/3",
+            "ipv4_ucast_server": ["10.0.0.{0}".format(i) for i in range(9)],
+        },
+        session,
+    )
+    assert result["failed"] is True
+    assert "ipv4_ucast_server accepts at most 8" in result["msg"]
+
+
+def test_too_many_ipv6_servers_rejected():
+    session = build_session(build_relay(False))
+    result = run_module(
+        {
+            "port": "1/1/3",
+            "ipv6_ucast_server": ["2001:db8::{0}".format(i) for i in range(9)],
+        },
+        session,
+    )
+    assert result["failed"] is True
+    assert "ipv6_ucast_server accepts at most 8" in result["msg"]
+
+
+# --------------------------------------------------------------------------
+# Create
+# --------------------------------------------------------------------------
+def test_create_new_relay():
+    existing = build_relay(False)
+    new = build_relay(False)
+    session = build_session(existing, new_relay=new)
+    result = run_module(
+        {"port": "1/1/3", "ipv4_ucast_server": ["10.1.1.1"]},
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_with_bootp_gateway():
+    existing = build_relay(False)
+    new = build_relay(False)
+    session = build_session(existing, new_relay=new)
+    result = run_module(
+        {
+            "port": "1/1/3",
+            "ipv4_ucast_server": ["10.1.1.1"],
+            "bootp_gateway": "10.1.1.254",
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_check_mode_does_not_write():
+    existing = build_relay(False)
+    new = build_relay(False)
+    session = build_session(existing, new_relay=new)
+    result = run_module(
+        {
+            "port": "1/1/3",
+            "ipv4_ucast_server": ["10.1.1.1"],
+            "_ansible_check_mode": True,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Idempotency / update
+# --------------------------------------------------------------------------
+def test_idempotent_no_change():
+    existing = build_relay(True, ipv4=["10.1.1.2", "10.1.1.1"])
+    session = build_session(existing)
+    result = run_module(
+        {
+            "port": "1/1/3",
+            "state": "update",
+            "ipv4_ucast_server": ["10.1.1.1", "10.1.1.2"],
+        },
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_update_changes_ipv4_list():
+    existing = build_relay(True, ipv4=["10.1.1.1"])
+    session = build_session(existing)
+    result = run_module(
+        {
+            "port": "1/1/3",
+            "state": "update",
+            "ipv4_ucast_server": ["10.1.1.1", "10.1.1.2"],
+        },
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_update_changes_bootp_gateway():
+    existing = build_relay(True, other_config={"bootp_gateway": "10.1.1.1"})
+    session = build_session(existing)
+    result = run_module(
+        {
+            "port": "1/1/3",
+            "state": "update",
+            "bootp_gateway": "10.1.1.254",
+        },
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_update_unspecified_attrs_left_untouched():
+    existing = build_relay(True, ipv4=["10.1.1.1"])
+    session = build_session(existing)
+    result = run_module(
+        {"port": "1/1/3", "state": "update"},
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Delete
+# --------------------------------------------------------------------------
+def test_delete_existing():
+    existing = build_relay(True)
+    session = build_session(existing)
+    result = run_module(
+        {"port": "1/1/3", "state": "delete"},
+        session,
+    )
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+
+
+def test_delete_absent_no_change():
+    existing = build_relay(False)
+    session = build_session(existing)
+    result = run_module(
+        {"port": "1/1/3", "state": "delete"},
+        session,
+    )
+    assert result["changed"] is False
+    existing.delete.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Error handling
+# --------------------------------------------------------------------------
+def test_create_error_is_reported():
+    existing = build_relay(False)
+    new = build_relay(False)
+    new.create.side_effect = Exception("boom")
+    session = build_session(existing, new_relay=new)
+    result = run_module(
+        {"port": "1/1/3", "ipv4_ucast_server": ["10.1.1.1"]},
+        session,
+    )
+    assert result["failed"] is True
+    assert "Could not create DHCP relay" in result["msg"]

--- a/tests/unit/modules/test_aoscx_udp_bcast_forwarder.py
+++ b/tests/unit/modules/test_aoscx_udp_bcast_forwarder.py
@@ -1,0 +1,263 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_udp_bcast_forwarder module.
+
+The pyaoscx session is fully mocked, so no switch is required. The tests
+cover input validation, check mode, idempotency, create, update, delete and
+error handling.
+
+Run with:
+    PYTHONPATH=/tmp/acoll2x .venv/bin/python -m pytest \
+        tests/unit/modules/test_aoscx_udp_bcast_forwarder.py -v
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+import pytest
+
+from unittest.mock import MagicMock, patch
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_udp_bcast_forwarder,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_udp_bcast_forwarder"
+)
+
+
+class AnsibleExitJson(Exception):
+    """Raised by the mocked exit_json to stop module execution."""
+
+
+class AnsibleFailJson(Exception):
+    """Raised by the mocked fail_json to stop module execution."""
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_forwarder(exists, ipv4=None):
+    fwd = MagicMock()
+    fwd.config_attrs = []
+    fwd.ipv4_ucast_server = ipv4 if ipv4 is not None else []
+    if exists:
+        fwd.get.return_value = True
+    else:
+        fwd.get.side_effect = Exception("not found")
+    return fwd
+
+
+def build_session(existing, new_forwarder=None):
+    session = MagicMock()
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module in ("Vrf", "Interface"):
+            return MagicMock(name=module)
+        if module == "UdpBcastForwarderServer":
+            if "ipv4_ucast_server" in kwargs and new_forwarder is not None:
+                return new_forwarder
+            return existing
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_udp_bcast_forwarder.main()
+    return exc.value.args[0]
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+def test_invalid_src_port_rejected():
+    session = build_session(build_forwarder(False))
+    result = run_module({"src_port": "a,b", "udp_dport": 53}, session)
+    assert result["failed"] is True
+    assert "Invalid src_port" in result["msg"]
+
+
+def test_invalid_dest_vrf_rejected():
+    session = build_session(build_forwarder(False))
+    result = run_module(
+        {"src_port": "1/1/1", "udp_dport": 53, "dest_vrf": "a/b"},
+        session,
+    )
+    assert result["failed"] is True
+    assert "Invalid dest_vrf" in result["msg"]
+
+
+def test_udp_dport_out_of_range_rejected():
+    session = build_session(build_forwarder(False))
+    result = run_module({"src_port": "1/1/1", "udp_dport": 70000}, session)
+    assert result["failed"] is True
+    assert "udp_dport must be between 0 and 65535" in result["msg"]
+
+
+def test_too_many_servers_rejected():
+    session = build_session(build_forwarder(False))
+    result = run_module(
+        {
+            "src_port": "1/1/1",
+            "udp_dport": 53,
+            "ipv4_ucast_server": ["10.0.0.{0}".format(i) for i in range(9)],
+        },
+        session,
+    )
+    assert result["failed"] is True
+    assert "at most 8" in result["msg"]
+
+
+# --------------------------------------------------------------------------
+# Create
+# --------------------------------------------------------------------------
+def test_create_new_forwarder():
+    existing = build_forwarder(False)
+    new = build_forwarder(False)
+    session = build_session(existing, new_forwarder=new)
+    result = run_module(
+        {
+            "src_port": "1/1/1",
+            "udp_dport": 53,
+            "ipv4_ucast_server": ["10.0.0.1"],
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_check_mode_does_not_write():
+    existing = build_forwarder(False)
+    new = build_forwarder(False)
+    session = build_session(existing, new_forwarder=new)
+    result = run_module(
+        {
+            "src_port": "1/1/1",
+            "udp_dport": 53,
+            "ipv4_ucast_server": ["10.0.0.1"],
+            "_ansible_check_mode": True,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Idempotency / update
+# --------------------------------------------------------------------------
+def test_idempotent_no_change():
+    existing = build_forwarder(True, ipv4=["10.0.0.2", "10.0.0.1"])
+    session = build_session(existing)
+    result = run_module(
+        {
+            "src_port": "1/1/1",
+            "udp_dport": 53,
+            "state": "update",
+            "ipv4_ucast_server": ["10.0.0.1", "10.0.0.2"],
+        },
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_update_changes_server_list():
+    existing = build_forwarder(True, ipv4=["10.0.0.1"])
+    session = build_session(existing)
+    result = run_module(
+        {
+            "src_port": "1/1/1",
+            "udp_dport": 53,
+            "state": "update",
+            "ipv4_ucast_server": ["10.0.0.1", "10.0.0.2"],
+        },
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+# --------------------------------------------------------------------------
+# Delete
+# --------------------------------------------------------------------------
+def test_delete_existing():
+    existing = build_forwarder(True)
+    session = build_session(existing)
+    result = run_module(
+        {"src_port": "1/1/1", "udp_dport": 53, "state": "delete"},
+        session,
+    )
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+
+
+def test_delete_absent_no_change():
+    existing = build_forwarder(False)
+    session = build_session(existing)
+    result = run_module(
+        {"src_port": "1/1/1", "udp_dport": 53, "state": "delete"},
+        session,
+    )
+    assert result["changed"] is False
+    existing.delete.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Error handling
+# --------------------------------------------------------------------------
+def test_create_error_is_reported():
+    existing = build_forwarder(False)
+    new = build_forwarder(False)
+    new.create.side_effect = Exception("boom")
+    session = build_session(existing, new_forwarder=new)
+    result = run_module(
+        {
+            "src_port": "1/1/1",
+            "udp_dport": 53,
+            "ipv4_ucast_server": ["10.0.0.1"],
+        },
+        session,
+    )
+    assert result["failed"] is True
+    assert "Could not create UDP forwarder" in result["msg"]


### PR DESCRIPTION
Fixes #192

Collection modules backed by dedicated pyaoscx SDK classes. Depends on SDK PR aruba/pyaoscx#55.

## Depends on
- aruba/pyaoscx#55 — DhcpRelay.get_all fix
- aruba/pyaoscx#53 — UdpBcastForwarderServer (PR also touches aoscx_udp_bcast_forwarder)
