### PR TITLE
Add Traffic Insight modules (instance and monitor)

### DIFF
--- a/changelogs/fragments/aoscx_traffic_insight.yml
+++ b/changelogs/fragments/aoscx_traffic_insight.yml
@@ -1,0 +1,8 @@
+---
+minor_changes:
+  - aoscx_traffic_insight - new module to create, update or delete the AOS-CX
+    Traffic Insight instance (system/traffic_insights).
+  - aoscx_traffic_insight_monitor - new module to create, update or delete
+    Traffic Insight monitors (system/traffic_insight_monitors).
+  - aoscx connection plugin - allow REST API version 10.13, which is required
+    by the IPFIX and Traffic Insight modules.

--- a/docs/aoscx_traffic_insight.md
+++ b/docs/aoscx_traffic_insight.md
@@ -1,0 +1,63 @@
+# module: aoscx_traffic_insight
+
+description: This module provides configuration management of the Traffic
+Insight instance on AOS-CX devices (system/traffic_insights). Traffic Insight
+requires REST API version 10.13 or later (set ansible_aoscx_rest_version to
+10.13). Note that the switch supports a single Traffic Insight instance at a
+time.
+
+##### ARGUMENTS
+
+```YAML
+  name:
+    description: >
+      Name of the Traffic Insight instance. This is the index of the resource
+      under system/traffic_insights.
+    required: true
+    type: str
+  enable:
+    description: Enable or disable the Traffic Insight instance.
+    required: false
+    type: bool
+  source:
+    description: >
+      List of data sources feeding the Traffic Insight instance. The only
+      supported source is ipfix. The supplied list fully replaces the current
+      sources.
+    required: false
+    type: list
+    elements: str
+    choices:
+      - ipfix
+  state:
+    description: Create, update or delete the Traffic Insight instance.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create a Traffic Insight instance
+  aoscx_traffic_insight:
+    name: TI-01
+    enable: true
+    source:
+      - ipfix
+
+- name: Disable a Traffic Insight instance
+  aoscx_traffic_insight:
+    name: TI-01
+    state: update
+    enable: false
+
+- name: Delete a Traffic Insight instance
+  aoscx_traffic_insight:
+    name: TI-01
+    state: delete
+```

--- a/docs/aoscx_traffic_insight_monitor.md
+++ b/docs/aoscx_traffic_insight_monitor.md
@@ -1,0 +1,115 @@
+# module: aoscx_traffic_insight_monitor
+
+description: This module provides configuration management of Traffic Insight
+monitors on AOS-CX devices (system/traffic_insight_monitors). A monitor is
+attached to a Traffic Insight instance and identified by the compound index
+made of the instance name, the monitor name and the monitor type. Traffic
+Insight requires REST API version 10.13 or later (set
+ansible_aoscx_rest_version to 10.13). The filter_by_single_value, group_by,
+monitor_n_flows and running_stats_reset_interval attributes apply to the
+topN-flows monitor type.
+
+##### ARGUMENTS
+
+```YAML
+  traffic_insight_instance:
+    description: >
+      Name of the parent Traffic Insight instance the monitor is attached to.
+      The instance must already exist.
+    required: true
+    type: str
+  monitor_name:
+    description: Name of the monitor.
+    required: true
+    type: str
+  monitor_type:
+    description: Type of the monitor.
+    required: true
+    choices:
+      - topN-flows
+      - application-flows
+      - dns-average-latency
+      - dns-onboarding-latency
+      - raw-flows
+      - dropped-flows
+      - congested-flows
+    type: str
+  filter_by_single_value:
+    description: >
+      Filter applied to the monitor, as a dictionary. Applies to the
+      topN-flows monitor type.
+    required: false
+    type: dict
+  group_by:
+    description: >
+      Grouping key for the monitor. Applies to the topN-flows monitor type.
+    required: false
+    choices:
+      - srcip
+      - dstip
+      - srcport
+      - dstport
+      - ipproto
+      - srcip_dstip
+      - srcip_dstport
+      - appid
+      - srcip_appid
+      - egress_interface
+      - egress_interface_queue
+    type: str
+  monitor_n_flows:
+    description: >
+      Number of flows tracked by the monitor (1 to 20). Applies to the
+      topN-flows monitor type.
+    required: false
+    type: int
+  running_stats_reset_interval:
+    description: >
+      Interval, in seconds, between running statistics resets (360 to 2700).
+      Applies to the topN-flows monitor type.
+    required: false
+    type: int
+  state:
+    description: Create, update or delete the Traffic Insight monitor.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create a topN-flows monitor grouped by application
+  aoscx_traffic_insight_monitor:
+    traffic_insight_instance: TI-01
+    monitor_name: TopN-apps
+    monitor_type: topN-flows
+    group_by: appid
+    monitor_n_flows: 10
+    running_stats_reset_interval: 600
+
+- name: Create an application-flows monitor
+  aoscx_traffic_insight_monitor:
+    traffic_insight_instance: TI-01
+    monitor_name: apps
+    monitor_type: application-flows
+
+- name: Update the number of tracked flows
+  aoscx_traffic_insight_monitor:
+    traffic_insight_instance: TI-01
+    monitor_name: TopN-apps
+    monitor_type: topN-flows
+    state: update
+    monitor_n_flows: 20
+
+- name: Delete a Traffic Insight monitor
+  aoscx_traffic_insight_monitor:
+    traffic_insight_instance: TI-01
+    monitor_name: TopN-apps
+    monitor_type: topN-flows
+    state: delete
+```

--- a/plugins/connection/aoscx.py
+++ b/plugins/connection/aoscx.py
@@ -120,9 +120,10 @@ options:
       - name: ansible_persistent_log_messages
   rest_version:
     description: >
-      Configures REST version, default version is 10.04, but 10.08 or 10.09
-      can be used in a specific host or globaly if it is set as an environment
-      variable.
+      Configures REST version, default version is 10.04, but 10.08, 10.09 or
+      10.13 can be used in a specific host or globaly if it is set as an
+      environment variable. REST version 10.13 is required for IPFIX and
+      Traffic Insight modules.
     default: '10.04'
     env:
       - name: ANSIBLE_AOSCX_REST_VERSION
@@ -208,10 +209,13 @@ class Connection(NetworkConnectionBase):
             password = self.get_option("password")
             self.use_proxy = self.get_option("use_proxy")
             rest_version = self.get_option("rest_version")
-            if rest_version not in ["10.04", "10.08", "10.09"]:
-                raise AnsibleConnectionFailure("Invalid REST version: %s"
-                                               % rest_version)
-            self.base_url = "https://{0}/rest/v{1}/".format(switchip, rest_version)
+            if rest_version not in ["10.04", "10.08", "10.09", "10.13"]:
+                raise AnsibleConnectionFailure(
+                    "Invalid REST version: %s" % rest_version
+                )
+            self.base_url = "https://{0}/rest/v{1}/".format(
+                switchip, rest_version
+            )
             # Set Credentials
             self.__username = username
             self.__password = password

--- a/plugins/modules/aoscx_traffic_insight.py
+++ b/plugins/modules/aoscx_traffic_insight.py
@@ -1,0 +1,198 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_traffic_insight
+version_added: "4.6.0"
+short_description: Create, update or delete a Traffic Insight instance
+description: >
+  This module provides configuration management of the Traffic Insight
+  instance on AOS-CX devices (system/traffic_insights). Traffic Insight
+  requires REST API version 10.13 or later (set ansible_aoscx_rest_version to
+  10.13). Note that the switch supports a single Traffic Insight instance at a
+  time.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: >
+      Name of the Traffic Insight instance. This is the index of the resource
+      under system/traffic_insights.
+    required: true
+    type: str
+  enable:
+    description: Enable or disable the Traffic Insight instance.
+    required: false
+    type: bool
+  source:
+    description: >
+      List of data sources feeding the Traffic Insight instance. The only
+      supported source is ipfix. The supplied list fully replaces the current
+      sources.
+    required: false
+    type: list
+    elements: str
+    choices:
+      - ipfix
+  state:
+    description: Create, update or delete the Traffic Insight instance.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a Traffic Insight instance
+  aoscx_traffic_insight:
+    name: TI-01
+    enable: true
+    source:
+      - ipfix
+
+- name: Disable a Traffic Insight instance
+  aoscx_traffic_insight:
+    name: TI-01
+    state: update
+    enable: false
+
+- name: Delete a Traffic Insight instance
+  aoscx_traffic_insight:
+    name: TI-01
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        name=dict(type="str", required=True),
+        enable=dict(type="bool", required=False, default=None),
+        source=dict(
+            type="list",
+            elements="str",
+            required=False,
+            default=None,
+            choices=["ipfix"],
+        ),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    name = ansible_module.params["name"]
+    state = ansible_module.params["state"]
+
+    scalar_attrs = ["enable", "source"]
+    supplied = {
+        attr: ansible_module.params[attr]
+        for attr in scalar_attrs
+        if ansible_module.params[attr] is not None
+    }
+
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        instance = session.api.get_module(session, "TrafficInsight", name)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support Traffic Insight. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        instance.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                instance.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete Traffic Insight instance: "
+                    "{0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # ------------------------------------------------------- create / update
+    if not exists:
+        instance = session.api.get_module(
+            session, "TrafficInsight", name, **supplied
+        )
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                instance.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create Traffic Insight instance: "
+                    "{0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+    for attr, value in supplied.items():
+        if getattr(instance, attr, None) != value:
+            changed = True
+            setattr(instance, attr, value)
+            if attr not in instance.config_attrs:
+                instance.config_attrs.append(attr)
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            instance.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update Traffic Insight instance: "
+                "{0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_traffic_insight.py
+++ b/plugins/modules/aoscx_traffic_insight.py
@@ -27,6 +27,10 @@ description: >
   10.13). Note that the switch supports a single Traffic Insight instance at a
   time.
 author: Aruba Networks (@ArubaNetworks)
+notes:
+  - Some platforms only expose a single built-in Traffic Insight instance and
+    reject creation of additional instances; in that case the switch returns
+    an error when a new name is created.
 options:
   name:
     description: >

--- a/plugins/modules/aoscx_traffic_insight_monitor.py
+++ b/plugins/modules/aoscx_traffic_insight_monitor.py
@@ -1,0 +1,311 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_traffic_insight_monitor
+version_added: "4.6.0"
+short_description: Create, update or delete a Traffic Insight monitor
+description: >
+  This module provides configuration management of Traffic Insight monitors on
+  AOS-CX devices (system/traffic_insight_monitors). A monitor is attached to a
+  Traffic Insight instance and identified by the compound index made of the
+  instance name, the monitor name and the monitor type. Traffic Insight
+  requires REST API version 10.13 or later (set ansible_aoscx_rest_version to
+  10.13). The filter_by_single_value, group_by, monitor_n_flows and
+  running_stats_reset_interval attributes apply to the topN-flows monitor type.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  traffic_insight_instance:
+    description: >
+      Name of the parent Traffic Insight instance the monitor is attached to.
+      The instance must already exist.
+    required: true
+    type: str
+  monitor_name:
+    description: Name of the monitor.
+    required: true
+    type: str
+  monitor_type:
+    description: Type of the monitor.
+    required: true
+    choices:
+      - topN-flows
+      - application-flows
+      - dns-average-latency
+      - dns-onboarding-latency
+      - raw-flows
+      - dropped-flows
+      - congested-flows
+    type: str
+  filter_by_single_value:
+    description: >
+      Filter applied to the monitor, as a dictionary. Applies to the
+      topN-flows monitor type.
+    required: false
+    type: dict
+  group_by:
+    description: >
+      Grouping key for the monitor. Applies to the topN-flows monitor type.
+    required: false
+    choices:
+      - srcip
+      - dstip
+      - srcport
+      - dstport
+      - ipproto
+      - srcip_dstip
+      - srcip_dstport
+      - appid
+      - srcip_appid
+      - egress_interface
+      - egress_interface_queue
+    type: str
+  monitor_n_flows:
+    description: >
+      Number of flows tracked by the monitor (1 to 20). Applies to the
+      topN-flows monitor type.
+    required: false
+    type: int
+  running_stats_reset_interval:
+    description: >
+      Interval, in seconds, between running statistics resets (360 to 2700).
+      Applies to the topN-flows monitor type.
+    required: false
+    type: int
+  state:
+    description: Create, update or delete the Traffic Insight monitor.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a topN-flows monitor grouped by application
+  aoscx_traffic_insight_monitor:
+    traffic_insight_instance: TI-01
+    monitor_name: TopN-apps
+    monitor_type: topN-flows
+    group_by: appid
+    monitor_n_flows: 10
+    running_stats_reset_interval: 600
+
+- name: Create an application-flows monitor
+  aoscx_traffic_insight_monitor:
+    traffic_insight_instance: TI-01
+    monitor_name: apps
+    monitor_type: application-flows
+
+- name: Update the number of tracked flows
+  aoscx_traffic_insight_monitor:
+    traffic_insight_instance: TI-01
+    monitor_name: TopN-apps
+    monitor_type: topN-flows
+    state: update
+    monitor_n_flows: 20
+
+- name: Delete a Traffic Insight monitor
+  aoscx_traffic_insight_monitor:
+    traffic_insight_instance: TI-01
+    monitor_name: TopN-apps
+    monitor_type: topN-flows
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        traffic_insight_instance=dict(type="str", required=True),
+        monitor_name=dict(type="str", required=True),
+        monitor_type=dict(
+            type="str",
+            required=True,
+            choices=[
+                "topN-flows",
+                "application-flows",
+                "dns-average-latency",
+                "dns-onboarding-latency",
+                "raw-flows",
+                "dropped-flows",
+                "congested-flows",
+            ],
+        ),
+        filter_by_single_value=dict(
+            type="dict", required=False, default=None
+        ),
+        group_by=dict(
+            type="str",
+            required=False,
+            default=None,
+            choices=[
+                "srcip",
+                "dstip",
+                "srcport",
+                "dstport",
+                "ipproto",
+                "srcip_dstip",
+                "srcip_dstport",
+                "appid",
+                "srcip_appid",
+                "egress_interface",
+                "egress_interface_queue",
+            ],
+        ),
+        monitor_n_flows=dict(type="int", required=False, default=None),
+        running_stats_reset_interval=dict(
+            type="int", required=False, default=None
+        ),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    instance_name = ansible_module.params["traffic_insight_instance"]
+    monitor_name = ansible_module.params["monitor_name"]
+    monitor_type = ansible_module.params["monitor_type"]
+    state = ansible_module.params["state"]
+
+    scalar_attrs = [
+        "filter_by_single_value",
+        "group_by",
+        "monitor_n_flows",
+        "running_stats_reset_interval",
+    ]
+    supplied = {
+        attr: ansible_module.params[attr]
+        for attr in scalar_attrs
+        if ansible_module.params[attr] is not None
+    }
+
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        instance = session.api.get_module(
+            session, "TrafficInsight", instance_name
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support Traffic Insight. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        instance.get()
+    except Exception:
+        ansible_module.fail_json(
+            msg="Traffic Insight instance '{0}' does not exist".format(
+                instance_name
+            )
+        )
+
+    monitor = session.api.get_module(
+        session,
+        "TrafficInsightMonitor",
+        instance,
+        monitor_name=monitor_name,
+        monitor_type=monitor_type,
+    )
+
+    try:
+        monitor.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                monitor.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete Traffic Insight monitor: "
+                    "{0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # ------------------------------------------------------- create / update
+    if not exists:
+        monitor = session.api.get_module(
+            session,
+            "TrafficInsightMonitor",
+            instance,
+            monitor_name=monitor_name,
+            monitor_type=monitor_type,
+            **supplied
+        )
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                monitor.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create Traffic Insight monitor: "
+                    "{0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+    for attr, value in supplied.items():
+        if getattr(monitor, attr, None) != value:
+            changed = True
+            setattr(monitor, attr, value)
+            if attr not in monitor.config_attrs:
+                monitor.config_attrs.append(attr)
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            monitor.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update Traffic Insight monitor: "
+                "{0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/aoscx_traffic_insight/aliases
+++ b/tests/integration/targets/aoscx_traffic_insight/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_traffic_insight/tasks/main.yml
+++ b/tests/integration/targets/aoscx_traffic_insight/tasks/main.yml
@@ -1,0 +1,65 @@
+# Integration tests for the aoscx_traffic_insight module.
+#
+# Run with:
+#   ansible-test integration aoscx_traffic_insight --venv
+#
+# Requires an inventory entry named "aoscx" reachable with a pyaoscx release
+# that ships the TrafficInsight class and a REST API version of 10.13 or
+# later. The switch supports a single Traffic Insight instance at a time, so
+# any pre-existing instance must be removed first. Uses a temporary instance
+# named "ansible-test" and cleans up afterwards.
+
+- name: Make sure the test instance does not exist yet
+  arubanetworks.aoscx.aoscx_traffic_insight:
+    name: ansible-test
+    state: delete
+  ignore_errors: true
+
+- name: Create a Traffic Insight instance
+  arubanetworks.aoscx.aoscx_traffic_insight:
+    name: ansible-test
+    enable: true
+    source:
+      - ipfix
+  register: result
+
+- name: Assert the instance was created
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Create the instance again (idempotent)
+  arubanetworks.aoscx.aoscx_traffic_insight:
+    name: ansible-test
+    enable: true
+    source:
+      - ipfix
+  register: result
+
+- name: Assert no change on re-create
+  ansible.builtin.assert:
+    that:
+      - not result.changed
+
+- name: Disable the instance
+  arubanetworks.aoscx.aoscx_traffic_insight:
+    name: ansible-test
+    state: update
+    enable: false
+  register: result
+
+- name: Assert the instance was updated
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Delete the instance
+  arubanetworks.aoscx.aoscx_traffic_insight:
+    name: ansible-test
+    state: delete
+  register: result
+
+- name: Assert the instance was deleted
+  ansible.builtin.assert:
+    that:
+      - result.changed

--- a/tests/integration/targets/aoscx_traffic_insight_monitor/aliases
+++ b/tests/integration/targets/aoscx_traffic_insight_monitor/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_traffic_insight_monitor/tasks/main.yml
+++ b/tests/integration/targets/aoscx_traffic_insight_monitor/tasks/main.yml
@@ -1,0 +1,84 @@
+# Integration tests for the aoscx_traffic_insight_monitor module.
+#
+# Run with:
+#   ansible-test integration aoscx_traffic_insight_monitor --venv
+#
+# Requires an inventory entry named "aoscx" reachable with a pyaoscx release
+# that ships the TrafficInsight and TrafficInsightMonitor classes and a REST
+# API version of 10.13 or later. Creates a temporary instance and monitor
+# named "ansible-test" / "ansible-mon" and cleans up afterwards.
+
+- name: Make sure the test instance does not exist yet
+  arubanetworks.aoscx.aoscx_traffic_insight:
+    name: ansible-test
+    state: delete
+  ignore_errors: true
+
+- name: Create the parent Traffic Insight instance
+  arubanetworks.aoscx.aoscx_traffic_insight:
+    name: ansible-test
+    enable: true
+    source:
+      - ipfix
+
+- name: Create a topN-flows monitor
+  arubanetworks.aoscx.aoscx_traffic_insight_monitor:
+    traffic_insight_instance: ansible-test
+    monitor_name: ansible-mon
+    monitor_type: topN-flows
+    group_by: appid
+    monitor_n_flows: 10
+    running_stats_reset_interval: 600
+  register: result
+
+- name: Assert the monitor was created
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Create the monitor again (idempotent)
+  arubanetworks.aoscx.aoscx_traffic_insight_monitor:
+    traffic_insight_instance: ansible-test
+    monitor_name: ansible-mon
+    monitor_type: topN-flows
+    group_by: appid
+    monitor_n_flows: 10
+    running_stats_reset_interval: 600
+  register: result
+
+- name: Assert no change on re-create
+  ansible.builtin.assert:
+    that:
+      - not result.changed
+
+- name: Update the monitor flow count
+  arubanetworks.aoscx.aoscx_traffic_insight_monitor:
+    traffic_insight_instance: ansible-test
+    monitor_name: ansible-mon
+    monitor_type: topN-flows
+    state: update
+    monitor_n_flows: 20
+  register: result
+
+- name: Assert the monitor was updated
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Delete the monitor
+  arubanetworks.aoscx.aoscx_traffic_insight_monitor:
+    traffic_insight_instance: ansible-test
+    monitor_name: ansible-mon
+    monitor_type: topN-flows
+    state: delete
+  register: result
+
+- name: Assert the monitor was deleted
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Clean up the parent instance
+  arubanetworks.aoscx.aoscx_traffic_insight:
+    name: ansible-test
+    state: delete

--- a/tests/unit/modules/test_aoscx_traffic_insight.py
+++ b/tests/unit/modules/test_aoscx_traffic_insight.py
@@ -1,0 +1,187 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_traffic_insight module.
+
+The pyaoscx session is fully mocked, so no switch is required.
+
+Run with:
+    PYTHONPATH=/tmp/acoll2x .venv/bin/python -m pytest \
+        tests/unit/modules/test_aoscx_traffic_insight.py -v
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_traffic_insight,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_traffic_insight"
+)
+
+
+class AnsibleExitJson(Exception):
+    """Raised by the mocked exit_json to stop module execution."""
+
+
+class AnsibleFailJson(Exception):
+    """Raised by the mocked fail_json to stop module execution."""
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_instance(exists, **attrs):
+    instance = MagicMock()
+    instance.config_attrs = []
+    for attr in ("enable", "source"):
+        setattr(instance, attr, attrs.get(attr))
+    if exists:
+        instance.get.return_value = True
+    else:
+        instance.get.side_effect = Exception("not found")
+    return instance
+
+
+def build_session(existing, new_instance=None):
+    session = MagicMock()
+    scalar_attrs = ("enable", "source")
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "TrafficInsight":
+            if (
+                any(k in kwargs for k in scalar_attrs)
+                and new_instance is not None
+            ):
+                return new_instance
+            return existing
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_traffic_insight.main()
+    return exc.value.args[0]
+
+
+# --------------------------------------------------------------------------
+# Create
+# --------------------------------------------------------------------------
+def test_create():
+    existing = build_instance(False)
+    new = build_instance(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {"name": "TI-01", "enable": True, "source": ["ipfix"]},
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_check_mode():
+    existing = build_instance(False)
+    new = build_instance(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {
+            "name": "TI-01",
+            "enable": True,
+            "_ansible_check_mode": True,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Update
+# --------------------------------------------------------------------------
+def test_update_enable():
+    existing = build_instance(True, enable=True)
+    session = build_session(existing)
+    result = run_module(
+        {"name": "TI-01", "state": "update", "enable": False},
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_update_idempotent():
+    existing = build_instance(True, enable=True, source=["ipfix"])
+    session = build_session(existing)
+    result = run_module(
+        {
+            "name": "TI-01",
+            "state": "update",
+            "enable": True,
+            "source": ["ipfix"],
+        },
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Delete
+# --------------------------------------------------------------------------
+def test_delete():
+    existing = build_instance(True)
+    session = build_session(existing)
+    result = run_module({"name": "TI-01", "state": "delete"}, session)
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+
+
+def test_delete_absent_noop():
+    existing = build_instance(False)
+    session = build_session(existing)
+    result = run_module({"name": "TI-01", "state": "delete"}, session)
+    assert result["changed"] is False
+    existing.delete.assert_not_called()

--- a/tests/unit/modules/test_aoscx_traffic_insight_monitor.py
+++ b/tests/unit/modules/test_aoscx_traffic_insight_monitor.py
@@ -1,0 +1,219 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_traffic_insight_monitor module.
+
+The pyaoscx session is fully mocked, so no switch is required.
+
+Run with:
+    PYTHONPATH=/tmp/acoll2x .venv/bin/python -m pytest \
+        tests/unit/modules/test_aoscx_traffic_insight_monitor.py -v
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_traffic_insight_monitor,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_traffic_insight_monitor"
+)
+
+SCALAR_ATTRS = (
+    "filter_by_single_value",
+    "group_by",
+    "monitor_n_flows",
+    "running_stats_reset_interval",
+)
+
+
+class AnsibleExitJson(Exception):
+    """Raised by the mocked exit_json to stop module execution."""
+
+
+class AnsibleFailJson(Exception):
+    """Raised by the mocked fail_json to stop module execution."""
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_instance(exists=True):
+    instance = MagicMock()
+    if exists:
+        instance.get.return_value = True
+    else:
+        instance.get.side_effect = Exception("not found")
+    return instance
+
+
+def build_monitor(exists, **attrs):
+    monitor = MagicMock()
+    monitor.config_attrs = []
+    for attr in SCALAR_ATTRS:
+        setattr(monitor, attr, attrs.get(attr))
+    if exists:
+        monitor.get.return_value = True
+    else:
+        monitor.get.side_effect = Exception("not found")
+    return monitor
+
+
+def build_session(instance, existing_monitor, new_monitor=None):
+    session = MagicMock()
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "TrafficInsight":
+            return instance
+        if module == "TrafficInsightMonitor":
+            if (
+                any(k in kwargs for k in SCALAR_ATTRS)
+                and new_monitor is not None
+            ):
+                return new_monitor
+            return existing_monitor
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_traffic_insight_monitor.main()
+    return exc.value.args[0]
+
+
+BASE = {
+    "traffic_insight_instance": "TI-01",
+    "monitor_name": "TopN-1",
+    "monitor_type": "topN-flows",
+}
+
+
+# --------------------------------------------------------------------------
+# Create
+# --------------------------------------------------------------------------
+def test_create():
+    instance = build_instance(exists=True)
+    existing = build_monitor(False)
+    new = build_monitor(False)
+    session = build_session(instance, existing, new_monitor=new)
+    args = dict(BASE)
+    args.update({"group_by": "appid", "monitor_n_flows": 10})
+    result = run_module(args, session)
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_check_mode():
+    instance = build_instance(exists=True)
+    existing = build_monitor(False)
+    new = build_monitor(False)
+    session = build_session(instance, existing, new_monitor=new)
+    args = dict(BASE)
+    args.update({"monitor_n_flows": 10, "_ansible_check_mode": True})
+    result = run_module(args, session)
+    assert result["changed"] is True
+    new.create.assert_not_called()
+
+
+def test_missing_parent_fails():
+    instance = build_instance(exists=False)
+    existing = build_monitor(False)
+    session = build_session(instance, existing)
+    args = dict(BASE)
+    result = run_module(args, session)
+    assert result["failed"] is True
+
+
+# --------------------------------------------------------------------------
+# Update
+# --------------------------------------------------------------------------
+def test_update_n_flows():
+    instance = build_instance(exists=True)
+    existing = build_monitor(True, monitor_n_flows=10)
+    session = build_session(instance, existing)
+    args = dict(BASE)
+    args.update({"state": "update", "monitor_n_flows": 15})
+    result = run_module(args, session)
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_update_idempotent():
+    instance = build_instance(exists=True)
+    existing = build_monitor(True, group_by="appid", monitor_n_flows=10)
+    session = build_session(instance, existing)
+    args = dict(BASE)
+    args.update(
+        {"state": "update", "group_by": "appid", "monitor_n_flows": 10}
+    )
+    result = run_module(args, session)
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Delete
+# --------------------------------------------------------------------------
+def test_delete():
+    instance = build_instance(exists=True)
+    existing = build_monitor(True)
+    session = build_session(instance, existing)
+    args = dict(BASE)
+    args.update({"state": "delete"})
+    result = run_module(args, session)
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+
+
+def test_delete_absent_noop():
+    instance = build_instance(exists=True)
+    existing = build_monitor(False)
+    session = build_session(instance, existing)
+    args = dict(BASE)
+    args.update({"state": "delete"})
+    result = run_module(args, session)
+    assert result["changed"] is False
+    existing.delete.assert_not_called()


### PR DESCRIPTION
Fixes #199

Collection modules backed by dedicated pyaoscx SDK classes. Depends on SDK PR aruba/pyaoscx#67.

## Depends on
- aruba/pyaoscx#67 — TrafficInsight / TrafficInsightMonitor
- aruba/pyaoscx#119 — REST API version modules `v10.13` / `v10.16` (needed to reach this feature at the 10.13/10.16 REST schema)
