### PR TITLE
Add aoscx_mirror and aoscx_mirror_endpoint modules

### DIFF
--- a/changelogs/fragments/aoscx_mirror.yml
+++ b/changelogs/fragments/aoscx_mirror.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - Add ``aoscx_mirror`` module to manage traffic mirror (port monitoring)
+    sessions.
+  - Add ``aoscx_mirror_endpoint`` module to manage remote (ERSPAN) mirror
+    endpoints.

--- a/changelogs/fragments/mirror_tunnel.yml
+++ b/changelogs/fragments/mirror_tunnel.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - aoscx_mirror - add the C(tunnel) and C(tunnel_vrf) options to configure
+    ERSPAN (encapsulated remote) mirror sessions, including the tunnel source
+    and destination IPv4 addresses, DSCP marking and the VRF used to reach the
+    tunnel destination.

--- a/docs/aoscx_mirror.md
+++ b/docs/aoscx_mirror.md
@@ -1,0 +1,120 @@
+# module: aoscx_mirror
+
+description: This module provides configuration management of traffic mirror
+(port monitoring) sessions on AOS-CX devices. A mirror session copies traffic
+from one or more source ports or VLANs to a destination (output) port. Source
+ports, destination ports and VLANs must already exist on the device.
+
+##### ARGUMENTS
+
+```YAML
+  mirror_id:
+    description: >
+      Numeric identifier of the mirror session. This is the index of the
+      resource under system/mirrors.
+    required: true
+    type: int
+  session_type:
+    description: >
+      Type of the mirror session. When omitted it is left unchanged.
+    required: false
+    choices:
+      - none
+      - port
+      - cpu
+      - tunnel
+    type: str
+  active:
+    description: >
+      Whether the mirror session is active. An inactive session is configured
+      but does not mirror any traffic. When omitted it is left unchanged.
+    required: false
+    type: bool
+  comment:
+    description: A descriptive comment for the mirror session.
+    required: false
+    type: str
+  output_port:
+    description: >
+      List of destination port names that receive the mirrored traffic. The
+      ports must already exist on the device. The list is compared regardless
+      of order.
+    required: false
+    type: list
+    elements: str
+  select_src_port:
+    description: >
+      List of port names whose ingress (received) traffic is mirrored. The
+      ports must already exist on the device. The list is compared regardless
+      of order.
+    required: false
+    type: list
+    elements: str
+  select_dst_port:
+    description: >
+      List of port names whose egress (transmitted) traffic is mirrored. The
+      ports must already exist on the device. The list is compared regardless
+      of order.
+    required: false
+    type: list
+    elements: str
+  select_rx_vlan:
+    description: >
+      List of VLAN ids whose ingress (received) traffic is mirrored. The
+      VLANs must already exist on the device. The list is compared regardless
+      of order.
+    required: false
+    type: list
+    elements: int
+  select_tx_vlan:
+    description: >
+      List of VLAN ids whose egress (transmitted) traffic is mirrored. The
+      VLANs must already exist on the device. The list is compared regardless
+      of order.
+    required: false
+    type: list
+    elements: int
+  state:
+    description: Create, update or delete the mirror session.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create a port mirror session, source 1/1/1 RX, destination 1/1/10
+  aoscx_mirror:
+    mirror_id: 5
+    session_type: port
+    active: true
+    comment: span-to-analyzer
+    select_src_port:
+      - 1/1/1
+    output_port:
+      - 1/1/10
+
+- name: Add VLANs to the mirrored receive set
+  aoscx_mirror:
+    mirror_id: 5
+    state: update
+    select_rx_vlan:
+      - 10
+      - 20
+
+- name: Deactivate a mirror session
+  aoscx_mirror:
+    mirror_id: 5
+    state: update
+    active: false
+
+- name: Delete a mirror session
+  aoscx_mirror:
+    mirror_id: 5
+    state: delete
+```

--- a/docs/aoscx_mirror_endpoint.md
+++ b/docs/aoscx_mirror_endpoint.md
@@ -1,0 +1,96 @@
+# module: aoscx_mirror_endpoint
+
+description: This module provides configuration management of remote mirror
+endpoints on AOS-CX devices. A mirror endpoint defines an ERSPAN tunnel
+destination to which mirrored traffic is encapsulated and forwarded. The
+output ports must already exist on the device.
+
+##### ARGUMENTS
+
+```YAML
+  name:
+    description: >
+      Name of the mirror endpoint. This is the index of the resource under
+      system/mirror_endpoints.
+    required: true
+    type: str
+  admin:
+    description: Administrative state of the mirror endpoint.
+    required: false
+    choices:
+      - up
+      - down
+    type: str
+  comment:
+    description: A descriptive comment for the mirror endpoint.
+    required: false
+    type: str
+  output_port:
+    description: >
+      List of port names through which the encapsulated mirrored traffic is
+      sent. The ports must already exist on the device. The list is compared
+      regardless of order.
+    required: false
+    type: list
+    elements: str
+  tunnel:
+    description: >
+      ERSPAN tunnel parameters for the endpoint. Only the supplied keys are
+      reconciled; existing keys that are not mentioned are preserved.
+    required: false
+    type: dict
+    suboptions:
+      dest_ip_address:
+        description: Destination IP address of the ERSPAN tunnel.
+        required: false
+        type: str
+      src_ip_address:
+        description: Source IP address of the ERSPAN tunnel.
+        required: false
+        type: str
+      dscp:
+        description: DSCP value used for the tunnel encapsulation.
+        required: false
+        type: int
+      id:
+        description: ERSPAN session id carried in the tunnel header.
+        required: false
+        type: int
+  state:
+    description: Create, update or delete the mirror endpoint.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create an ERSPAN mirror endpoint
+  aoscx_mirror_endpoint:
+    name: erspan-to-collector
+    admin: up
+    comment: collector-1
+    output_port:
+      - 1/1/10
+    tunnel:
+      src_ip_address: 10.0.0.1
+      dest_ip_address: 10.0.0.2
+      id: 100
+
+- name: Update the tunnel destination of a mirror endpoint
+  aoscx_mirror_endpoint:
+    name: erspan-to-collector
+    state: update
+    tunnel:
+      dest_ip_address: 10.0.0.3
+
+- name: Delete a mirror endpoint
+  aoscx_mirror_endpoint:
+    name: erspan-to-collector
+    state: delete
+```

--- a/plugins/modules/aoscx_mirror.py
+++ b/plugins/modules/aoscx_mirror.py
@@ -1,0 +1,319 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_mirror
+version_added: "4.6.0"
+short_description: Create, update or delete a mirror session on AOS-CX
+description: >
+  This module provides configuration management of traffic mirror (port
+  monitoring) sessions on AOS-CX devices. A mirror session copies traffic
+  from one or more source ports or VLANs to a destination (output) port.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  mirror_id:
+    description: >
+      Numeric identifier of the mirror session. This is the index of the
+      resource under system/mirrors.
+    required: true
+    type: int
+  session_type:
+    description: >
+      Type of the mirror session.
+    required: false
+    choices:
+      - none
+      - port
+      - cpu
+      - tunnel
+    type: str
+  active:
+    description: >
+      Whether the mirror session is active. An inactive session is configured
+      but does not mirror any traffic.
+    required: false
+    type: bool
+  comment:
+    description: A descriptive comment for the mirror session.
+    required: false
+    type: str
+  output_port:
+    description: >
+      List of destination port names that receive the mirrored traffic. The
+      ports must already exist on the device.
+    required: false
+    type: list
+    elements: str
+  select_src_port:
+    description: >
+      List of port names whose ingress (received) traffic is mirrored. The
+      ports must already exist on the device.
+    required: false
+    type: list
+    elements: str
+  select_dst_port:
+    description: >
+      List of port names whose egress (transmitted) traffic is mirrored. The
+      ports must already exist on the device.
+    required: false
+    type: list
+    elements: str
+  select_rx_vlan:
+    description: >
+      List of VLAN ids whose ingress (received) traffic is mirrored. The
+      VLANs must already exist on the device.
+    required: false
+    type: list
+    elements: int
+  select_tx_vlan:
+    description: >
+      List of VLAN ids whose egress (transmitted) traffic is mirrored. The
+      VLANs must already exist on the device.
+    required: false
+    type: list
+    elements: int
+  state:
+    description: Create, update or delete the mirror session.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a port mirror session, source 1/1/1 RX, destination 1/1/10
+  aoscx_mirror:
+    mirror_id: 5
+    session_type: port
+    active: true
+    comment: span-to-analyzer
+    select_src_port:
+      - 1/1/1
+    output_port:
+      - 1/1/10
+
+- name: Add a VLAN to the mirrored receive set
+  aoscx_mirror:
+    mirror_id: 5
+    state: update
+    select_rx_vlan:
+      - 10
+      - 20
+
+- name: Deactivate a mirror session
+  aoscx_mirror:
+    mirror_id: 5
+    state: update
+    active: false
+
+- name: Delete a mirror session
+  aoscx_mirror:
+    mirror_id: 5
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        mirror_id=dict(type="int", required=True),
+        session_type=dict(
+            type="str",
+            required=False,
+            choices=["none", "port", "cpu", "tunnel"],
+        ),
+        active=dict(type="bool", required=False, default=None),
+        comment=dict(type="str", required=False, default=None),
+        output_port=dict(
+            type="list", elements="str", required=False, default=None
+        ),
+        select_src_port=dict(
+            type="list", elements="str", required=False, default=None
+        ),
+        select_dst_port=dict(
+            type="list", elements="str", required=False, default=None
+        ),
+        select_rx_vlan=dict(
+            type="list", elements="int", required=False, default=None
+        ),
+        select_tx_vlan=dict(
+            type="list", elements="int", required=False, default=None
+        ),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    mirror_id = ansible_module.params["mirror_id"]
+    session_type = ansible_module.params["session_type"]
+    active = ansible_module.params["active"]
+    comment = ansible_module.params["comment"]
+    output_port = ansible_module.params["output_port"]
+    select_src_port = ansible_module.params["select_src_port"]
+    select_dst_port = ansible_module.params["select_dst_port"]
+    select_rx_vlan = ansible_module.params["select_rx_vlan"]
+    select_tx_vlan = ansible_module.params["select_tx_vlan"]
+    state = ansible_module.params["state"]
+
+    result = dict(changed=False)
+
+    if mirror_id < 1:
+        ansible_module.fail_json(msg="mirror_id must be a positive integer.")
+
+    port_params = {
+        "output_port": output_port,
+        "select_src_port": select_src_port,
+        "select_dst_port": select_dst_port,
+    }
+    vlan_params = {
+        "select_rx_vlan": select_rx_vlan,
+        "select_tx_vlan": select_tx_vlan,
+    }
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        mirror = session.api.get_module(session, "Mirror", mirror_id)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support mirroring. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        mirror.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                mirror.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete mirror session: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    def materialize_ports(names):
+        return [session.api.get_module(session, "Interface", n) for n in names]
+
+    def materialize_vlans(ids):
+        return [session.api.get_module(session, "Vlan", v) for v in ids]
+
+    # ------------------------------------------------------- create / update
+    if not exists:
+        kwargs = {}
+        if session_type is not None:
+            kwargs["session_type"] = session_type
+        if active is not None:
+            kwargs["active"] = active
+        if comment is not None:
+            kwargs["comment"] = comment
+        for attr, names in port_params.items():
+            if names is not None:
+                kwargs[attr] = materialize_ports(names)
+        for attr, ids in vlan_params.items():
+            if ids is not None:
+                kwargs[attr] = materialize_vlans(ids)
+        mirror = session.api.get_module(session, "Mirror", mirror_id, **kwargs)
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                mirror.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create mirror session: {0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+
+    if session_type is not None and (
+        getattr(mirror, "session_type", None) != session_type
+    ):
+        changed = True
+        mirror.session_type = session_type
+
+    if active is not None and getattr(mirror, "active", None) != active:
+        changed = True
+        mirror.active = active
+
+    if comment is not None and getattr(mirror, "comment", None) != comment:
+        changed = True
+        mirror.comment = comment
+
+    # Port references are unordered; compare them by name regardless of order.
+    for attr, names in port_params.items():
+        if names is None:
+            continue
+        current = sorted(p.name for p in (getattr(mirror, attr, None) or []))
+        if current != sorted(names):
+            changed = True
+            setattr(mirror, attr, materialize_ports(names))
+
+    # VLAN references are unordered; compare them by id regardless of order.
+    for attr, ids in vlan_params.items():
+        if ids is None:
+            continue
+        current = sorted(
+            int(v.id) for v in (getattr(mirror, attr, None) or [])
+        )
+        if current != sorted(int(i) for i in ids):
+            changed = True
+            setattr(mirror, attr, materialize_vlans(ids))
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            mirror.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update mirror session: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_mirror.py
+++ b/plugins/modules/aoscx_mirror.py
@@ -87,6 +87,32 @@ options:
     required: false
     type: list
     elements: int
+  tunnel_vrf:
+    description: >
+      Name of the VRF used to reach the tunnel destination IP address. Only
+      considered when I(session_type=tunnel). The VRF must already exist. If
+      not specified, the 'default' VRF is used.
+    required: false
+    type: str
+  tunnel:
+    description: >
+      Tunnel parameters for an ERSPAN (encapsulated remote) mirror session.
+      Only considered when I(session_type=tunnel).
+    required: false
+    type: dict
+    suboptions:
+      src_ip_address:
+        description: Source IPv4 address of the tunnel.
+        required: false
+        type: str
+      dest_ip_address:
+        description: Destination IPv4 address of the tunnel.
+        required: false
+        type: str
+      dscp:
+        description: DSCP value to mark on the tunneled packets (0-63).
+        required: false
+        type: int
   state:
     description: Create, update or delete the mirror session.
     required: false
@@ -163,6 +189,21 @@ def main():
         select_tx_vlan=dict(
             type="list", elements="int", required=False, default=None
         ),
+        tunnel_vrf=dict(type="str", required=False, default=None),
+        tunnel=dict(
+            type="dict",
+            required=False,
+            default=None,
+            options=dict(
+                src_ip_address=dict(
+                    type="str", required=False, default=None
+                ),
+                dest_ip_address=dict(
+                    type="str", required=False, default=None
+                ),
+                dscp=dict(type="int", required=False, default=None),
+            ),
+        ),
         state=dict(
             type="str",
             default="create",
@@ -183,6 +224,8 @@ def main():
     select_dst_port = ansible_module.params["select_dst_port"]
     select_rx_vlan = ansible_module.params["select_rx_vlan"]
     select_tx_vlan = ansible_module.params["select_tx_vlan"]
+    tunnel_vrf = ansible_module.params["tunnel_vrf"]
+    tunnel = ansible_module.params["tunnel"]
     state = ansible_module.params["state"]
 
     result = dict(changed=False)
@@ -241,6 +284,21 @@ def main():
     def materialize_vlans(ids):
         return [session.api.get_module(session, "Vlan", v) for v in ids]
 
+    def materialize_vrf(vrf_name):
+        return session.api.get_module(session, "Vrf", vrf_name)
+
+    def vrf_name_of(ref):
+        if not ref:
+            return None
+        if isinstance(ref, str):
+            return ref.rstrip("/").split("/")[-1]
+        if isinstance(ref, dict):
+            return next(iter(ref), None)
+        return getattr(ref, "name", None)
+
+    def clean_tunnel(value):
+        return {k: v for k, v in value.items() if v is not None}
+
     # ------------------------------------------------------- create / update
     if not exists:
         kwargs = {}
@@ -256,6 +314,10 @@ def main():
         for attr, ids in vlan_params.items():
             if ids is not None:
                 kwargs[attr] = materialize_vlans(ids)
+        if tunnel is not None:
+            kwargs["tunnel"] = clean_tunnel(tunnel)
+        if tunnel_vrf is not None:
+            kwargs["tunnel_vrf"] = materialize_vrf(tunnel_vrf).get_uri()
         mirror = session.api.get_module(session, "Mirror", mirror_id, **kwargs)
         result["changed"] = True
         if not ansible_module.check_mode:
@@ -302,6 +364,20 @@ def main():
         if current != sorted(int(i) for i in ids):
             changed = True
             setattr(mirror, attr, materialize_vlans(ids))
+
+    if tunnel is not None:
+        want = clean_tunnel(tunnel)
+        current_tunnel = getattr(mirror, "tunnel", None) or {}
+        if any(current_tunnel.get(k) != v for k, v in want.items()):
+            changed = True
+            merged = dict(current_tunnel)
+            merged.update(want)
+            mirror.tunnel = merged
+
+    if tunnel_vrf is not None:
+        if vrf_name_of(getattr(mirror, "tunnel_vrf", None)) != tunnel_vrf:
+            changed = True
+            mirror.tunnel_vrf = materialize_vrf(tunnel_vrf).get_uri()
 
     result["changed"] = changed
     if changed and not ansible_module.check_mode:

--- a/plugins/modules/aoscx_mirror_endpoint.py
+++ b/plugins/modules/aoscx_mirror_endpoint.py
@@ -1,0 +1,268 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_mirror_endpoint
+version_added: "4.6.0"
+short_description: Manage remote mirror (ERSPAN) endpoints on AOS-CX
+description: >
+  This module provides configuration management of remote mirror endpoints
+  on AOS-CX devices. A mirror endpoint defines an ERSPAN tunnel destination
+  to which mirrored traffic is encapsulated and forwarded.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: >
+      Name of the mirror endpoint. This is the index of the resource under
+      system/mirror_endpoints.
+    required: true
+    type: str
+  admin:
+    description: Administrative state of the mirror endpoint.
+    required: false
+    choices:
+      - up
+      - down
+    type: str
+  comment:
+    description: A descriptive comment for the mirror endpoint.
+    required: false
+    type: str
+  output_port:
+    description: >
+      List of port names through which the encapsulated mirrored traffic is
+      sent. The ports must already exist on the device.
+    required: false
+    type: list
+    elements: str
+  tunnel:
+    description: >
+      ERSPAN tunnel parameters for the endpoint.
+    required: false
+    type: dict
+    suboptions:
+      dest_ip_address:
+        description: Destination IP address of the ERSPAN tunnel.
+        required: false
+        type: str
+      src_ip_address:
+        description: Source IP address of the ERSPAN tunnel.
+        required: false
+        type: str
+      dscp:
+        description: DSCP value used for the tunnel encapsulation.
+        required: false
+        type: int
+      id:
+        description: ERSPAN session id carried in the tunnel header.
+        required: false
+        type: int
+  state:
+    description: Create, update or delete the mirror endpoint.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create an ERSPAN mirror endpoint
+  aoscx_mirror_endpoint:
+    name: erspan-to-collector
+    admin: up
+    comment: collector-1
+    output_port:
+      - 1/1/10
+    tunnel:
+      src_ip_address: 10.0.0.1
+      dest_ip_address: 10.0.0.2
+      id: 100
+
+- name: Update the tunnel destination of a mirror endpoint
+  aoscx_mirror_endpoint:
+    name: erspan-to-collector
+    state: update
+    tunnel:
+      dest_ip_address: 10.0.0.3
+
+- name: Delete a mirror endpoint
+  aoscx_mirror_endpoint:
+    name: erspan-to-collector
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        name=dict(type="str", required=True),
+        admin=dict(type="str", required=False, choices=["up", "down"]),
+        comment=dict(type="str", required=False, default=None),
+        output_port=dict(
+            type="list", elements="str", required=False, default=None
+        ),
+        tunnel=dict(
+            type="dict",
+            required=False,
+            default=None,
+            options=dict(
+                dest_ip_address=dict(type="str", required=False),
+                src_ip_address=dict(type="str", required=False),
+                dscp=dict(type="int", required=False),
+                id=dict(type="int", required=False),
+            ),
+        ),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    name = ansible_module.params["name"]
+    admin = ansible_module.params["admin"]
+    comment = ansible_module.params["comment"]
+    output_port = ansible_module.params["output_port"]
+    tunnel = ansible_module.params["tunnel"]
+    state = ansible_module.params["state"]
+
+    result = dict(changed=False)
+
+    # AnsibleModule keeps suboptions the user did not set as None; drop them
+    # so they are not sent to the switch and do not cause false changes.
+    if tunnel is not None:
+        tunnel = {k: v for k, v in tunnel.items() if v is not None}
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        endpoint = session.api.get_module(session, "MirrorEndpoint", name)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support mirror endpoints. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        endpoint.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                endpoint.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete mirror endpoint: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    def materialize_ports(names):
+        return [session.api.get_module(session, "Interface", n) for n in names]
+
+    # ------------------------------------------------------- create / update
+    if not exists:
+        kwargs = {}
+        if admin is not None:
+            kwargs["admin"] = admin
+        if comment is not None:
+            kwargs["comment"] = comment
+        if output_port is not None:
+            kwargs["output_port"] = materialize_ports(output_port)
+        if tunnel is not None:
+            kwargs["tunnel"] = tunnel
+        endpoint = session.api.get_module(
+            session, "MirrorEndpoint", name, **kwargs
+        )
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                endpoint.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create mirror endpoint: {0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+
+    if admin is not None and getattr(endpoint, "admin", None) != admin:
+        changed = True
+        endpoint.admin = admin
+
+    if comment is not None and getattr(endpoint, "comment", None) != comment:
+        changed = True
+        endpoint.comment = comment
+
+    # Port references are unordered; compare them by name regardless of order.
+    if output_port is not None:
+        current = sorted(
+            p.name for p in (getattr(endpoint, "output_port", None) or [])
+        )
+        if current != sorted(output_port):
+            changed = True
+            endpoint.output_port = materialize_ports(output_port)
+
+    # tunnel is a dictionary; only reconcile the keys provided and preserve
+    # any existing keys the user did not mention.
+    if tunnel is not None:
+        current = dict(getattr(endpoint, "tunnel", None) or {})
+        merged = dict(current)
+        merged.update(tunnel)
+        if merged != current:
+            changed = True
+            endpoint.tunnel = merged
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            endpoint.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update mirror endpoint: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/aoscx_mirror/aliases
+++ b/tests/integration/targets/aoscx_mirror/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_mirror/tasks/main.yml
+++ b/tests/integration/targets/aoscx_mirror/tasks/main.yml
@@ -1,0 +1,86 @@
+# Integration tests for the aoscx_mirror module.
+#
+# Run with:
+#   ansible-test integration aoscx_mirror --venv
+#
+# Requires an inventory entry named "aoscx" reachable with a pyaoscx release
+# that ships the Mirror class. Uses a temporary mirror session (3999) that is
+# kept inactive, and cleans up afterwards. Adjust the port names to match the
+# device under test.
+
+- name: Make sure the test mirror session does not exist yet
+  arubanetworks.aoscx.aoscx_mirror:
+    mirror_id: 3999
+    state: delete
+  ignore_errors: true
+
+- name: Create an inactive port mirror session
+  arubanetworks.aoscx.aoscx_mirror:
+    mirror_id: 3999
+    session_type: port
+    active: false
+    comment: mirror-integration-test
+    select_src_port:
+      - 1/1/27
+    output_port:
+      - 1/1/28
+    state: create
+  register: create_result
+
+- name: Assert create changed
+  ansible.builtin.assert:
+    that:
+      - create_result is changed
+
+- name: Re-apply identical configuration
+  arubanetworks.aoscx.aoscx_mirror:
+    mirror_id: 3999
+    state: update
+    session_type: port
+    active: false
+    comment: mirror-integration-test
+    select_src_port:
+      - 1/1/27
+    output_port:
+      - 1/1/28
+  register: idem_result
+
+- name: Assert re-apply did not change
+  ansible.builtin.assert:
+    that:
+      - idem_result is not changed
+
+- name: Change the source port
+  arubanetworks.aoscx.aoscx_mirror:
+    mirror_id: 3999
+    state: update
+    select_src_port:
+      - 1/1/26
+  register: update_result
+
+- name: Assert update changed
+  ansible.builtin.assert:
+    that:
+      - update_result is changed
+
+- name: Delete the mirror session
+  arubanetworks.aoscx.aoscx_mirror:
+    mirror_id: 3999
+    state: delete
+  register: delete_result
+
+- name: Assert delete changed
+  ansible.builtin.assert:
+    that:
+      - delete_result is changed
+
+- name: Delete again (idempotent)
+  arubanetworks.aoscx.aoscx_mirror:
+    mirror_id: 3999
+    state: delete
+  register: delete_idem
+
+- name: Assert second delete did not change
+  ansible.builtin.assert:
+    that:
+      - delete_idem is not changed

--- a/tests/integration/targets/aoscx_mirror_endpoint/aliases
+++ b/tests/integration/targets/aoscx_mirror_endpoint/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_mirror_endpoint/tasks/main.yml
+++ b/tests/integration/targets/aoscx_mirror_endpoint/tasks/main.yml
@@ -1,0 +1,88 @@
+# Integration tests for the aoscx_mirror_endpoint module.
+#
+# Run with:
+#   ansible-test integration aoscx_mirror_endpoint --venv
+#
+# Requires an inventory entry named "aoscx" reachable with a pyaoscx release
+# that ships the MirrorEndpoint class. Uses a temporary endpoint, kept
+# administratively down, and cleans up afterwards. Adjust the port name to
+# match the device under test.
+
+- name: Make sure the test mirror endpoint does not exist yet
+  arubanetworks.aoscx.aoscx_mirror_endpoint:
+    name: mirror-integration-ep
+    state: delete
+  ignore_errors: true
+
+- name: Create an ERSPAN mirror endpoint (admin down)
+  arubanetworks.aoscx.aoscx_mirror_endpoint:
+    name: mirror-integration-ep
+    admin: down
+    comment: endpoint-integration-test
+    output_port:
+      - 1/1/27
+    tunnel:
+      src_ip_address: 10.0.0.1
+      dest_ip_address: 10.0.0.2
+      id: 100
+    state: create
+  register: create_result
+
+- name: Assert create changed
+  ansible.builtin.assert:
+    that:
+      - create_result is changed
+
+- name: Re-apply identical configuration
+  arubanetworks.aoscx.aoscx_mirror_endpoint:
+    name: mirror-integration-ep
+    state: update
+    admin: down
+    comment: endpoint-integration-test
+    output_port:
+      - 1/1/27
+    tunnel:
+      src_ip_address: 10.0.0.1
+      dest_ip_address: 10.0.0.2
+      id: 100
+  register: idem_result
+
+- name: Assert re-apply did not change
+  ansible.builtin.assert:
+    that:
+      - idem_result is not changed
+
+- name: Update the tunnel destination
+  arubanetworks.aoscx.aoscx_mirror_endpoint:
+    name: mirror-integration-ep
+    state: update
+    tunnel:
+      dest_ip_address: 10.0.0.3
+  register: update_result
+
+- name: Assert update changed
+  ansible.builtin.assert:
+    that:
+      - update_result is changed
+
+- name: Delete the mirror endpoint
+  arubanetworks.aoscx.aoscx_mirror_endpoint:
+    name: mirror-integration-ep
+    state: delete
+  register: delete_result
+
+- name: Assert delete changed
+  ansible.builtin.assert:
+    that:
+      - delete_result is changed
+
+- name: Delete again (idempotent)
+  arubanetworks.aoscx.aoscx_mirror_endpoint:
+    name: mirror-integration-ep
+    state: delete
+  register: delete_idem
+
+- name: Assert second delete did not change
+  ansible.builtin.assert:
+    that:
+      - delete_idem is not changed

--- a/tests/unit/modules/test_aoscx_mirror.py
+++ b/tests/unit/modules/test_aoscx_mirror.py
@@ -1,0 +1,279 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_mirror module.
+
+The pyaoscx session is fully mocked, so no switch is required.
+
+Run with:
+    PYTHONPATH=/tmp/acoll2x .venv/bin/python -m pytest \
+        tests/unit/modules/test_aoscx_mirror.py -v
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_mirror,
+)
+
+MODULE = "ansible_collections.arubanetworks.aoscx.plugins.modules.aoscx_mirror"
+
+
+class AnsibleExitJson(Exception):
+    """Raised by the mocked exit_json to stop module execution."""
+
+
+class AnsibleFailJson(Exception):
+    """Raised by the mocked fail_json to stop module execution."""
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_port(name):
+    port = MagicMock()
+    port.name = name
+    return port
+
+
+def build_vlan(vlan_id):
+    vlan = MagicMock()
+    vlan.id = vlan_id
+    return vlan
+
+
+def build_mirror(
+    exists,
+    session_type="port",
+    active=False,
+    comment=None,
+    select_src_port=None,
+    output_port=None,
+    select_rx_vlan=None,
+):
+    mirror = MagicMock()
+    mirror.session_type = session_type
+    mirror.active = active
+    mirror.comment = comment
+    mirror.output_port = [build_port(p) for p in (output_port or [])]
+    mirror.select_src_port = [build_port(p) for p in (select_src_port or [])]
+    mirror.select_dst_port = []
+    mirror.select_rx_vlan = [build_vlan(v) for v in (select_rx_vlan or [])]
+    mirror.select_tx_vlan = []
+    if exists:
+        mirror.get.return_value = True
+    else:
+        mirror.get.side_effect = Exception("not found")
+    return mirror
+
+
+def build_session(existing, new_mirror=None):
+    session = MagicMock()
+    create_kwargs = (
+        "session_type",
+        "active",
+        "comment",
+        "output_port",
+        "select_src_port",
+        "select_dst_port",
+        "select_rx_vlan",
+        "select_tx_vlan",
+    )
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "Mirror":
+            if (
+                any(k in kwargs for k in create_kwargs)
+                and new_mirror is not None
+            ):
+                return new_mirror
+            return existing
+        if module == "Interface":
+            return build_port(index)
+        if module == "Vlan":
+            return build_vlan(index)
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_mirror.main()
+    return exc.value.args[0]
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+def test_invalid_id_rejected():
+    session = build_session(build_mirror(False))
+    result = run_module({"mirror_id": 0}, session)
+    assert result["failed"] is True
+    assert "positive integer" in result["msg"]
+
+
+# --------------------------------------------------------------------------
+# Create
+# --------------------------------------------------------------------------
+def test_create():
+    existing = build_mirror(False)
+    new = build_mirror(False)
+    session = build_session(existing, new_mirror=new)
+    result = run_module(
+        {
+            "mirror_id": 5,
+            "session_type": "port",
+            "active": True,
+            "select_src_port": ["1/1/1"],
+            "output_port": ["1/1/10"],
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_check_mode():
+    existing = build_mirror(False)
+    new = build_mirror(False)
+    session = build_session(existing, new_mirror=new)
+    result = run_module(
+        {"mirror_id": 5, "session_type": "port", "_ansible_check_mode": True},
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Update
+# --------------------------------------------------------------------------
+def test_update_active():
+    existing = build_mirror(True, active=False)
+    session = build_session(existing)
+    result = run_module(
+        {"mirror_id": 5, "state": "update", "active": True}, session
+    )
+    assert result["changed"] is True
+    assert existing.active is True
+    existing.update.assert_called_once()
+
+
+def test_update_idempotent():
+    existing = build_mirror(True, active=True, select_src_port=["1/1/1"])
+    session = build_session(existing)
+    result = run_module(
+        {
+            "mirror_id": 5,
+            "state": "update",
+            "active": True,
+            "select_src_port": ["1/1/1"],
+        },
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_update_src_port_set():
+    existing = build_mirror(True, select_src_port=["1/1/1"])
+    session = build_session(existing)
+    result = run_module(
+        {
+            "mirror_id": 5,
+            "state": "update",
+            "select_src_port": ["1/1/2"],
+        },
+        session,
+    )
+    assert result["changed"] is True
+    assert [p.name for p in existing.select_src_port] == ["1/1/2"]
+    existing.update.assert_called_once()
+
+
+def test_update_rx_vlan_set():
+    existing = build_mirror(True, select_rx_vlan=[10])
+    session = build_session(existing)
+    result = run_module(
+        {
+            "mirror_id": 5,
+            "state": "update",
+            "select_rx_vlan": [10, 20],
+        },
+        session,
+    )
+    assert result["changed"] is True
+    assert sorted(v.id for v in existing.select_rx_vlan) == [10, 20]
+
+
+def test_update_vlan_idempotent_order_insensitive():
+    existing = build_mirror(True, select_rx_vlan=[20, 10])
+    session = build_session(existing)
+    result = run_module(
+        {
+            "mirror_id": 5,
+            "state": "update",
+            "select_rx_vlan": [10, 20],
+        },
+        session,
+    )
+    assert result["changed"] is False
+
+
+# --------------------------------------------------------------------------
+# Delete
+# --------------------------------------------------------------------------
+def test_delete_existing():
+    existing = build_mirror(True)
+    session = build_session(existing)
+    result = run_module({"mirror_id": 5, "state": "delete"}, session)
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+
+
+def test_delete_absent():
+    existing = build_mirror(False)
+    session = build_session(existing)
+    result = run_module({"mirror_id": 5, "state": "delete"}, session)
+    assert result["changed"] is False
+    existing.delete.assert_not_called()

--- a/tests/unit/modules/test_aoscx_mirror_endpoint.py
+++ b/tests/unit/modules/test_aoscx_mirror_endpoint.py
@@ -1,0 +1,258 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_mirror_endpoint module.
+
+The pyaoscx session is fully mocked, so no switch is required.
+
+Run with:
+    PYTHONPATH=/tmp/acoll2x .venv/bin/python -m pytest \
+        tests/unit/modules/test_aoscx_mirror_endpoint.py -v
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_mirror_endpoint,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules"
+    ".aoscx_mirror_endpoint"
+)
+
+
+class AnsibleExitJson(Exception):
+    """Raised by the mocked exit_json to stop module execution."""
+
+
+class AnsibleFailJson(Exception):
+    """Raised by the mocked fail_json to stop module execution."""
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_port(name):
+    port = MagicMock()
+    port.name = name
+    return port
+
+
+def build_endpoint(
+    exists,
+    admin="down",
+    comment=None,
+    output_port=None,
+    tunnel=None,
+):
+    endpoint = MagicMock()
+    endpoint.admin = admin
+    endpoint.comment = comment
+    endpoint.output_port = [build_port(p) for p in (output_port or [])]
+    endpoint.tunnel = dict(tunnel) if tunnel else {}
+    if exists:
+        endpoint.get.return_value = True
+    else:
+        endpoint.get.side_effect = Exception("not found")
+    return endpoint
+
+
+def build_session(existing, new_endpoint=None):
+    session = MagicMock()
+    create_kwargs = ("admin", "comment", "output_port", "tunnel")
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "MirrorEndpoint":
+            if (
+                any(k in kwargs for k in create_kwargs)
+                and new_endpoint is not None
+            ):
+                return new_endpoint
+            return existing
+        if module == "Interface":
+            return build_port(index)
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_mirror_endpoint.main()
+    return exc.value.args[0]
+
+
+# --------------------------------------------------------------------------
+# Create
+# --------------------------------------------------------------------------
+def test_create():
+    existing = build_endpoint(False)
+    new = build_endpoint(False)
+    session = build_session(existing, new_endpoint=new)
+    result = run_module(
+        {
+            "name": "erspan1",
+            "admin": "up",
+            "output_port": ["1/1/10"],
+            "tunnel": {
+                "src_ip_address": "10.0.0.1",
+                "dest_ip_address": "10.0.0.2",
+                "id": 100,
+            },
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_check_mode():
+    existing = build_endpoint(False)
+    new = build_endpoint(False)
+    session = build_session(existing, new_endpoint=new)
+    result = run_module(
+        {"name": "erspan1", "admin": "up", "_ansible_check_mode": True},
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Update
+# --------------------------------------------------------------------------
+def test_update_admin():
+    existing = build_endpoint(True, admin="down")
+    session = build_session(existing)
+    result = run_module(
+        {"name": "erspan1", "state": "update", "admin": "up"}, session
+    )
+    assert result["changed"] is True
+    assert existing.admin == "up"
+    existing.update.assert_called_once()
+
+
+def test_update_idempotent():
+    existing = build_endpoint(True, admin="up", output_port=["1/1/10"])
+    session = build_session(existing)
+    result = run_module(
+        {
+            "name": "erspan1",
+            "state": "update",
+            "admin": "up",
+            "output_port": ["1/1/10"],
+        },
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_update_output_port_set():
+    existing = build_endpoint(True, output_port=["1/1/10"])
+    session = build_session(existing)
+    result = run_module(
+        {
+            "name": "erspan1",
+            "state": "update",
+            "output_port": ["1/1/11"],
+        },
+        session,
+    )
+    assert result["changed"] is True
+    assert [p.name for p in existing.output_port] == ["1/1/11"]
+
+
+def test_update_tunnel_merge():
+    existing = build_endpoint(
+        True, tunnel={"src_ip_address": "10.0.0.1", "id": 100}
+    )
+    session = build_session(existing)
+    result = run_module(
+        {
+            "name": "erspan1",
+            "state": "update",
+            "tunnel": {"dest_ip_address": "10.0.0.9"},
+        },
+        session,
+    )
+    assert result["changed"] is True
+    assert existing.tunnel["dest_ip_address"] == "10.0.0.9"
+    # existing keys are preserved
+    assert existing.tunnel["src_ip_address"] == "10.0.0.1"
+    assert existing.tunnel["id"] == 100
+
+
+def test_update_tunnel_idempotent():
+    existing = build_endpoint(
+        True, tunnel={"src_ip_address": "10.0.0.1", "id": 100}
+    )
+    session = build_session(existing)
+    result = run_module(
+        {
+            "name": "erspan1",
+            "state": "update",
+            "tunnel": {"id": 100},
+        },
+        session,
+    )
+    assert result["changed"] is False
+
+
+# --------------------------------------------------------------------------
+# Delete
+# --------------------------------------------------------------------------
+def test_delete_existing():
+    existing = build_endpoint(True)
+    session = build_session(existing)
+    result = run_module({"name": "erspan1", "state": "delete"}, session)
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+
+
+def test_delete_absent():
+    existing = build_endpoint(False)
+    session = build_session(existing)
+    result = run_module({"name": "erspan1", "state": "delete"}, session)
+    assert result["changed"] is False
+    existing.delete.assert_not_called()


### PR DESCRIPTION
Fixes #193

Collection modules backed by dedicated pyaoscx SDK classes. Depends on SDK PR aruba/pyaoscx#61.

## Depends on
- aruba/pyaoscx#61 — Mirror / MirrorEndpoint
