### PR TITLE
Add aoscx_evpn and aoscx_evpn_vlan modules

### DIFF
--- a/changelogs/fragments/aoscx_evpn.yml
+++ b/changelogs/fragments/aoscx_evpn.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Add ``aoscx_evpn`` module to manage the global EVPN configuration.
+  - Add ``aoscx_evpn_vlan`` module to manage per-VLAN EVPN settings.

--- a/docs/aoscx_evpn.md
+++ b/docs/aoscx_evpn.md
@@ -1,0 +1,74 @@
+# module: aoscx_evpn
+
+description: This module provides configuration management of the global EVPN
+(Ethernet VPN) settings on AOS-CX devices. EVPN is a singleton resource, so
+this module only updates the existing configuration; it never creates or
+deletes the resource. Only the parameters you supply are reconciled; any
+parameter left unset is preserved.
+
+##### ARGUMENTS
+
+```YAML
+  arp_suppression_enable:
+    description: >
+      Whether ARP suppression is globally enabled. When omitted it is left
+      unchanged.
+    required: false
+    type: bool
+  nd_suppression_enable:
+    description: >
+      Whether Neighbor Discovery (ND) suppression is globally enabled. When
+      omitted it is left unchanged.
+    required: false
+    type: bool
+  mac_move_count:
+    description: >
+      Maximum number of MAC moves allowed within the MAC move interval before
+      the MAC address is frozen. When omitted it is left unchanged.
+    required: false
+    type: int
+  mac_move_timer:
+    description: >
+      Length of the MAC move detection interval, in seconds. When omitted it
+      is left unchanged.
+    required: false
+    type: int
+  redistribute:
+    description: >
+      Dictionary controlling which local address types are redistributed into
+      EVPN, for example {"local-mac": true, "local-svi": false}. Only the keys
+      you provide are reconciled; other keys are preserved. When omitted it is
+      left unchanged.
+    required: false
+    type: dict
+  state:
+    description: >
+      Use create or update to apply the configuration. Both behave the same
+      because EVPN is a singleton that always exists.
+    required: false
+    default: update
+    choices:
+      - create
+      - update
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Enable ARP and ND suppression globally
+  aoscx_evpn:
+    arp_suppression_enable: true
+    nd_suppression_enable: true
+
+- name: Tune the MAC move detection
+  aoscx_evpn:
+    mac_move_count: 5
+    mac_move_timer: 180
+
+- name: Configure EVPN redistribution
+  aoscx_evpn:
+    redistribute:
+      local-mac: true
+      local-svi: true
+```

--- a/docs/aoscx_evpn_vlan.md
+++ b/docs/aoscx_evpn_vlan.md
@@ -1,0 +1,87 @@
+# module: aoscx_evpn_vlan
+
+description: This module provides configuration management of per-VLAN EVPN
+(Ethernet VPN) settings on AOS-CX devices. Each entry binds a VLAN to its
+EVPN instance and configures its route distinguisher, import and export route
+targets, and redistribution. The VLAN must already exist on the device.
+
+##### ARGUMENTS
+
+```YAML
+  vlan:
+    description: >
+      ID of the VLAN the EVPN instance is bound to. The VLAN must already
+      exist on the device.
+    required: true
+    type: int
+  rd:
+    description: >
+      Route distinguisher for the VLAN's EVPN instance, for example 65000:204
+      or auto. When omitted it is left unchanged. Ignored when state is
+      delete.
+    required: false
+    type: str
+  import_route_targets:
+    description: >
+      List of import route targets for the VLAN's EVPN instance. The list is
+      compared regardless of order. When omitted it is left unchanged. Ignored
+      when state is delete.
+    required: false
+    type: list
+    elements: str
+  export_route_targets:
+    description: >
+      List of export route targets for the VLAN's EVPN instance. The list is
+      compared regardless of order. When omitted it is left unchanged. Ignored
+      when state is delete.
+    required: false
+    type: list
+    elements: str
+  redistribute:
+    description: >
+      Dictionary controlling redistribution for the VLAN's EVPN instance, for
+      example {"host-route": true}. Only the keys you provide are reconciled;
+      other keys are preserved. When omitted it is left unchanged. Ignored
+      when state is delete.
+    required: false
+    type: dict
+  state:
+    description: Create, update or delete the per-VLAN EVPN entry.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create an EVPN instance for VLAN 204
+  aoscx_evpn_vlan:
+    vlan: 204
+    rd: "65000:204"
+    import_route_targets:
+      - "65000:204"
+    export_route_targets:
+      - "65000:204"
+
+- name: Update the route distinguisher of an EVPN VLAN
+  aoscx_evpn_vlan:
+    vlan: 204
+    state: update
+    rd: "65001:204"
+
+- name: Configure redistribution for an EVPN VLAN
+  aoscx_evpn_vlan:
+    vlan: 204
+    redistribute:
+      host-route: true
+
+- name: Delete an EVPN VLAN entry
+  aoscx_evpn_vlan:
+    vlan: 204
+    state: delete
+```

--- a/plugins/modules/aoscx_evpn.py
+++ b/plugins/modules/aoscx_evpn.py
@@ -1,0 +1,195 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_evpn
+version_added: "4.6.0"
+short_description: Manage the global EVPN configuration on AOS-CX
+description: >
+  This module provides configuration management of the global EVPN
+  (Ethernet VPN) settings on AOS-CX devices. EVPN is a singleton resource,
+  so this module only updates the existing configuration; it never creates
+  or deletes the resource. Only the parameters you supply are reconciled;
+  any parameter left unset is preserved.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  arp_suppression_enable:
+    description: >
+      Whether ARP suppression is globally enabled. When omitted it is left
+      unchanged.
+    required: false
+    type: bool
+  nd_suppression_enable:
+    description: >
+      Whether Neighbor Discovery (ND) suppression is globally enabled. When
+      omitted it is left unchanged.
+    required: false
+    type: bool
+  mac_move_count:
+    description: >
+      Maximum number of MAC moves allowed within the MAC move interval
+      before the MAC address is frozen. When omitted it is left unchanged.
+    required: false
+    type: int
+  mac_move_timer:
+    description: >
+      Length of the MAC move detection interval, in seconds. When omitted it
+      is left unchanged.
+    required: false
+    type: int
+  redistribute:
+    description: >
+      Dictionary controlling which local address types are redistributed
+      into EVPN, for example C({"local-mac": true, "local-svi": false}).
+      Only the keys you provide are reconciled; other keys are preserved.
+      When omitted it is left unchanged.
+    required: false
+    type: dict
+  state:
+    description: >
+      Use C(create) or C(update) to apply the configuration. Both behave
+      the same because EVPN is a singleton that always exists.
+    required: false
+    default: update
+    choices:
+      - create
+      - update
+    type: str
+"""
+
+EXAMPLES = """
+- name: Enable ARP and ND suppression globally
+  aoscx_evpn:
+    arp_suppression_enable: true
+    nd_suppression_enable: true
+
+- name: Tune the MAC move detection
+  aoscx_evpn:
+    mac_move_count: 5
+    mac_move_timer: 180
+
+- name: Configure EVPN redistribution
+  aoscx_evpn:
+    redistribute:
+      local-mac: true
+      local-svi: true
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the global EVPN configuration was modified.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        arp_suppression_enable=dict(type="bool", default=None),
+        nd_suppression_enable=dict(type="bool", default=None),
+        mac_move_count=dict(type="int", default=None),
+        mac_move_timer=dict(type="int", default=None),
+        redistribute=dict(type="dict", default=None),
+        state=dict(
+            type="str",
+            default="update",
+            choices=["create", "update"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    arp_suppression_enable = ansible_module.params["arp_suppression_enable"]
+    nd_suppression_enable = ansible_module.params["nd_suppression_enable"]
+    mac_move_count = ansible_module.params["mac_move_count"]
+    mac_move_timer = ansible_module.params["mac_move_timer"]
+    redistribute = ansible_module.params["redistribute"]
+
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        evpn = session.api.get_module(session, "Evpn")
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support EVPN. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        evpn.get(selector="writable")
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not retrieve EVPN configuration: {0}".format(str(e))
+        )
+
+    changed = False
+
+    # Simple scalar attributes: reconcile each supplied value.
+    scalars = {
+        "arp_suppression_enable": arp_suppression_enable,
+        "nd_suppression_enable": nd_suppression_enable,
+        "mac_move_count": mac_move_count,
+        "mac_move_timer": mac_move_timer,
+    }
+    for attr, value in scalars.items():
+        if value is None:
+            continue
+        if getattr(evpn, attr, None) != value:
+            changed = True
+            setattr(evpn, attr, value)
+
+    # redistribute is a dictionary; only reconcile the keys provided and
+    # preserve any existing keys the user did not mention.
+    if redistribute is not None:
+        current = dict(getattr(evpn, "redistribute", None) or {})
+        merged = dict(current)
+        merged.update(redistribute)
+        if merged != current:
+            changed = True
+            evpn.redistribute = merged
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            evpn.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update EVPN configuration: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_evpn_vlan.py
+++ b/plugins/modules/aoscx_evpn_vlan.py
@@ -1,0 +1,265 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_evpn_vlan
+version_added: "4.6.0"
+short_description: Create, Update or Delete a per-VLAN EVPN entry on AOS-CX
+description: >
+  This module provides configuration management of per-VLAN EVPN (Ethernet
+  VPN) settings on AOS-CX devices. Each entry binds a VLAN to its EVPN
+  instance and configures its route distinguisher, import and export route
+  targets, and redistribution. The VLAN must already exist on the device.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  vlan:
+    description: >
+      ID of the VLAN the EVPN instance is bound to. The VLAN must already
+      exist on the device.
+    required: true
+    type: int
+  rd:
+    description: >
+      Route distinguisher for the VLAN's EVPN instance, for example
+      C(65000:204) or C(auto). When omitted it is left unchanged. Ignored
+      when I(state) is C(delete).
+    required: false
+    type: str
+  import_route_targets:
+    description: >
+      List of import route targets for the VLAN's EVPN instance. The list is
+      compared regardless of order. When omitted it is left unchanged.
+      Ignored when I(state) is C(delete).
+    required: false
+    type: list
+    elements: str
+  export_route_targets:
+    description: >
+      List of export route targets for the VLAN's EVPN instance. The list is
+      compared regardless of order. When omitted it is left unchanged.
+      Ignored when I(state) is C(delete).
+    required: false
+    type: list
+    elements: str
+  redistribute:
+    description: >
+      Dictionary controlling redistribution for the VLAN's EVPN instance,
+      for example C({"host-route": true}). Only the keys you provide are
+      reconciled; other keys are preserved. When omitted it is left
+      unchanged. Ignored when I(state) is C(delete).
+    required: false
+    type: dict
+  state:
+    description: Create, update or delete the per-VLAN EVPN entry.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create an EVPN instance for VLAN 204
+  aoscx_evpn_vlan:
+    vlan: 204
+    rd: "65000:204"
+    import_route_targets:
+      - "65000:204"
+    export_route_targets:
+      - "65000:204"
+
+- name: Update the route distinguisher of an EVPN VLAN
+  aoscx_evpn_vlan:
+    vlan: 204
+    state: update
+    rd: "65001:204"
+
+- name: Configure redistribution for an EVPN VLAN
+  aoscx_evpn_vlan:
+    vlan: 204
+    redistribute:
+      host-route: true
+
+- name: Delete an EVPN VLAN entry
+  aoscx_evpn_vlan:
+    vlan: 204
+    state: delete
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the per-VLAN EVPN entry was modified.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+# VLAN IDs are 12-bit values, 1 to 4094 are usable.
+MIN_VLAN_ID = 1
+MAX_VLAN_ID = 4094
+
+
+def main():
+    module_args = dict(
+        vlan=dict(type="int", required=True),
+        rd=dict(type="str", default=None),
+        import_route_targets=dict(type="list", elements="str", default=None),
+        export_route_targets=dict(type="list", elements="str", default=None),
+        redistribute=dict(type="dict", default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    vlan = ansible_module.params["vlan"]
+    rd = ansible_module.params["rd"]
+    import_route_targets = ansible_module.params["import_route_targets"]
+    export_route_targets = ansible_module.params["export_route_targets"]
+    redistribute = ansible_module.params["redistribute"]
+    state = ansible_module.params["state"]
+
+    result = dict(changed=False)
+
+    if not MIN_VLAN_ID <= vlan <= MAX_VLAN_ID:
+        ansible_module.fail_json(
+            msg="vlan must be between {0} and {1}.".format(
+                MIN_VLAN_ID, MAX_VLAN_ID
+            )
+        )
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        evpn_vlan = session.api.get_module(session, "EvpnVlan", vlan)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support EVPN. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        evpn_vlan.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                evpn_vlan.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete EVPN VLAN: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # The per-VLAN EVPN entry references the VLAN resource, so it must exist.
+    try:
+        vlan_obj = session.api.get_module(session, "Vlan", vlan)
+        vlan_obj.get()
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not find VLAN {0}: {1}".format(vlan, str(e))
+        )
+
+    # ------------------------------------------------------- create / update
+    if not exists:
+        kwargs = {}
+        if rd is not None:
+            kwargs["rd"] = rd
+        if import_route_targets is not None:
+            kwargs["import_route_targets"] = import_route_targets
+        if export_route_targets is not None:
+            kwargs["export_route_targets"] = export_route_targets
+        if redistribute is not None:
+            kwargs["redistribute"] = redistribute
+        evpn_vlan = session.api.get_module(session, "EvpnVlan", vlan, **kwargs)
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                evpn_vlan.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create EVPN VLAN: {0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+
+    if rd is not None and getattr(evpn_vlan, "rd", None) != rd:
+        changed = True
+        evpn_vlan.rd = rd
+
+    # Route targets are unordered, compare them regardless of order.
+    if import_route_targets is not None:
+        current = getattr(evpn_vlan, "import_route_targets", None) or []
+        if sorted(current) != sorted(import_route_targets):
+            changed = True
+            evpn_vlan.import_route_targets = import_route_targets
+
+    if export_route_targets is not None:
+        current = getattr(evpn_vlan, "export_route_targets", None) or []
+        if sorted(current) != sorted(export_route_targets):
+            changed = True
+            evpn_vlan.export_route_targets = export_route_targets
+
+    # redistribute is a dictionary; only reconcile the keys provided and
+    # preserve any existing keys the user did not mention.
+    if redistribute is not None:
+        current = dict(getattr(evpn_vlan, "redistribute", None) or {})
+        merged = dict(current)
+        merged.update(redistribute)
+        if merged != current:
+            changed = True
+            evpn_vlan.redistribute = merged
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            evpn_vlan.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update EVPN VLAN: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/aoscx_evpn/aliases
+++ b/tests/integration/targets/aoscx_evpn/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_evpn/tasks/main.yml
+++ b/tests/integration/targets/aoscx_evpn/tasks/main.yml
@@ -1,0 +1,43 @@
+# Integration tests for the aoscx_evpn module.
+#
+# Run with:
+#   ansible-test integration aoscx_evpn --venv
+#
+# Requires an inventory entry named "aoscx" reachable over httpapi with a
+# pyaoscx release that ships the Evpn class. EVPN is a singleton, so this
+# test changes the mac_move_timer and restores it to its original value.
+
+- name: Read the current global mac_move_timer
+  arubanetworks.aoscx.aoscx_facts:
+  register: facts_result
+  ignore_errors: true
+
+- name: Change the global mac_move_timer
+  arubanetworks.aoscx.aoscx_evpn:
+    mac_move_timer: 181
+  register: change_result
+
+- name: Assert change reported
+  ansible.builtin.assert:
+    that:
+      - change_result is changed
+
+- name: Re-apply identical configuration
+  arubanetworks.aoscx.aoscx_evpn:
+    mac_move_timer: 181
+  register: idem_result
+
+- name: Assert re-apply did not change
+  ansible.builtin.assert:
+    that:
+      - idem_result is not changed
+
+- name: Restore the global mac_move_timer
+  arubanetworks.aoscx.aoscx_evpn:
+    mac_move_timer: 180
+  register: restore_result
+
+- name: Assert restore reported
+  ansible.builtin.assert:
+    that:
+      - restore_result is changed

--- a/tests/integration/targets/aoscx_evpn_vlan/aliases
+++ b/tests/integration/targets/aoscx_evpn_vlan/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_evpn_vlan/tasks/main.yml
+++ b/tests/integration/targets/aoscx_evpn_vlan/tasks/main.yml
@@ -1,0 +1,89 @@
+# Integration tests for the aoscx_evpn_vlan module.
+#
+# Run with:
+#   ansible-test integration aoscx_evpn_vlan --venv
+#
+# Requires an inventory entry named "aoscx" reachable over httpapi with a
+# pyaoscx release that ships the EvpnVlan class. Uses a temporary VLAN (3999)
+# and cleans up afterwards.
+
+- name: Make sure the test EVPN VLAN does not exist yet
+  arubanetworks.aoscx.aoscx_evpn_vlan:
+    vlan: 3999
+    state: delete
+  ignore_errors: true
+
+- name: Ensure the test VLAN exists
+  arubanetworks.aoscx.aoscx_vlan:
+    vlan_id: 3999
+    name: evpn-integration-test
+    state: create
+
+- name: Create an EVPN instance for the test VLAN
+  arubanetworks.aoscx.aoscx_evpn_vlan:
+    vlan: 3999
+    rd: "65000:3999"
+    import_route_targets:
+      - "65000:3999"
+    export_route_targets:
+      - "65000:3999"
+    state: create
+  register: create_result
+
+- name: Assert create changed
+  ansible.builtin.assert:
+    that:
+      - create_result is changed
+
+- name: Re-apply identical configuration
+  arubanetworks.aoscx.aoscx_evpn_vlan:
+    vlan: 3999
+    state: update
+    rd: "65000:3999"
+    import_route_targets:
+      - "65000:3999"
+  register: idem_result
+
+- name: Assert re-apply did not change
+  ansible.builtin.assert:
+    that:
+      - idem_result is not changed
+
+- name: Update the route distinguisher
+  arubanetworks.aoscx.aoscx_evpn_vlan:
+    vlan: 3999
+    state: update
+    rd: "65000:3998"
+  register: update_result
+
+- name: Assert update changed
+  ansible.builtin.assert:
+    that:
+      - update_result is changed
+
+- name: Delete the EVPN VLAN
+  arubanetworks.aoscx.aoscx_evpn_vlan:
+    vlan: 3999
+    state: delete
+  register: delete_result
+
+- name: Assert delete changed
+  ansible.builtin.assert:
+    that:
+      - delete_result is changed
+
+- name: Delete again (idempotent)
+  arubanetworks.aoscx.aoscx_evpn_vlan:
+    vlan: 3999
+    state: delete
+  register: delete_idem
+
+- name: Assert second delete did not change
+  ansible.builtin.assert:
+    that:
+      - delete_idem is not changed
+
+- name: Remove the test VLAN
+  arubanetworks.aoscx.aoscx_vlan:
+    vlan_id: 3999
+    state: delete

--- a/tests/unit/modules/test_aoscx_evpn.py
+++ b/tests/unit/modules/test_aoscx_evpn.py
@@ -1,0 +1,191 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_evpn module.
+
+The pyaoscx session is fully mocked, so no switch is required. The tests
+cover idempotency, scalar and dictionary reconciliation, check mode and
+error handling.
+
+Run with:
+    PYTHONPATH=/tmp/acoll2x .venv/bin/python -m pytest \
+        tests/unit/modules/test_aoscx_evpn.py -v
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_evpn,
+)
+
+MODULE = "ansible_collections.arubanetworks.aoscx.plugins.modules.aoscx_evpn"
+
+
+class AnsibleExitJson(Exception):
+    """Raised by the mocked exit_json to stop module execution."""
+
+
+class AnsibleFailJson(Exception):
+    """Raised by the mocked fail_json to stop module execution."""
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_evpn(
+    arp_suppression_enable=True,
+    nd_suppression_enable=False,
+    mac_move_count=5,
+    mac_move_timer=180,
+    redistribute=None,
+):
+    evpn = MagicMock()
+    evpn.arp_suppression_enable = arp_suppression_enable
+    evpn.nd_suppression_enable = nd_suppression_enable
+    evpn.mac_move_count = mac_move_count
+    evpn.mac_move_timer = mac_move_timer
+    evpn.redistribute = (
+        redistribute
+        if redistribute is not None
+        else {"local-mac": False, "local-svi": False}
+    )
+    evpn.get.return_value = True
+    return evpn
+
+
+def build_session(evpn):
+    session = MagicMock()
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "Evpn":
+            return evpn
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_evpn.main()
+    return exc.value.args[0]
+
+
+# --------------------------------------------------------------------------
+# Idempotency
+# --------------------------------------------------------------------------
+def test_no_params_no_change():
+    evpn = build_evpn()
+    session = build_session(evpn)
+    result = run_module({}, session)
+    assert result["changed"] is False
+    evpn.update.assert_not_called()
+
+
+def test_same_value_no_change():
+    evpn = build_evpn(mac_move_timer=180)
+    session = build_session(evpn)
+    result = run_module({"mac_move_timer": 180}, session)
+    assert result["changed"] is False
+    evpn.update.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Update
+# --------------------------------------------------------------------------
+def test_change_scalar():
+    evpn = build_evpn(mac_move_timer=180)
+    session = build_session(evpn)
+    result = run_module({"mac_move_timer": 181}, session)
+    assert result["changed"] is True
+    assert evpn.mac_move_timer == 181
+    evpn.update.assert_called_once()
+
+
+def test_change_bool():
+    evpn = build_evpn(nd_suppression_enable=False)
+    session = build_session(evpn)
+    result = run_module({"nd_suppression_enable": True}, session)
+    assert result["changed"] is True
+    assert evpn.nd_suppression_enable is True
+    evpn.update.assert_called_once()
+
+
+def test_redistribute_merge():
+    evpn = build_evpn(redistribute={"local-mac": False, "local-svi": False})
+    session = build_session(evpn)
+    result = run_module({"redistribute": {"local-mac": True}}, session)
+    assert result["changed"] is True
+    assert evpn.redistribute == {"local-mac": True, "local-svi": False}
+    evpn.update.assert_called_once()
+
+
+def test_redistribute_no_change():
+    evpn = build_evpn(redistribute={"local-mac": True, "local-svi": False})
+    session = build_session(evpn)
+    result = run_module({"redistribute": {"local-mac": True}}, session)
+    assert result["changed"] is False
+    evpn.update.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Check mode
+# --------------------------------------------------------------------------
+def test_check_mode_no_update():
+    evpn = build_evpn(mac_move_timer=180)
+    session = build_session(evpn)
+    result = run_module(
+        {"mac_move_timer": 181, "_ansible_check_mode": True}, session
+    )
+    assert result["changed"] is True
+    evpn.update.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Error handling
+# --------------------------------------------------------------------------
+def test_get_failure():
+    evpn = build_evpn()
+    evpn.get.side_effect = Exception("boom")
+    session = build_session(evpn)
+    result = run_module({"mac_move_timer": 181}, session)
+    assert result["failed"] is True
+    assert "Could not retrieve EVPN configuration" in result["msg"]

--- a/tests/unit/modules/test_aoscx_evpn_vlan.py
+++ b/tests/unit/modules/test_aoscx_evpn_vlan.py
@@ -1,0 +1,275 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_evpn_vlan module.
+
+The pyaoscx session is fully mocked, so no switch is required. The tests
+cover input validation, check mode, idempotency, create, update, delete and
+error handling.
+
+Run with:
+    PYTHONPATH=/tmp/acoll2x .venv/bin/python -m pytest \
+        tests/unit/modules/test_aoscx_evpn_vlan.py -v
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_evpn_vlan,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules"
+    ".aoscx_evpn_vlan"
+)
+
+
+class AnsibleExitJson(Exception):
+    """Raised by the mocked exit_json to stop module execution."""
+
+
+class AnsibleFailJson(Exception):
+    """Raised by the mocked fail_json to stop module execution."""
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_evpn_vlan(
+    exists,
+    rd="65000:204",
+    import_route_targets=None,
+    export_route_targets=None,
+    redistribute=None,
+):
+    ev = MagicMock()
+    ev.rd = rd
+    ev.import_route_targets = (
+        import_route_targets
+        if import_route_targets is not None
+        else ["65000:204"]
+    )
+    ev.export_route_targets = (
+        export_route_targets
+        if export_route_targets is not None
+        else ["65000:204"]
+    )
+    ev.redistribute = (
+        redistribute if redistribute is not None else {"host-route": True}
+    )
+    if exists:
+        ev.get.return_value = True
+    else:
+        ev.get.side_effect = Exception("not found")
+    return ev
+
+
+def build_session(existing, new_ev=None, vlan_exists=True):
+    session = MagicMock()
+    create_kwargs = (
+        "rd",
+        "import_route_targets",
+        "export_route_targets",
+        "redistribute",
+    )
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "EvpnVlan":
+            if any(k in kwargs for k in create_kwargs) and new_ev is not None:
+                return new_ev
+            return existing
+        if module == "Vlan":
+            vlan = MagicMock()
+            if vlan_exists:
+                vlan.get.return_value = True
+            else:
+                vlan.get.side_effect = Exception("no vlan")
+            return vlan
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_evpn_vlan.main()
+    return exc.value.args[0]
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+def test_invalid_vlan_rejected():
+    session = build_session(build_evpn_vlan(False))
+    result = run_module({"vlan": 0}, session)
+    assert result["failed"] is True
+    assert "vlan must be between" in result["msg"]
+
+
+def test_vlan_not_found_rejected():
+    session = build_session(build_evpn_vlan(False), vlan_exists=False)
+    result = run_module({"vlan": 204, "rd": "65000:204"}, session)
+    assert result["failed"] is True
+    assert "Could not find VLAN" in result["msg"]
+
+
+# --------------------------------------------------------------------------
+# Create
+# --------------------------------------------------------------------------
+def test_create():
+    existing = build_evpn_vlan(False)
+    new = build_evpn_vlan(False)
+    session = build_session(existing, new_ev=new)
+    result = run_module(
+        {
+            "vlan": 204,
+            "rd": "65000:204",
+            "import_route_targets": ["65000:204"],
+            "export_route_targets": ["65000:204"],
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_check_mode():
+    existing = build_evpn_vlan(False)
+    new = build_evpn_vlan(False)
+    session = build_session(existing, new_ev=new)
+    result = run_module(
+        {"vlan": 204, "rd": "65000:204", "_ansible_check_mode": True},
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Update
+# --------------------------------------------------------------------------
+def test_update_rd():
+    existing = build_evpn_vlan(True, rd="65000:204")
+    session = build_session(existing)
+    result = run_module(
+        {"vlan": 204, "state": "update", "rd": "65001:204"}, session
+    )
+    assert result["changed"] is True
+    assert existing.rd == "65001:204"
+    existing.update.assert_called_once()
+
+
+def test_update_route_targets_order_insensitive():
+    existing = build_evpn_vlan(
+        True, import_route_targets=["65000:204", "65000:205"]
+    )
+    session = build_session(existing)
+    result = run_module(
+        {
+            "vlan": 204,
+            "state": "update",
+            "import_route_targets": ["65000:205", "65000:204"],
+        },
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_update_route_targets_change():
+    existing = build_evpn_vlan(True, export_route_targets=["65000:204"])
+    session = build_session(existing)
+    result = run_module(
+        {
+            "vlan": 204,
+            "state": "update",
+            "export_route_targets": ["65000:204", "65000:999"],
+        },
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_update_redistribute_merge():
+    existing = build_evpn_vlan(True, redistribute={"host-route": False})
+    session = build_session(existing)
+    result = run_module(
+        {
+            "vlan": 204,
+            "state": "update",
+            "redistribute": {"host-route": True},
+        },
+        session,
+    )
+    assert result["changed"] is True
+    assert existing.redistribute == {"host-route": True}
+    existing.update.assert_called_once()
+
+
+def test_update_no_change():
+    existing = build_evpn_vlan(True, rd="65000:204")
+    session = build_session(existing)
+    result = run_module(
+        {"vlan": 204, "state": "update", "rd": "65000:204"}, session
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Delete
+# --------------------------------------------------------------------------
+def test_delete_existing():
+    existing = build_evpn_vlan(True)
+    session = build_session(existing)
+    result = run_module({"vlan": 204, "state": "delete"}, session)
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+
+
+def test_delete_absent():
+    existing = build_evpn_vlan(False)
+    session = build_session(existing)
+    result = run_module({"vlan": 204, "state": "delete"}, session)
+    assert result["changed"] is False
+    existing.delete.assert_not_called()


### PR DESCRIPTION
Fixes #196

Collection modules backed by dedicated pyaoscx SDK classes. Depends on SDK PR aruba/pyaoscx#59.

## Depends on
- aruba/pyaoscx#59 — Evpn / EvpnVlan
