### PR TITLE
Add aoscx_vni module

### DIFF
--- a/changelogs/fragments/aoscx_vni.yml
+++ b/changelogs/fragments/aoscx_vni.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add ``aoscx_vni`` module to manage VXLAN VNIs.

--- a/docs/aoscx_vni.md
+++ b/docs/aoscx_vni.md
@@ -1,0 +1,90 @@
+# module: aoscx_vni
+
+description: This module provides configuration management of Virtual Network
+Identifiers (VNIs) on AOS-CX devices. A VNI maps a network segment onto a
+VXLAN tunnel interface. A Layer 2 VNI maps the segment to a VLAN, while a
+Layer 3 VNI maps it to a VRF with routing enabled. A VNI is identified by the
+compound index (vni_type, vni_id).
+
+##### ARGUMENTS
+
+```YAML
+  vni_id:
+    description: >
+      Numeric identifier of the VNI (VXLAN Network Identifier), in the range
+      1 to 16777215.
+    required: true
+    type: int
+  interface:
+    description: >
+      Name of the VXLAN tunnel interface the VNI is attached to, for example
+      vxlan1. The interface must already exist and be of type VXLAN.
+    required: true
+    type: str
+  vni_type:
+    description: Type of the VNI. Only VXLAN VNIs are supported.
+    required: false
+    default: vxlan_vni
+    choices:
+      - vxlan_vni
+    type: str
+  vlan:
+    description: >
+      VLAN ID mapped to the VNI for a Layer 2 VNI. Mutually exclusive with
+      vrf. The VLAN must already exist on the device. When omitted it is left
+      unchanged. Ignored when state is delete.
+    required: false
+    type: int
+  vrf:
+    description: >
+      Name of the VRF mapped to the VNI for a Layer 3 VNI. Mutually exclusive
+      with vlan. The VRF must already exist on the device. When omitted it is
+      left unchanged. Ignored when state is delete.
+    required: false
+    type: str
+  routing:
+    description: >
+      Whether routing is enabled for the VNI. Enable it for a Layer 3 (VRF)
+      VNI. When omitted it is left unchanged. Ignored when state is delete.
+    required: false
+    type: bool
+  state:
+    description: Create, update or delete the VNI.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create a Layer 2 VNI mapping VLAN 4000
+  aoscx_vni:
+    vni_id: 40000
+    interface: vxlan1
+    vlan: 4000
+
+- name: Create a Layer 3 VNI mapping a VRF
+  aoscx_vni:
+    vni_id: 50000
+    interface: vxlan1
+    vrf: red
+    routing: true
+
+- name: Update the VLAN mapped to an existing VNI
+  aoscx_vni:
+    vni_id: 40000
+    interface: vxlan1
+    state: update
+    vlan: 4001
+
+- name: Delete a VNI
+  aoscx_vni:
+    vni_id: 40000
+    interface: vxlan1
+    state: delete
+```

--- a/plugins/modules/aoscx_vni.py
+++ b/plugins/modules/aoscx_vni.py
@@ -1,0 +1,311 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_vni
+version_added: "4.6.0"
+short_description: Create, Update or Delete a VXLAN VNI on AOS-CX
+description: >
+  This module provides configuration management of Virtual Network
+  Identifiers (VNIs) on AOS-CX devices. A VNI maps a network segment onto a
+  VXLAN tunnel interface. A Layer 2 VNI maps the segment to a VLAN, while a
+  Layer 3 VNI maps it to a VRF with routing enabled.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  vni_id:
+    description: >
+      Numeric identifier of the VNI (VXLAN Network Identifier), in the range
+      1 to 16777215.
+    required: true
+    type: int
+  interface:
+    description: >
+      Name of the VXLAN tunnel interface the VNI is attached to, for example
+      C(vxlan1). The interface must already exist and be of type VXLAN.
+    required: true
+    type: str
+  vni_type:
+    description: Type of the VNI. Only VXLAN VNIs are supported.
+    required: false
+    default: vxlan_vni
+    choices:
+      - vxlan_vni
+    type: str
+  vlan:
+    description: >
+      VLAN ID mapped to the VNI for a Layer 2 VNI. Mutually exclusive with
+      I(vrf). The VLAN must already exist on the device. When omitted it is
+      left unchanged. Ignored when I(state) is C(delete).
+    required: false
+    type: int
+  vrf:
+    description: >
+      Name of the VRF mapped to the VNI for a Layer 3 VNI. Mutually exclusive
+      with I(vlan). The VRF must already exist on the device. When omitted it
+      is left unchanged. Ignored when I(state) is C(delete).
+    required: false
+    type: str
+  routing:
+    description: >
+      Whether routing is enabled for the VNI. Enable it for a Layer 3 (VRF)
+      VNI. When omitted it is left unchanged. Ignored when I(state) is
+      C(delete).
+    required: false
+    type: bool
+  state:
+    description: Create, update or delete the VNI.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a Layer 2 VNI mapping VLAN 4000
+  aoscx_vni:
+    vni_id: 40000
+    interface: vxlan1
+    vlan: 4000
+
+- name: Create a Layer 3 VNI mapping a VRF
+  aoscx_vni:
+    vni_id: 50000
+    interface: vxlan1
+    vrf: red
+    routing: true
+
+- name: Update the VLAN mapped to an existing VNI
+  aoscx_vni:
+    vni_id: 40000
+    interface: vxlan1
+    state: update
+    vlan: 4001
+
+- name: Delete a VNI
+  aoscx_vni:
+    vni_id: 40000
+    interface: vxlan1
+    state: delete
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the VNI was modified.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+# VXLAN Network Identifiers are 24-bit values, 0 is reserved.
+MIN_VNI_ID = 1
+MAX_VNI_ID = 16777215
+
+
+def main():
+    module_args = dict(
+        vni_id=dict(type="int", required=True),
+        interface=dict(type="str", required=True),
+        vni_type=dict(type="str", default="vxlan_vni", choices=["vxlan_vni"]),
+        vlan=dict(type="int", default=None),
+        vrf=dict(type="str", default=None),
+        routing=dict(type="bool", default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+        mutually_exclusive=[["vlan", "vrf"]],
+    )
+
+    vni_id = ansible_module.params["vni_id"]
+    interface = ansible_module.params["interface"]
+    vni_type = ansible_module.params["vni_type"]
+    vlan = ansible_module.params["vlan"]
+    vrf = ansible_module.params["vrf"]
+    routing = ansible_module.params["routing"]
+    state = ansible_module.params["state"]
+
+    result = dict(changed=False)
+
+    if not MIN_VNI_ID <= vni_id <= MAX_VNI_ID:
+        ansible_module.fail_json(
+            msg="vni_id must be between {0} and {1}.".format(
+                MIN_VNI_ID, MAX_VNI_ID
+            )
+        )
+
+    # Defense in depth: interface and vrf names are interpolated into REST
+    # URIs, reject values that could escape the resource path.
+    if interface in ("", ".", "..") or "," in interface:
+        ansible_module.fail_json(
+            msg="Invalid interface: {0}".format(interface)
+        )
+    if vrf is not None and (
+        vrf in ("", ".", "..") or "," in vrf or "/" in vrf
+    ):
+        ansible_module.fail_json(msg="Invalid vrf: {0}".format(vrf))
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    # Resolve and materialize the VXLAN tunnel interface. The Vni constructor
+    # validates that the interface is of type VXLAN.
+    try:
+        interface_obj = session.api.get_module(session, "Interface", interface)
+        interface_obj.get()
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not find interface {0}: {1}".format(interface, str(e))
+        )
+    if getattr(interface_obj, "type", None) != "vxlan":
+        ansible_module.fail_json(
+            msg="Interface {0} is not a VXLAN interface.".format(interface)
+        )
+
+    try:
+        vni = session.api.get_module(
+            session,
+            "Vni",
+            vni_id,
+            interface=interface_obj,
+            vni_type=vni_type,
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support VNIs. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        vni.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                vni.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete VNI: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # Resolve the mapped VLAN or VRF objects when requested.
+    vlan_obj = None
+    if vlan is not None:
+        try:
+            vlan_obj = session.api.get_module(session, "Vlan", vlan)
+            vlan_obj.get()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not find VLAN {0}: {1}".format(vlan, str(e))
+            )
+
+    vrf_obj = None
+    if vrf is not None:
+        try:
+            vrf_obj = session.api.get_module(session, "Vrf", vrf)
+            vrf_obj.get()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not find VRF {0}: {1}".format(vrf, str(e))
+            )
+
+    # ------------------------------------------------------- create / update
+    if not exists:
+        kwargs = {}
+        if vlan_obj is not None:
+            kwargs["vlan"] = vlan_obj
+        if vrf_obj is not None:
+            kwargs["vrf"] = vrf_obj
+        if routing is not None:
+            kwargs["routing"] = routing
+        vni = session.api.get_module(
+            session,
+            "Vni",
+            vni_id,
+            interface=interface_obj,
+            vni_type=vni_type,
+            **kwargs
+        )
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                vni.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create VNI: {0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+
+    if vlan_obj is not None:
+        current_vlan = getattr(vni, "vlan", None)
+        current_vlan_id = getattr(current_vlan, "id", None)
+        if current_vlan_id != vlan:
+            changed = True
+            vni.vlan = vlan_obj
+
+    if vrf_obj is not None:
+        current_vrf = getattr(vni, "vrf", None)
+        current_vrf_name = getattr(current_vrf, "name", None)
+        if current_vrf_name != vrf:
+            changed = True
+            vni.vrf = vrf_obj
+
+    if routing is not None:
+        if bool(getattr(vni, "routing", False)) != routing:
+            changed = True
+            vni.routing = routing
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            vni.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update VNI: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/aoscx_vni/aliases
+++ b/tests/integration/targets/aoscx_vni/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_vni/tasks/main.yml
+++ b/tests/integration/targets/aoscx_vni/tasks/main.yml
@@ -1,0 +1,91 @@
+# Integration tests for the aoscx_vni module.
+#
+# Run with:
+#   ansible-test integration aoscx_vni --venv
+#
+# Requires an inventory entry named "aoscx" reachable over httpapi with a
+# pyaoscx release that ships the Vni class and the delete_attrs fix, plus an
+# existing VXLAN tunnel interface (vxlan1). Uses an unused VNI id (39990) and
+# a temporary VLAN (3999), and cleans up afterwards.
+
+- name: Make sure the test VNI does not exist yet
+  arubanetworks.aoscx.aoscx_vni:
+    vni_id: 39990
+    interface: vxlan1
+    state: delete
+  ignore_errors: true
+
+- name: Ensure the test VLAN exists
+  arubanetworks.aoscx.aoscx_vlan:
+    vlan_id: 3999
+    name: vni-integration-test
+    state: create
+
+- name: Create a Layer 2 VNI mapping the test VLAN
+  arubanetworks.aoscx.aoscx_vni:
+    vni_id: 39990
+    interface: vxlan1
+    vlan: 3999
+    state: create
+  register: create_result
+
+- name: Assert create changed
+  ansible.builtin.assert:
+    that:
+      - create_result is changed
+
+- name: Re-apply identical configuration
+  arubanetworks.aoscx.aoscx_vni:
+    vni_id: 39990
+    interface: vxlan1
+    vlan: 3999
+    state: create
+  register: idem_result
+
+- name: Assert re-apply did not change
+  ansible.builtin.assert:
+    that:
+      - idem_result is not changed
+
+- name: Reject a non-VXLAN interface
+  arubanetworks.aoscx.aoscx_vni:
+    vni_id: 39990
+    interface: 1/1/1
+    vlan: 3999
+    state: update
+  register: bad_intf
+  ignore_errors: true
+
+- name: Assert the non-VXLAN interface was rejected
+  ansible.builtin.assert:
+    that:
+      - bad_intf is failed
+
+- name: Delete the VNI
+  arubanetworks.aoscx.aoscx_vni:
+    vni_id: 39990
+    interface: vxlan1
+    state: delete
+  register: delete_result
+
+- name: Assert delete changed
+  ansible.builtin.assert:
+    that:
+      - delete_result is changed
+
+- name: Delete again (idempotent)
+  arubanetworks.aoscx.aoscx_vni:
+    vni_id: 39990
+    interface: vxlan1
+    state: delete
+  register: delete_idem
+
+- name: Assert second delete did not change
+  ansible.builtin.assert:
+    that:
+      - delete_idem is not changed
+
+- name: Remove the test VLAN
+  arubanetworks.aoscx.aoscx_vlan:
+    vlan_id: 3999
+    state: delete

--- a/tests/unit/modules/test_aoscx_vni.py
+++ b/tests/unit/modules/test_aoscx_vni.py
@@ -1,0 +1,326 @@
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_vni module.
+
+The pyaoscx session is fully mocked, so no switch is required. The tests
+cover input validation, check mode, idempotency, create, update, delete and
+error handling.
+
+Run with:
+    PYTHONPATH=/tmp/acoll2x .venv/bin/python -m pytest \
+        tests/unit/modules/test_aoscx_vni.py -v
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_vni,
+)
+
+MODULE = "ansible_collections.arubanetworks.aoscx.plugins.modules.aoscx_vni"
+
+
+class AnsibleExitJson(Exception):
+    """Raised by the mocked exit_json to stop module execution."""
+
+
+class AnsibleFailJson(Exception):
+    """Raised by the mocked fail_json to stop module execution."""
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_vni(exists, vlan_id=None, vrf_name=None, routing=False):
+    vni = MagicMock()
+    vni.routing = routing
+    if vlan_id is not None:
+        vlan = MagicMock()
+        vlan.id = vlan_id
+        vni.vlan = vlan
+    else:
+        vni.vlan = None
+    if vrf_name is not None:
+        vrf = MagicMock()
+        vrf.name = vrf_name
+        vni.vrf = vrf
+    else:
+        vni.vrf = None
+    if exists:
+        vni.get.return_value = True
+    else:
+        vni.get.side_effect = Exception("not found")
+    return vni
+
+
+def build_session(existing, new_vni=None, interface_type="vxlan"):
+    session = MagicMock()
+    create_kwargs = ("vlan", "vrf", "routing")
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "Interface":
+            intf = MagicMock()
+            intf.type = interface_type
+            return intf
+        if module == "Vlan":
+            vlan = MagicMock()
+            vlan.id = index
+            return vlan
+        if module == "Vrf":
+            vrf = MagicMock()
+            vrf.name = index
+            return vrf
+        if module == "Vni":
+            if any(k in kwargs for k in create_kwargs) and new_vni is not None:
+                return new_vni
+            return existing
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_vni.main()
+    return exc.value.args[0]
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+def test_invalid_vni_id_rejected():
+    session = build_session(build_vni(False))
+    result = run_module({"vni_id": 0, "interface": "vxlan1"}, session)
+    assert result["failed"] is True
+    assert "vni_id must be between" in result["msg"]
+
+
+def test_invalid_interface_rejected():
+    session = build_session(build_vni(False))
+    result = run_module({"vni_id": 40000, "interface": "a,b"}, session)
+    assert result["failed"] is True
+    assert "Invalid interface" in result["msg"]
+
+
+def test_invalid_vrf_rejected():
+    session = build_session(build_vni(False))
+    result = run_module(
+        {"vni_id": 40000, "interface": "vxlan1", "vrf": "a/b"}, session
+    )
+    assert result["failed"] is True
+    assert "Invalid vrf" in result["msg"]
+
+
+def test_vlan_vrf_mutually_exclusive():
+    session = build_session(build_vni(False))
+    result = run_module(
+        {
+            "vni_id": 40000,
+            "interface": "vxlan1",
+            "vlan": 4000,
+            "vrf": "red",
+        },
+        session,
+    )
+    assert result["failed"] is True
+
+
+def test_non_vxlan_interface_rejected():
+    session = build_session(build_vni(False), interface_type="system")
+    result = run_module(
+        {"vni_id": 40000, "interface": "1/1/1", "vlan": 4000}, session
+    )
+    assert result["failed"] is True
+    assert "not a VXLAN interface" in result["msg"]
+
+
+# --------------------------------------------------------------------------
+# Create
+# --------------------------------------------------------------------------
+def test_create_l2_vni():
+    existing = build_vni(False)
+    new = build_vni(False)
+    session = build_session(existing, new_vni=new)
+    result = run_module(
+        {"vni_id": 40000, "interface": "vxlan1", "vlan": 4000},
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_l3_vni():
+    existing = build_vni(False)
+    new = build_vni(False)
+    session = build_session(existing, new_vni=new)
+    result = run_module(
+        {
+            "vni_id": 50000,
+            "interface": "vxlan1",
+            "vrf": "red",
+            "routing": True,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_check_mode_does_not_write():
+    existing = build_vni(False)
+    new = build_vni(False)
+    session = build_session(existing, new_vni=new)
+    result = run_module(
+        {
+            "vni_id": 40000,
+            "interface": "vxlan1",
+            "vlan": 4000,
+            "_ansible_check_mode": True,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Idempotency / update
+# --------------------------------------------------------------------------
+def test_idempotent_no_change():
+    existing = build_vni(True, vlan_id=4000)
+    session = build_session(existing)
+    result = run_module(
+        {
+            "vni_id": 40000,
+            "interface": "vxlan1",
+            "state": "update",
+            "vlan": 4000,
+        },
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_update_changes_vlan():
+    existing = build_vni(True, vlan_id=4000)
+    session = build_session(existing)
+    result = run_module(
+        {
+            "vni_id": 40000,
+            "interface": "vxlan1",
+            "state": "update",
+            "vlan": 4001,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_update_changes_routing():
+    existing = build_vni(True, vrf_name="red", routing=False)
+    session = build_session(existing)
+    result = run_module(
+        {
+            "vni_id": 50000,
+            "interface": "vxlan1",
+            "state": "update",
+            "routing": True,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_update_unspecified_attrs_left_untouched():
+    existing = build_vni(True, vlan_id=4000)
+    session = build_session(existing)
+    result = run_module(
+        {"vni_id": 40000, "interface": "vxlan1", "state": "update"},
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Delete
+# --------------------------------------------------------------------------
+def test_delete_existing():
+    existing = build_vni(True, vlan_id=4000)
+    session = build_session(existing)
+    result = run_module(
+        {"vni_id": 40000, "interface": "vxlan1", "state": "delete"},
+        session,
+    )
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+
+
+def test_delete_absent_no_change():
+    existing = build_vni(False)
+    session = build_session(existing)
+    result = run_module(
+        {"vni_id": 40000, "interface": "vxlan1", "state": "delete"},
+        session,
+    )
+    assert result["changed"] is False
+    existing.delete.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Error handling
+# --------------------------------------------------------------------------
+def test_create_error_is_reported():
+    existing = build_vni(False)
+    new = build_vni(False)
+    new.create.side_effect = Exception("boom")
+    session = build_session(existing, new_vni=new)
+    result = run_module(
+        {"vni_id": 40000, "interface": "vxlan1", "vlan": 4000},
+        session,
+    )
+    assert result["failed"] is True
+    assert "Could not create VNI" in result["msg"]


### PR DESCRIPTION
Fixes #201

Collection modules backed by dedicated pyaoscx SDK classes. Depends on SDK PR aruba/pyaoscx#57.

## Depends on
No pyaoscx changes required — uses existing pyaoscx classes (Device / Vlan / Interface).
