### PR TITLE
aoscx_ipsla: add advanced source and responder parameters

### DIFF
--- a/changelogs/fragments/aoscx_ipsla.yml
+++ b/changelogs/fragments/aoscx_ipsla.yml
@@ -1,0 +1,10 @@
+---
+minor_changes:
+  - aoscx_ipsla_source - new module to create, update or delete IP SLA sources
+    (system/ipsla_sources).
+  - aoscx_ipsla_responder - new module to create or delete IP SLA responders
+    (system/ipsla_responders).
+  - aoscx_ipsla_track_object - new module to create, update or delete IP SLA
+    track objects (system/ipsla_track_objects).
+  - aoscx connection plugin - allow REST API version 10.16, which is required
+    by the IP SLA track object module.

--- a/changelogs/fragments/aoscx_ipsla.yml
+++ b/changelogs/fragments/aoscx_ipsla.yml
@@ -8,3 +8,7 @@ minor_changes:
     track objects (system/ipsla_track_objects).
   - aoscx connection plugin - allow REST API version 10.16, which is required
     by the IP SLA track object module.
+  - aoscx_ipsla_source - support the advanced parameters source_interface,
+    http_sla, https_sla and voip_jitter_sla.
+  - aoscx_ipsla_responder - support the responder_interface parameter, which
+    binds the responder to an interface (recreated when changed).

--- a/changelogs/fragments/ipsla_responder.yml
+++ b/changelogs/fragments/ipsla_responder.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - aoscx_ipsla_source - add the C(responder) option to configure the IP SLA
+    responder address (hostname and port), required for all probe types except
+    http and https.

--- a/docs/aoscx_ipsla_responder.md
+++ b/docs/aoscx_ipsla_responder.md
@@ -43,6 +43,12 @@ attributes, so any change is applied by recreating the responder.
     description: IP address the responder is bound to.
     required: false
     type: str
+  responder_interface:
+    description: >
+      Name of the interface (for example 1/1/1) the responder is bound to.
+      Set on creation only; changing it recreates the responder.
+    required: false
+    type: str
   persistence:
     description: Whether the responder survives a reboot.
     required: false
@@ -70,6 +76,14 @@ attributes, so any change is applied by recreating the responder.
     vrf: default
     responder_port_number: 5000
     responder_type: ipv4
+
+- name: Create a responder bound to a specific interface
+  aoscx_ipsla_responder:
+    name: responder-2
+    type: udp_echo
+    vrf: default
+    responder_port_number: 5000
+    responder_interface: 1/1/1
 
 - name: Delete an IP SLA responder
   aoscx_ipsla_responder:

--- a/docs/aoscx_ipsla_responder.md
+++ b/docs/aoscx_ipsla_responder.md
@@ -1,0 +1,78 @@
+# module: aoscx_ipsla_responder
+
+description: This module provides configuration management of IP SLA
+responders on AOS-CX devices (system/ipsla_responders). An IP SLA responder
+answers probes sent by IP SLA sources. IP SLA requires REST API version 10.16
+(set ansible_aoscx_rest_version to 10.16). A responder has no modifiable
+attributes, so any change is applied by recreating the responder.
+
+##### ARGUMENTS
+
+```YAML
+  name:
+    description: >
+      Name of the IP SLA responder. This is the index of the resource under
+      system/ipsla_responders.
+    required: true
+    type: str
+  vrf:
+    description: Name of the VRF the IP SLA responder belongs to.
+    required: false
+    default: default
+    type: str
+  type:
+    description: Probe type the responder answers.
+    required: false
+    type: str
+    choices:
+      - udp_echo
+      - tcp_connect
+      - udp_jitter_voip
+  responder_port_number:
+    description: UDP/TCP port the responder listens on (1-65535).
+    required: false
+    type: int
+  responder_type:
+    description: IP address family used by the responder.
+    required: false
+    type: str
+    choices:
+      - ipv4
+      - ipv6
+  responder_ip:
+    description: IP address the responder is bound to.
+    required: false
+    type: str
+  persistence:
+    description: Whether the responder survives a reboot.
+    required: false
+    type: str
+    choices:
+      - persistent
+      - volatile
+  state:
+    description: Create or delete the IP SLA responder.
+    required: false
+    choices:
+      - create
+      - delete
+    default: create
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create a UDP echo IP SLA responder
+  aoscx_ipsla_responder:
+    name: responder-1
+    type: udp_echo
+    vrf: default
+    responder_port_number: 5000
+    responder_type: ipv4
+
+- name: Delete an IP SLA responder
+  aoscx_ipsla_responder:
+    name: responder-1
+    state: delete
+```

--- a/docs/aoscx_ipsla_source.md
+++ b/docs/aoscx_ipsla_source.md
@@ -1,0 +1,110 @@
+# module: aoscx_ipsla_source
+
+description: This module provides configuration management of IP SLA sources
+on AOS-CX devices (system/ipsla_sources). An IP SLA source originates probes
+used to measure reachability, latency and jitter. IP SLA requires REST API
+version 10.16 (set ansible_aoscx_rest_version to 10.16). The type and vrf are
+set when the source is created and cannot be changed afterwards.
+
+##### ARGUMENTS
+
+```YAML
+  name:
+    description: >
+      Name of the IP SLA source. This is the index of the resource under
+      system/ipsla_sources.
+    required: true
+    type: str
+  vrf:
+    description: >
+      Name of the VRF the IP SLA source belongs to. Set on creation only.
+    required: false
+    default: default
+    type: str
+  type:
+    description: >
+      Probe type of the IP SLA source. Required when the source is created
+      and cannot be changed afterwards.
+    required: false
+    type: str
+    choices:
+      - icmp_echo
+      - udp_echo
+      - tcp_connect
+      - udp_jitter_voip
+      - http
+      - https
+      - dns
+      - dhcp
+  enable:
+    description: Enable or disable the IP SLA source.
+    required: false
+    type: bool
+  frequency:
+    description: >
+      Interval in seconds between two consecutive probes (5-604800).
+    required: false
+    type: int
+  history_interval:
+    description: >
+      Number of probes whose statistics are kept in the history (10-7200).
+    required: false
+    type: int
+  ipsla_timeout:
+    description: >
+      Time in seconds to wait for a probe response (5-604800).
+    required: false
+    type: int
+  payload_size:
+    description: Probe payload size in bytes (0-1440).
+    required: false
+    type: int
+  source_ip:
+    description: Source IP address used by the probes.
+    required: false
+    type: str
+  source_port_number:
+    description: Source UDP/TCP port used by the probes (1-65535).
+    required: false
+    type: int
+  tos:
+    description: Type of Service value carried by the probes (0-255).
+    required: false
+    type: int
+  domain_name_server:
+    description: DNS server used to resolve the probe destination.
+    required: false
+    type: str
+  state:
+    description: Create, update or delete the IP SLA source.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create an ICMP echo IP SLA source
+  aoscx_ipsla_source:
+    name: probe-gw
+    type: icmp_echo
+    vrf: default
+    frequency: 30
+    tos: 8
+
+- name: Update the probe frequency
+  aoscx_ipsla_source:
+    name: probe-gw
+    state: update
+    frequency: 60
+
+- name: Delete an IP SLA source
+  aoscx_ipsla_source:
+    name: probe-gw
+    state: delete
+```

--- a/docs/aoscx_ipsla_source.md
+++ b/docs/aoscx_ipsla_source.md
@@ -75,6 +75,30 @@ set when the source is created and cannot be changed afterwards.
     description: DNS server used to resolve the probe destination.
     required: false
     type: str
+  source_interface:
+    description: >
+      Name of the interface (for example 1/1/1) used as the source of the
+      probes. May be set on creation and changed on update.
+    required: false
+    type: str
+  http_sla:
+    description: >
+      HTTP probe options. A dictionary with the keys cache_disable (bool),
+      type (get or raw) and version_number (for example "1.0" or "1.1").
+    required: false
+    type: dict
+  https_sla:
+    description: >
+      HTTPS probe options. A dictionary with the keys cache_disable (bool),
+      type (get or raw) and version_number.
+    required: false
+    type: dict
+  voip_jitter_sla:
+    description: >
+      VoIP jitter probe options. A dictionary with the keys advantage_factor
+      (int) and codec_type (for example g711a or g729a).
+    required: false
+    type: dict
   state:
     description: Create, update or delete the IP SLA source.
     required: false
@@ -102,6 +126,26 @@ set when the source is created and cannot be changed afterwards.
     name: probe-gw
     state: update
     frequency: 60
+
+- name: Create an HTTP IP SLA source bound to an interface
+  aoscx_ipsla_source:
+    name: probe-http
+    type: http
+    vrf: default
+    source_interface: 1/1/1
+    http_sla:
+      cache_disable: true
+      type: get
+      version_number: "1.1"
+
+- name: Create a VoIP jitter IP SLA source
+  aoscx_ipsla_source:
+    name: probe-voip
+    type: udp_jitter_voip
+    vrf: default
+    voip_jitter_sla:
+      advantage_factor: 10
+      codec_type: g711a
 
 - name: Delete an IP SLA source
   aoscx_ipsla_source:

--- a/docs/aoscx_ipsla_track_object.md
+++ b/docs/aoscx_ipsla_track_object.md
@@ -1,0 +1,77 @@
+# module: aoscx_ipsla_track_object
+
+description: This module provides configuration management of IP SLA track
+objects on AOS-CX devices (system/ipsla_track_objects). A track object follows
+the state of one or more IP SLA sessions. IP SLA requires REST API version
+10.16 (set ansible_aoscx_rest_version to 10.16). The tracked IP SLA sessions
+are set when the track object is created and cannot be modified; changing them
+recreates the track object.
+
+##### ARGUMENTS
+
+```YAML
+  name:
+    description: >
+      Name of the IP SLA track object. This is the index of the resource
+      under system/ipsla_track_objects.
+    required: true
+    type: str
+  tracked_ipsla_session:
+    description: >
+      List of IP SLA source names tracked by this object. Set on creation;
+      changing this list recreates the track object.
+    required: false
+    type: list
+    elements: str
+  track_list_operator:
+    description: >
+      Operator combining the tracked sessions to compute the overall state.
+    required: false
+    type: str
+    choices:
+      - and
+      - or
+  up_delay:
+    description: >
+      Delay in seconds before the track object is declared up (0-180).
+    required: false
+    type: int
+  down_delay:
+    description: >
+      Delay in seconds before the track object is declared down (0-180).
+    required: false
+    type: int
+  state:
+    description: Create, update or delete the IP SLA track object.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create an IP SLA track object
+  aoscx_ipsla_track_object:
+    name: track-gw
+    tracked_ipsla_session:
+      - probe-gw
+    track_list_operator: or
+    up_delay: 5
+
+- name: Update the track object timers
+  aoscx_ipsla_track_object:
+    name: track-gw
+    state: update
+    up_delay: 10
+    down_delay: 5
+
+- name: Delete an IP SLA track object
+  aoscx_ipsla_track_object:
+    name: track-gw
+    state: delete
+```

--- a/plugins/connection/aoscx.py
+++ b/plugins/connection/aoscx.py
@@ -120,9 +120,10 @@ options:
       - name: ansible_persistent_log_messages
   rest_version:
     description: >
-      Configures REST version, default version is 10.04, but 10.08 or 10.09
-      can be used in a specific host or globaly if it is set as an environment
-      variable.
+      Configures REST version, default version is 10.04, but 10.08, 10.09 or
+      10.16 can be used in a specific host or globaly if it is set as an
+      environment variable. Version 10.16 is required for IP SLA track
+      objects.
     default: '10.04'
     env:
       - name: ANSIBLE_AOSCX_REST_VERSION
@@ -208,10 +209,13 @@ class Connection(NetworkConnectionBase):
             password = self.get_option("password")
             self.use_proxy = self.get_option("use_proxy")
             rest_version = self.get_option("rest_version")
-            if rest_version not in ["10.04", "10.08", "10.09"]:
-                raise AnsibleConnectionFailure("Invalid REST version: %s"
-                                               % rest_version)
-            self.base_url = "https://{0}/rest/v{1}/".format(switchip, rest_version)
+            if rest_version not in ["10.04", "10.08", "10.09", "10.16"]:
+                raise AnsibleConnectionFailure(
+                    "Invalid REST version: %s" % rest_version
+                )
+            self.base_url = "https://{0}/rest/v{1}/".format(
+                switchip, rest_version
+            )
             # Set Credentials
             self.__username = username
             self.__password = password

--- a/plugins/modules/aoscx_ipsla_responder.py
+++ b/plugins/modules/aoscx_ipsla_responder.py
@@ -62,6 +62,12 @@ options:
     description: IP address the responder is bound to.
     required: false
     type: str
+  responder_interface:
+    description: >
+      Name of the interface (for example 1/1/1) the responder is bound to.
+      Set on creation only; changing it recreates the responder.
+    required: false
+    type: str
   persistence:
     description: Whether the responder survives a reboot.
     required: false
@@ -88,6 +94,14 @@ EXAMPLES = """
     responder_port_number: 5000
     responder_type: ipv4
 
+- name: Create a responder bound to a specific interface
+  aoscx_ipsla_responder:
+    name: responder-2
+    type: udp_echo
+    vrf: default
+    responder_port_number: 5000
+    responder_interface: 1/1/1
+
 - name: Delete an IP SLA responder
   aoscx_ipsla_responder:
     name: responder-1
@@ -96,10 +110,26 @@ EXAMPLES = """
 
 RETURN = r""" # """
 
+from urllib.parse import quote
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
     get_pyaoscx_session,
 )
+
+
+def interface_uri(session, ansible_module, name):
+    """Validate an interface exists and return its URI for a request body."""
+    interface = session.api.get_module(session, "Interface", name)
+    try:
+        interface.get()
+    except Exception:
+        ansible_module.fail_json(
+            msg="Could not find interface {0}".format(name)
+        )
+    return "{0}system/interfaces/{1}".format(
+        session.resource_prefix, quote(name, safe="")
+    )
 
 
 def main():
@@ -120,6 +150,7 @@ def main():
             choices=["ipv4", "ipv6"],
         ),
         responder_ip=dict(type="str", required=False, default=None),
+        responder_interface=dict(type="str", required=False, default=None),
         persistence=dict(
             type="str",
             required=False,
@@ -140,6 +171,7 @@ def main():
     name = ansible_module.params["name"]
     vrf_name = ansible_module.params["vrf"]
     state = ansible_module.params["state"]
+    responder_interface = ansible_module.params["responder_interface"]
 
     scalar_attrs = [
         "type",
@@ -201,8 +233,13 @@ def main():
             ansible_module.fail_json(
                 msg="Could not find VRF, make sure it exists"
             )
+        kwargs = dict(supplied)
+        if responder_interface is not None:
+            kwargs["responder_interface"] = interface_uri(
+                session, ansible_module, responder_interface
+            )
         return session.api.get_module(
-            session, "IpslaResponder", name, vrf=vrf, **supplied
+            session, "IpslaResponder", name, vrf=vrf, **kwargs
         )
 
     if not exists:
@@ -231,6 +268,18 @@ def main():
         differs = True
     for attr, value in supplied.items():
         if getattr(responder, attr, None) != value:
+            differs = True
+
+    if responder_interface is not None:
+        desired_if = interface_uri(
+            session, ansible_module, responder_interface
+        )
+        current_if = getattr(responder, "responder_interface", None)
+        if isinstance(current_if, dict) and current_if:
+            current_if_uri = list(current_if.values())[0]
+        else:
+            current_if_uri = None
+        if current_if_uri != desired_if:
             differs = True
 
     result["changed"] = differs

--- a/plugins/modules/aoscx_ipsla_responder.py
+++ b/plugins/modules/aoscx_ipsla_responder.py
@@ -1,0 +1,250 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_ipsla_responder
+version_added: "4.6.0"
+short_description: Create or delete an IP SLA responder
+description: >
+  This module provides configuration management of IP SLA responders on
+  AOS-CX devices (system/ipsla_responders). An IP SLA responder answers
+  probes sent by IP SLA sources. IP SLA requires REST API version 10.16 (set
+  ansible_aoscx_rest_version to 10.16). A responder has no modifiable
+  attributes, so any change is applied by recreating the responder.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: >
+      Name of the IP SLA responder. This is the index of the resource under
+      system/ipsla_responders.
+    required: true
+    type: str
+  vrf:
+    description: Name of the VRF the IP SLA responder belongs to.
+    required: false
+    default: default
+    type: str
+  type:
+    description: Probe type the responder answers.
+    required: false
+    type: str
+    choices:
+      - udp_echo
+      - tcp_connect
+      - udp_jitter_voip
+  responder_port_number:
+    description: UDP/TCP port the responder listens on (1-65535).
+    required: false
+    type: int
+  responder_type:
+    description: IP address family used by the responder.
+    required: false
+    type: str
+    choices:
+      - ipv4
+      - ipv6
+  responder_ip:
+    description: IP address the responder is bound to.
+    required: false
+    type: str
+  persistence:
+    description: Whether the responder survives a reboot.
+    required: false
+    type: str
+    choices:
+      - persistent
+      - volatile
+  state:
+    description: Create or delete the IP SLA responder.
+    required: false
+    choices:
+      - create
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a UDP echo IP SLA responder
+  aoscx_ipsla_responder:
+    name: responder-1
+    type: udp_echo
+    vrf: default
+    responder_port_number: 5000
+    responder_type: ipv4
+
+- name: Delete an IP SLA responder
+  aoscx_ipsla_responder:
+    name: responder-1
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        name=dict(type="str", required=True),
+        vrf=dict(type="str", required=False, default="default"),
+        type=dict(
+            type="str",
+            required=False,
+            default=None,
+            choices=["udp_echo", "tcp_connect", "udp_jitter_voip"],
+        ),
+        responder_port_number=dict(type="int", required=False, default=None),
+        responder_type=dict(
+            type="str",
+            required=False,
+            default=None,
+            choices=["ipv4", "ipv6"],
+        ),
+        responder_ip=dict(type="str", required=False, default=None),
+        persistence=dict(
+            type="str",
+            required=False,
+            default=None,
+            choices=["persistent", "volatile"],
+        ),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    name = ansible_module.params["name"]
+    vrf_name = ansible_module.params["vrf"]
+    state = ansible_module.params["state"]
+
+    scalar_attrs = [
+        "type",
+        "responder_port_number",
+        "responder_type",
+        "responder_ip",
+        "persistence",
+    ]
+    supplied = {
+        attr: ansible_module.params[attr]
+        for attr in scalar_attrs
+        if ansible_module.params[attr] is not None
+    }
+
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        responder = session.api.get_module(session, "IpslaResponder", name)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support IP SLA. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        responder.get(selector="configuration")
+        exists = True
+    except Exception:
+        exists = False
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                responder.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete IP SLA responder: "
+                    "{0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # ------------------------------------------------------------ create
+    def build_responder():
+        vrf = session.api.get_module(session, "Vrf", vrf_name)
+        try:
+            vrf.get()
+        except Exception:
+            ansible_module.fail_json(
+                msg="Could not find VRF, make sure it exists"
+            )
+        return session.api.get_module(
+            session, "IpslaResponder", name, vrf=vrf, **supplied
+        )
+
+    if not exists:
+        new_responder = build_responder()
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                new_responder.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create IP SLA responder: "
+                    "{0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    # A responder has no modifiable attributes. Compare the supplied values
+    # against the current configuration and recreate the responder if they
+    # differ.
+    differs = False
+    current_vrf = getattr(responder, "vrf", None)
+    if isinstance(current_vrf, dict) and current_vrf:
+        current_vrf_name = list(current_vrf.keys())[0]
+    else:
+        current_vrf_name = None
+    if current_vrf_name is not None and current_vrf_name != vrf_name:
+        differs = True
+    for attr, value in supplied.items():
+        if getattr(responder, attr, None) != value:
+            differs = True
+
+    result["changed"] = differs
+    if differs and not ansible_module.check_mode:
+        try:
+            responder.delete()
+            build_responder().create()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update IP SLA responder: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_ipsla_source.py
+++ b/plugins/modules/aoscx_ipsla_source.py
@@ -1,0 +1,285 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_ipsla_source
+version_added: "4.6.0"
+short_description: Create, update or delete an IP SLA source
+description: >
+  This module provides configuration management of IP SLA sources on AOS-CX
+  devices (system/ipsla_sources). An IP SLA source originates probes used to
+  measure reachability, latency and jitter. IP SLA requires REST API version
+  10.16 (set ansible_aoscx_rest_version to 10.16). The type and vrf are set
+  when the source is created and cannot be changed afterwards.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: >
+      Name of the IP SLA source. This is the index of the resource under
+      system/ipsla_sources.
+    required: true
+    type: str
+  vrf:
+    description: >
+      Name of the VRF the IP SLA source belongs to. Set on creation only.
+    required: false
+    default: default
+    type: str
+  type:
+    description: >
+      Probe type of the IP SLA source. Required when the source is created
+      and cannot be changed afterwards.
+    required: false
+    type: str
+    choices:
+      - icmp_echo
+      - udp_echo
+      - tcp_connect
+      - udp_jitter_voip
+      - http
+      - https
+      - dns
+      - dhcp
+  enable:
+    description: Enable or disable the IP SLA source.
+    required: false
+    type: bool
+  frequency:
+    description: >
+      Interval in seconds between two consecutive probes (5-604800).
+    required: false
+    type: int
+  history_interval:
+    description: >
+      Number of probes whose statistics are kept in the history (10-7200).
+    required: false
+    type: int
+  ipsla_timeout:
+    description: >
+      Time in seconds to wait for a probe response (5-604800).
+    required: false
+    type: int
+  payload_size:
+    description: Probe payload size in bytes (0-1440).
+    required: false
+    type: int
+  source_ip:
+    description: Source IP address used by the probes.
+    required: false
+    type: str
+  source_port_number:
+    description: Source UDP/TCP port used by the probes (1-65535).
+    required: false
+    type: int
+  tos:
+    description: Type of Service value carried by the probes (0-255).
+    required: false
+    type: int
+  domain_name_server:
+    description: DNS server used to resolve the probe destination.
+    required: false
+    type: str
+  state:
+    description: Create, update or delete the IP SLA source.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create an ICMP echo IP SLA source
+  aoscx_ipsla_source:
+    name: probe-gw
+    type: icmp_echo
+    vrf: default
+    frequency: 30
+    tos: 8
+
+- name: Update the probe frequency
+  aoscx_ipsla_source:
+    name: probe-gw
+    state: update
+    frequency: 60
+
+- name: Delete an IP SLA source
+  aoscx_ipsla_source:
+    name: probe-gw
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        name=dict(type="str", required=True),
+        vrf=dict(type="str", required=False, default="default"),
+        type=dict(
+            type="str",
+            required=False,
+            default=None,
+            choices=[
+                "icmp_echo",
+                "udp_echo",
+                "tcp_connect",
+                "udp_jitter_voip",
+                "http",
+                "https",
+                "dns",
+                "dhcp",
+            ],
+        ),
+        enable=dict(type="bool", required=False, default=None),
+        frequency=dict(type="int", required=False, default=None),
+        history_interval=dict(type="int", required=False, default=None),
+        ipsla_timeout=dict(type="int", required=False, default=None),
+        payload_size=dict(type="int", required=False, default=None),
+        source_ip=dict(type="str", required=False, default=None),
+        source_port_number=dict(type="int", required=False, default=None),
+        tos=dict(type="int", required=False, default=None),
+        domain_name_server=dict(type="str", required=False, default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    name = ansible_module.params["name"]
+    vrf_name = ansible_module.params["vrf"]
+    state = ansible_module.params["state"]
+
+    scalar_attrs = [
+        "type",
+        "enable",
+        "frequency",
+        "history_interval",
+        "ipsla_timeout",
+        "payload_size",
+        "source_ip",
+        "source_port_number",
+        "tos",
+        "domain_name_server",
+    ]
+    supplied = {
+        attr: ansible_module.params[attr]
+        for attr in scalar_attrs
+        if ansible_module.params[attr] is not None
+    }
+
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        source = session.api.get_module(session, "IpslaSource", name)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support IP SLA. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        source.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                source.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete IP SLA source: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # ------------------------------------------------------- create / update
+    if not exists:
+        if "type" not in supplied:
+            ansible_module.fail_json(
+                msg="type is required to create an IP SLA source"
+            )
+        vrf = session.api.get_module(session, "Vrf", vrf_name)
+        try:
+            vrf.get()
+        except Exception:
+            ansible_module.fail_json(
+                msg="Could not find VRF, make sure it exists"
+            )
+        source = session.api.get_module(
+            session, "IpslaSource", name, vrf=vrf, **supplied
+        )
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                source.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create IP SLA source: {0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+    for attr, value in supplied.items():
+        # type is set at creation time and cannot be changed.
+        if attr == "type":
+            continue
+        if getattr(source, attr, None) != value:
+            changed = True
+            setattr(source, attr, value)
+            if attr not in source.config_attrs:
+                source.config_attrs.append(attr)
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            source.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update IP SLA source: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_ipsla_source.py
+++ b/plugins/modules/aoscx_ipsla_source.py
@@ -120,6 +120,15 @@ options:
       The supplied dictionary fully replaces the current settings.
     required: false
     type: dict
+  responder:
+    description: >
+      IP SLA responder address. Required for all probe types except http and
+      https (which use a URL instead). Supported keys are hostname (the
+      hostname, FQDN or IPv4/IPv6 address of the responder) and port (the
+      transport layer port number; not needed for icmp_echo). The supplied
+      dictionary fully replaces the current settings.
+    required: false
+    type: dict
   state:
     description: Create, update or delete the IP SLA source.
     required: false
@@ -228,6 +237,7 @@ def main():
         http_sla=dict(type="dict", required=False, default=None),
         https_sla=dict(type="dict", required=False, default=None),
         voip_jitter_sla=dict(type="dict", required=False, default=None),
+        responder=dict(type="dict", required=False, default=None),
         state=dict(
             type="str",
             default="create",
@@ -258,6 +268,7 @@ def main():
         "http_sla",
         "https_sla",
         "voip_jitter_sla",
+        "responder",
     ]
     supplied = {
         attr: ansible_module.params[attr]

--- a/plugins/modules/aoscx_ipsla_source.py
+++ b/plugins/modules/aoscx_ipsla_source.py
@@ -94,6 +94,32 @@ options:
     description: DNS server used to resolve the probe destination.
     required: false
     type: str
+  source_interface:
+    description: >
+      Name of the interface (for example 1/1/1) the probes are sourced from.
+    required: false
+    type: str
+  http_sla:
+    description: >
+      HTTP probe settings, applicable to the http probe type. Supported keys
+      are cache_disable (bool), type (get or raw) and version_number (str).
+      The supplied dictionary fully replaces the current settings.
+    required: false
+    type: dict
+  https_sla:
+    description: >
+      HTTPS probe settings, applicable to the https probe type. Supported keys
+      are cache_disable (bool), type (get or raw) and version_number (str).
+      The supplied dictionary fully replaces the current settings.
+    required: false
+    type: dict
+  voip_jitter_sla:
+    description: >
+      VoIP jitter probe settings, applicable to the udp_jitter_voip probe
+      type. Supported keys are advantage_factor (int) and codec_type (str).
+      The supplied dictionary fully replaces the current settings.
+    required: false
+    type: dict
   state:
     description: Create, update or delete the IP SLA source.
     required: false
@@ -120,6 +146,26 @@ EXAMPLES = """
     state: update
     frequency: 60
 
+- name: Create an HTTP IP SLA source from a given interface
+  aoscx_ipsla_source:
+    name: probe-web
+    type: http
+    vrf: default
+    source_interface: 1/1/1
+    http_sla:
+      cache_disable: true
+      type: get
+      version_number: "1.1"
+
+- name: Create a VoIP jitter IP SLA source
+  aoscx_ipsla_source:
+    name: probe-voip
+    type: udp_jitter_voip
+    vrf: default
+    voip_jitter_sla:
+      advantage_factor: 5
+      codec_type: g729a
+
 - name: Delete an IP SLA source
   aoscx_ipsla_source:
     name: probe-gw
@@ -128,10 +174,26 @@ EXAMPLES = """
 
 RETURN = r""" # """
 
+from urllib.parse import quote
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
     get_pyaoscx_session,
 )
+
+
+def interface_uri(session, ansible_module, name):
+    """Validate an interface exists and return its URI for a request body."""
+    interface = session.api.get_module(session, "Interface", name)
+    try:
+        interface.get()
+    except Exception:
+        ansible_module.fail_json(
+            msg="Could not find interface {0}".format(name)
+        )
+    return "{0}system/interfaces/{1}".format(
+        session.resource_prefix, quote(name, safe="")
+    )
 
 
 def main():
@@ -162,6 +224,10 @@ def main():
         source_port_number=dict(type="int", required=False, default=None),
         tos=dict(type="int", required=False, default=None),
         domain_name_server=dict(type="str", required=False, default=None),
+        source_interface=dict(type="str", required=False, default=None),
+        http_sla=dict(type="dict", required=False, default=None),
+        https_sla=dict(type="dict", required=False, default=None),
+        voip_jitter_sla=dict(type="dict", required=False, default=None),
         state=dict(
             type="str",
             default="create",
@@ -176,6 +242,7 @@ def main():
     name = ansible_module.params["name"]
     vrf_name = ansible_module.params["vrf"]
     state = ansible_module.params["state"]
+    source_interface = ansible_module.params["source_interface"]
 
     scalar_attrs = [
         "type",
@@ -188,6 +255,9 @@ def main():
         "source_port_number",
         "tos",
         "domain_name_server",
+        "http_sla",
+        "https_sla",
+        "voip_jitter_sla",
     ]
     supplied = {
         attr: ansible_module.params[attr]
@@ -245,8 +315,13 @@ def main():
             ansible_module.fail_json(
                 msg="Could not find VRF, make sure it exists"
             )
+        create_kwargs = dict(supplied)
+        if source_interface is not None:
+            create_kwargs["source_interface"] = interface_uri(
+                session, ansible_module, source_interface
+            )
         source = session.api.get_module(
-            session, "IpslaSource", name, vrf=vrf, **supplied
+            session, "IpslaSource", name, vrf=vrf, **create_kwargs
         )
         result["changed"] = True
         if not ansible_module.check_mode:
@@ -268,6 +343,19 @@ def main():
             setattr(source, attr, value)
             if attr not in source.config_attrs:
                 source.config_attrs.append(attr)
+
+    if source_interface is not None:
+        desired_uri = interface_uri(session, ansible_module, source_interface)
+        current = getattr(source, "source_interface", None)
+        if isinstance(current, dict) and current:
+            current_uri = list(current.values())[0]
+        else:
+            current_uri = None
+        if current_uri != desired_uri:
+            changed = True
+            source.source_interface = desired_uri
+            if "source_interface" not in source.config_attrs:
+                source.config_attrs.append("source_interface")
 
     result["changed"] = changed
     if changed and not ansible_module.check_mode:

--- a/plugins/modules/aoscx_ipsla_track_object.py
+++ b/plugins/modules/aoscx_ipsla_track_object.py
@@ -1,0 +1,268 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_ipsla_track_object
+version_added: "4.6.0"
+short_description: Create, update or delete an IP SLA track object
+description: >
+  This module provides configuration management of IP SLA track objects on
+  AOS-CX devices (system/ipsla_track_objects). A track object follows the
+  state of one or more IP SLA sessions. IP SLA requires REST API version 10.16
+  (set ansible_aoscx_rest_version to 10.16). The tracked IP SLA sessions are
+  set when the track object is created and cannot be modified; changing them
+  recreates the track object.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: >
+      Name of the IP SLA track object. This is the index of the resource
+      under system/ipsla_track_objects.
+    required: true
+    type: str
+  tracked_ipsla_session:
+    description: >
+      List of IP SLA source names tracked by this object. Set on creation;
+      changing this list recreates the track object.
+    required: false
+    type: list
+    elements: str
+  track_list_operator:
+    description: >
+      Operator combining the tracked sessions to compute the overall state.
+    required: false
+    type: str
+    choices:
+      - and
+      - or
+  up_delay:
+    description: >
+      Delay in seconds before the track object is declared up (0-180).
+    required: false
+    type: int
+  down_delay:
+    description: >
+      Delay in seconds before the track object is declared down (0-180).
+    required: false
+    type: int
+  state:
+    description: Create, update or delete the IP SLA track object.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create an IP SLA track object
+  aoscx_ipsla_track_object:
+    name: track-gw
+    tracked_ipsla_session:
+      - probe-gw
+    track_list_operator: or
+    up_delay: 5
+
+- name: Update the track object timers
+  aoscx_ipsla_track_object:
+    name: track-gw
+    state: update
+    up_delay: 10
+    down_delay: 5
+
+- name: Delete an IP SLA track object
+  aoscx_ipsla_track_object:
+    name: track-gw
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        name=dict(type="str", required=True),
+        tracked_ipsla_session=dict(
+            type="list",
+            elements="str",
+            required=False,
+            default=None,
+        ),
+        track_list_operator=dict(
+            type="str",
+            required=False,
+            default=None,
+            choices=["and", "or"],
+        ),
+        up_delay=dict(type="int", required=False, default=None),
+        down_delay=dict(type="int", required=False, default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    name = ansible_module.params["name"]
+    tracked = ansible_module.params["tracked_ipsla_session"]
+    state = ansible_module.params["state"]
+
+    scalar_attrs = ["track_list_operator", "up_delay", "down_delay"]
+    supplied = {
+        attr: ansible_module.params[attr]
+        for attr in scalar_attrs
+        if ansible_module.params[attr] is not None
+    }
+
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        track = session.api.get_module(session, "IpslaTrackObject", name)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support IP SLA. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        track.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                track.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete IP SLA track object: "
+                    "{0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    def materialize_sources():
+        sources = []
+        for source_name in tracked or []:
+            source = session.api.get_module(
+                session, "IpslaSource", source_name
+            )
+            try:
+                source.get()
+            except Exception:
+                ansible_module.fail_json(
+                    msg="Could not find IP SLA source {0}".format(source_name)
+                )
+            sources.append(source)
+        return sources
+
+    def build_track():
+        return session.api.get_module(
+            session,
+            "IpslaTrackObject",
+            name,
+            tracked_ipsla_session=materialize_sources(),
+            **supplied
+        )
+
+    # ------------------------------------------------------------ create
+    if not exists:
+        new_track = build_track()
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                new_track.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create IP SLA track object: "
+                    "{0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    # ------------------------------------------------------------ update
+    # The tracked sessions are set at creation time. If a different set is
+    # requested, the track object must be recreated.
+    recreate = False
+    if tracked is not None:
+        probe = session.api.get_module(session, "IpslaTrackObject", name)
+        try:
+            probe.get(selector="configuration")
+        except Exception:
+            probe = None
+        current = set((getattr(probe, "tracked_ipsla_session", {}) or {}))
+        if current != set(tracked):
+            recreate = True
+
+    if recreate:
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                track.delete()
+                build_track().create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not update IP SLA track object: "
+                    "{0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+    for attr, value in supplied.items():
+        if getattr(track, attr, None) != value:
+            changed = True
+            setattr(track, attr, value)
+            if attr not in track.config_attrs:
+                track.config_attrs.append(attr)
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            track.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update IP SLA track object: "
+                "{0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/aoscx_ipsla_responder/aliases
+++ b/tests/integration/targets/aoscx_ipsla_responder/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_ipsla_responder/tasks/main.yml
+++ b/tests/integration/targets/aoscx_ipsla_responder/tasks/main.yml
@@ -1,0 +1,69 @@
+# Integration tests for the aoscx_ipsla_responder module.
+#
+# Run with:
+#   ansible-test integration aoscx_ipsla_responder --venv
+#
+# Requires an inventory entry named "aoscx" reachable with a pyaoscx release
+# that ships the IpslaResponder class and a REST API version of 10.16. Uses a
+# temporary responder named "ansible-test" and cleans up afterwards. The
+# responder has no modifiable attributes, so a change is applied by recreating
+# it.
+
+- name: Make sure the test responder does not exist yet
+  arubanetworks.aoscx.aoscx_ipsla_responder:
+    name: ansible-test
+    state: delete
+  ignore_errors: true
+
+- name: Create an IP SLA responder
+  arubanetworks.aoscx.aoscx_ipsla_responder:
+    name: ansible-test
+    type: udp_echo
+    vrf: default
+    responder_port_number: 5000
+    responder_type: ipv4
+  register: result
+
+- name: Assert the responder was created
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Create the responder again (idempotent)
+  arubanetworks.aoscx.aoscx_ipsla_responder:
+    name: ansible-test
+    type: udp_echo
+    vrf: default
+    responder_port_number: 5000
+    responder_type: ipv4
+  register: result
+
+- name: Assert no change on re-create
+  ansible.builtin.assert:
+    that:
+      - not result.changed
+
+- name: Recreate the responder with a new port
+  arubanetworks.aoscx.aoscx_ipsla_responder:
+    name: ansible-test
+    type: udp_echo
+    vrf: default
+    responder_port_number: 6000
+    responder_type: ipv4
+  register: result
+
+- name: Assert the responder was recreated
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Delete the responder
+  arubanetworks.aoscx.aoscx_ipsla_responder:
+    name: ansible-test
+    state: delete
+  register: result
+
+- name: Assert the responder was deleted
+  ansible.builtin.assert:
+    that:
+      - result.changed

--- a/tests/integration/targets/aoscx_ipsla_source/aliases
+++ b/tests/integration/targets/aoscx_ipsla_source/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_ipsla_source/tasks/main.yml
+++ b/tests/integration/targets/aoscx_ipsla_source/tasks/main.yml
@@ -1,0 +1,65 @@
+# Integration tests for the aoscx_ipsla_source module.
+#
+# Run with:
+#   ansible-test integration aoscx_ipsla_source --venv
+#
+# Requires an inventory entry named "aoscx" reachable with a pyaoscx release
+# that ships the IpslaSource class and a REST API version of 10.16. Uses a
+# temporary source named "ansible-test" and cleans up afterwards.
+
+- name: Make sure the test source does not exist yet
+  arubanetworks.aoscx.aoscx_ipsla_source:
+    name: ansible-test
+    state: delete
+  ignore_errors: true
+
+- name: Create an IP SLA source
+  arubanetworks.aoscx.aoscx_ipsla_source:
+    name: ansible-test
+    type: icmp_echo
+    vrf: default
+    frequency: 30
+    tos: 8
+  register: result
+
+- name: Assert the source was created
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Create the source again (idempotent)
+  arubanetworks.aoscx.aoscx_ipsla_source:
+    name: ansible-test
+    type: icmp_echo
+    vrf: default
+    frequency: 30
+    tos: 8
+  register: result
+
+- name: Assert no change on re-create
+  ansible.builtin.assert:
+    that:
+      - not result.changed
+
+- name: Update the source frequency
+  arubanetworks.aoscx.aoscx_ipsla_source:
+    name: ansible-test
+    state: update
+    frequency: 90
+  register: result
+
+- name: Assert the source was updated
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Delete the source
+  arubanetworks.aoscx.aoscx_ipsla_source:
+    name: ansible-test
+    state: delete
+  register: result
+
+- name: Assert the source was deleted
+  ansible.builtin.assert:
+    that:
+      - result.changed

--- a/tests/integration/targets/aoscx_ipsla_track_object/aliases
+++ b/tests/integration/targets/aoscx_ipsla_track_object/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_ipsla_track_object/tasks/main.yml
+++ b/tests/integration/targets/aoscx_ipsla_track_object/tasks/main.yml
@@ -1,0 +1,78 @@
+# Integration tests for the aoscx_ipsla_track_object module.
+#
+# Run with:
+#   ansible-test integration aoscx_ipsla_track_object --venv
+#
+# Requires an inventory entry named "aoscx" reachable with a pyaoscx release
+# that ships the IpslaTrackObject class and a REST API version of 10.16. Uses
+# a temporary IP SLA source and track object both named "ansible-test" and
+# cleans up afterwards.
+
+- name: Make sure the test track object does not exist yet
+  arubanetworks.aoscx.aoscx_ipsla_track_object:
+    name: ansible-test
+    state: delete
+  ignore_errors: true
+
+- name: Make sure the test source exists for the track object
+  arubanetworks.aoscx.aoscx_ipsla_source:
+    name: ansible-test
+    type: icmp_echo
+    vrf: default
+
+- name: Create an IP SLA track object
+  arubanetworks.aoscx.aoscx_ipsla_track_object:
+    name: ansible-test
+    tracked_ipsla_session:
+      - ansible-test
+    track_list_operator: or
+    up_delay: 5
+  register: result
+
+- name: Assert the track object was created
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Create the track object again (idempotent)
+  arubanetworks.aoscx.aoscx_ipsla_track_object:
+    name: ansible-test
+    tracked_ipsla_session:
+      - ansible-test
+    track_list_operator: or
+    up_delay: 5
+  register: result
+
+- name: Assert no change on re-create
+  ansible.builtin.assert:
+    that:
+      - not result.changed
+
+- name: Update the track object timers
+  arubanetworks.aoscx.aoscx_ipsla_track_object:
+    name: ansible-test
+    state: update
+    up_delay: 10
+    down_delay: 5
+  register: result
+
+- name: Assert the track object was updated
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Delete the track object
+  arubanetworks.aoscx.aoscx_ipsla_track_object:
+    name: ansible-test
+    state: delete
+  register: result
+
+- name: Assert the track object was deleted
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Clean up the test source
+  arubanetworks.aoscx.aoscx_ipsla_source:
+    name: ansible-test
+    state: delete

--- a/tests/unit/modules/test_aoscx_ipsla_responder.py
+++ b/tests/unit/modules/test_aoscx_ipsla_responder.py
@@ -73,12 +73,15 @@ def patch_ansible_module():
         yield
 
 
-def build_responder(exists, vrf_name="default", **attrs):
+def build_responder(
+    exists, vrf_name="default", responder_interface=None, **attrs
+):
     responder = MagicMock()
     responder.config_attrs = []
     for attr in SCALAR_ATTRS:
         setattr(responder, attr, attrs.get(attr))
     responder.vrf = {vrf_name: "/rest/v10.16/system/vrfs/" + vrf_name}
+    responder.responder_interface = responder_interface
     if exists:
         responder.get.return_value = True
     else:
@@ -88,12 +91,17 @@ def build_responder(exists, vrf_name="default", **attrs):
 
 def build_session(existing, new_instance=None):
     session = MagicMock()
+    session.resource_prefix = "/rest/v10.16/"
     vrf = MagicMock()
     vrf.get.return_value = True
+    interface = MagicMock()
+    interface.get.return_value = True
 
     def get_module(sess, module, index=None, **kwargs):
         if module == "Vrf":
             return vrf
+        if module == "Interface":
+            return interface
         if module == "IpslaResponder":
             if "vrf" in kwargs and new_instance is not None:
                 return new_instance
@@ -126,6 +134,69 @@ def test_create():
     )
     assert result["changed"] is True
     new.create.assert_called_once()
+
+
+def test_create_with_interface():
+    existing = build_responder(False)
+    new = build_responder(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {
+            "name": "resp1",
+            "type": "udp_echo",
+            "responder_port_number": 5000,
+            "responder_interface": "1/1/1",
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_recreate_on_interface_change():
+    uri = "/rest/v10.16/system/interfaces/1%2F1%2F1"
+    existing = build_responder(
+        True,
+        type="udp_echo",
+        responder_port_number=5000,
+        responder_interface={"1/1/1": uri},
+    )
+    new = build_responder(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {
+            "name": "resp1",
+            "type": "udp_echo",
+            "responder_port_number": 5000,
+            "responder_interface": "1/1/2",
+        },
+        session,
+    )
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+    new.create.assert_called_once()
+
+
+def test_interface_idempotent():
+    uri = "/rest/v10.16/system/interfaces/1%2F1%2F1"
+    existing = build_responder(
+        True,
+        type="udp_echo",
+        responder_port_number=5000,
+        responder_interface={"1/1/1": uri},
+    )
+    session = build_session(existing)
+    result = run_module(
+        {
+            "name": "resp1",
+            "type": "udp_echo",
+            "responder_port_number": 5000,
+            "responder_interface": "1/1/1",
+        },
+        session,
+    )
+    assert result["changed"] is False
+    existing.delete.assert_not_called()
 
 
 def test_create_check_mode():

--- a/tests/unit/modules/test_aoscx_ipsla_responder.py
+++ b/tests/unit/modules/test_aoscx_ipsla_responder.py
@@ -1,0 +1,196 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_ipsla_responder module.
+
+The pyaoscx session is fully mocked, so no switch is required.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_ipsla_responder,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_ipsla_responder"
+)
+
+SCALAR_ATTRS = (
+    "type",
+    "responder_port_number",
+    "responder_type",
+    "responder_ip",
+    "persistence",
+)
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_responder(exists, vrf_name="default", **attrs):
+    responder = MagicMock()
+    responder.config_attrs = []
+    for attr in SCALAR_ATTRS:
+        setattr(responder, attr, attrs.get(attr))
+    responder.vrf = {vrf_name: "/rest/v10.16/system/vrfs/" + vrf_name}
+    if exists:
+        responder.get.return_value = True
+    else:
+        responder.get.side_effect = Exception("not found")
+    return responder
+
+
+def build_session(existing, new_instance=None):
+    session = MagicMock()
+    vrf = MagicMock()
+    vrf.get.return_value = True
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "Vrf":
+            return vrf
+        if module == "IpslaResponder":
+            if "vrf" in kwargs and new_instance is not None:
+                return new_instance
+            return existing
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_ipsla_responder.main()
+    return exc.value.args[0]
+
+
+def test_create():
+    existing = build_responder(False)
+    new = build_responder(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {
+            "name": "resp1",
+            "type": "udp_echo",
+            "responder_port_number": 5000,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_check_mode():
+    existing = build_responder(False)
+    new = build_responder(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {
+            "name": "resp1",
+            "type": "udp_echo",
+            "_ansible_check_mode": True,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_not_called()
+
+
+def test_recreate_on_diff():
+    existing = build_responder(
+        True, type="udp_echo", responder_port_number=5000
+    )
+    new = build_responder(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {
+            "name": "resp1",
+            "type": "udp_echo",
+            "responder_port_number": 6000,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+    new.create.assert_called_once()
+
+
+def test_idempotent():
+    existing = build_responder(
+        True, type="udp_echo", responder_port_number=5000
+    )
+    session = build_session(existing)
+    result = run_module(
+        {
+            "name": "resp1",
+            "type": "udp_echo",
+            "responder_port_number": 5000,
+        },
+        session,
+    )
+    assert result["changed"] is False
+    existing.delete.assert_not_called()
+
+
+def test_delete():
+    existing = build_responder(True)
+    session = build_session(existing)
+    result = run_module({"name": "resp1", "state": "delete"}, session)
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+
+
+def test_delete_absent_noop():
+    existing = build_responder(False)
+    session = build_session(existing)
+    result = run_module({"name": "resp1", "state": "delete"}, session)
+    assert result["changed"] is False
+    existing.delete.assert_not_called()

--- a/tests/unit/modules/test_aoscx_ipsla_source.py
+++ b/tests/unit/modules/test_aoscx_ipsla_source.py
@@ -41,6 +41,9 @@ SCALAR_ATTRS = (
     "source_port_number",
     "tos",
     "domain_name_server",
+    "http_sla",
+    "https_sla",
+    "voip_jitter_sla",
 )
 
 
@@ -78,11 +81,12 @@ def patch_ansible_module():
         yield
 
 
-def build_source(exists, **attrs):
+def build_source(exists, source_interface=None, **attrs):
     source = MagicMock()
     source.config_attrs = []
     for attr in SCALAR_ATTRS:
         setattr(source, attr, attrs.get(attr))
+    source.source_interface = source_interface
     if exists:
         source.get.return_value = True
     else:
@@ -92,12 +96,17 @@ def build_source(exists, **attrs):
 
 def build_session(existing, new_instance=None):
     session = MagicMock()
+    session.resource_prefix = "/rest/v10.16/"
     vrf = MagicMock()
     vrf.get.return_value = True
+    interface = MagicMock()
+    interface.get.return_value = True
 
     def get_module(sess, module, index=None, **kwargs):
         if module == "Vrf":
             return vrf
+        if module == "Interface":
+            return interface
         if module == "IpslaSource":
             if "vrf" in kwargs and new_instance is not None:
                 return new_instance
@@ -178,6 +187,63 @@ def test_update_type_is_ignored():
     session = build_session(existing)
     result = run_module(
         {"name": "src1", "state": "update", "type": "udp_echo"},
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_create_with_interface_and_sla():
+    existing = build_source(False)
+    new = build_source(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {
+            "name": "src1",
+            "type": "http",
+            "source_interface": "1/1/1",
+            "http_sla": {
+                "cache_disable": True,
+                "type": "get",
+                "version_number": "1.1",
+            },
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_update_source_interface():
+    uri = "/rest/v10.16/system/interfaces/1%2F1%2F1"
+    existing = build_source(True, source_interface={"1/1/1": uri})
+    session = build_session(existing)
+    result = run_module(
+        {"name": "src1", "state": "update", "source_interface": "1/1/2"},
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_update_source_interface_idempotent():
+    uri = "/rest/v10.16/system/interfaces/1%2F1%2F1"
+    existing = build_source(True, source_interface={"1/1/1": uri})
+    session = build_session(existing)
+    result = run_module(
+        {"name": "src1", "state": "update", "source_interface": "1/1/1"},
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_update_sla_idempotent():
+    sla = {"cache_disable": True, "type": "get", "version_number": "1.1"}
+    existing = build_source(True, http_sla=sla)
+    session = build_session(existing)
+    result = run_module(
+        {"name": "src1", "state": "update", "http_sla": dict(sla)},
         session,
     )
     assert result["changed"] is False

--- a/tests/unit/modules/test_aoscx_ipsla_source.py
+++ b/tests/unit/modules/test_aoscx_ipsla_source.py
@@ -1,0 +1,200 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_ipsla_source module.
+
+The pyaoscx session is fully mocked, so no switch is required.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_ipsla_source,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_ipsla_source"
+)
+
+SCALAR_ATTRS = (
+    "type",
+    "enable",
+    "frequency",
+    "history_interval",
+    "ipsla_timeout",
+    "payload_size",
+    "source_ip",
+    "source_port_number",
+    "tos",
+    "domain_name_server",
+)
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_source(exists, **attrs):
+    source = MagicMock()
+    source.config_attrs = []
+    for attr in SCALAR_ATTRS:
+        setattr(source, attr, attrs.get(attr))
+    if exists:
+        source.get.return_value = True
+    else:
+        source.get.side_effect = Exception("not found")
+    return source
+
+
+def build_session(existing, new_instance=None):
+    session = MagicMock()
+    vrf = MagicMock()
+    vrf.get.return_value = True
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "Vrf":
+            return vrf
+        if module == "IpslaSource":
+            if "vrf" in kwargs and new_instance is not None:
+                return new_instance
+            return existing
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_ipsla_source.main()
+    return exc.value.args[0]
+
+
+def test_create():
+    existing = build_source(False)
+    new = build_source(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {"name": "src1", "type": "icmp_echo", "frequency": 30},
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_check_mode():
+    existing = build_source(False)
+    new = build_source(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {
+            "name": "src1",
+            "type": "icmp_echo",
+            "_ansible_check_mode": True,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_not_called()
+
+
+def test_create_requires_type():
+    existing = build_source(False)
+    session = build_session(existing)
+    result = run_module({"name": "src1"}, session)
+    assert result["failed"] is True
+
+
+def test_update_frequency():
+    existing = build_source(True, frequency=60)
+    session = build_session(existing)
+    result = run_module(
+        {"name": "src1", "state": "update", "frequency": 90},
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_update_idempotent():
+    existing = build_source(True, frequency=60, tos=8)
+    session = build_session(existing)
+    result = run_module(
+        {"name": "src1", "state": "update", "frequency": 60, "tos": 8},
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_update_type_is_ignored():
+    existing = build_source(True, type="icmp_echo")
+    session = build_session(existing)
+    result = run_module(
+        {"name": "src1", "state": "update", "type": "udp_echo"},
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_delete():
+    existing = build_source(True)
+    session = build_session(existing)
+    result = run_module({"name": "src1", "state": "delete"}, session)
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+
+
+def test_delete_absent_noop():
+    existing = build_source(False)
+    session = build_session(existing)
+    result = run_module({"name": "src1", "state": "delete"}, session)
+    assert result["changed"] is False
+    existing.delete.assert_not_called()

--- a/tests/unit/modules/test_aoscx_ipsla_track_object.py
+++ b/tests/unit/modules/test_aoscx_ipsla_track_object.py
@@ -1,0 +1,202 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_ipsla_track_object module.
+
+The pyaoscx session is fully mocked, so no switch is required.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_ipsla_track_object,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_ipsla_track_object"
+)
+
+SCALAR_ATTRS = ("track_list_operator", "up_delay", "down_delay")
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_track(exists, tracked=None, **attrs):
+    track = MagicMock()
+    track.config_attrs = []
+    for attr in SCALAR_ATTRS:
+        setattr(track, attr, attrs.get(attr))
+    track.tracked_ipsla_session = tracked or {}
+    if exists:
+        track.get.return_value = True
+    else:
+        track.get.side_effect = Exception("not found")
+    return track
+
+
+def build_session(existing, new_instance=None):
+    session = MagicMock()
+    source = MagicMock()
+    source.get.return_value = True
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "IpslaSource":
+            return source
+        if module == "IpslaTrackObject":
+            if "tracked_ipsla_session" in kwargs and new_instance is not None:
+                return new_instance
+            return existing
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_ipsla_track_object.main()
+    return exc.value.args[0]
+
+
+def test_create():
+    existing = build_track(False)
+    new = build_track(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {
+            "name": "trk1",
+            "tracked_ipsla_session": ["src1"],
+            "track_list_operator": "or",
+            "up_delay": 5,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_check_mode():
+    existing = build_track(False)
+    new = build_track(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {
+            "name": "trk1",
+            "tracked_ipsla_session": ["src1"],
+            "_ansible_check_mode": True,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_not_called()
+
+
+def test_update_scalar():
+    existing = build_track(True, up_delay=0)
+    session = build_session(existing)
+    result = run_module(
+        {"name": "trk1", "state": "update", "up_delay": 10},
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_update_idempotent():
+    existing = build_track(True, up_delay=5, down_delay=0)
+    session = build_session(existing)
+    result = run_module(
+        {
+            "name": "trk1",
+            "state": "update",
+            "up_delay": 5,
+            "down_delay": 0,
+        },
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_recreate_on_tracked_change():
+    existing = build_track(
+        True,
+        tracked={"old": "/rest/v10.16/system/ipsla_sources/old"},
+    )
+    new = build_track(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {
+            "name": "trk1",
+            "state": "update",
+            "tracked_ipsla_session": ["src1"],
+        },
+        session,
+    )
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+    new.create.assert_called_once()
+
+
+def test_delete():
+    existing = build_track(True)
+    session = build_session(existing)
+    result = run_module({"name": "trk1", "state": "delete"}, session)
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+
+
+def test_delete_absent_noop():
+    existing = build_track(False)
+    session = build_session(existing)
+    result = run_module({"name": "trk1", "state": "delete"}, session)
+    assert result["changed"] is False
+    existing.delete.assert_not_called()


### PR DESCRIPTION
Fixes #198

Collection modules backed by dedicated pyaoscx SDK classes. Depends on SDK PR aruba/pyaoscx#69.

## Depends on
- aruba/pyaoscx#69 — IpslaSource / Responder / TrackObject
- aruba/pyaoscx#119 — REST API version modules `v10.13` / `v10.16` (needed to reach this feature at the 10.13/10.16 REST schema)
