### PR TITLE
Add AAA server family modules (aaa_server_group, radius_server, tacacs_server)

### DIFF
--- a/changelogs/fragments/aaa.yml
+++ b/changelogs/fragments/aaa.yml
@@ -3,7 +3,8 @@ minor_changes:
   - aoscx_aaa_server_group - new module to create, update or delete AAA server
     groups (system/aaa_server_groups).
   - aoscx_radius_server - new module to create, update or delete RADIUS servers
-    (system/vrfs/{vrf}/radius_servers).
+    (system/vrfs/{vrf}/radius_servers), including authentication, tracking,
+    message-authenticator, IPsec AH/ESP and ClearPass options.
   - aoscx_tacacs_server - new module to create, update or delete TACACS+
     servers (system/vrfs/{vrf}/tacacs_servers).
   - aoscx connection plugin - allow REST API version 10.16, which is required

--- a/changelogs/fragments/aaa.yml
+++ b/changelogs/fragments/aaa.yml
@@ -1,0 +1,10 @@
+---
+minor_changes:
+  - aoscx_aaa_server_group - new module to create, update or delete AAA server
+    groups (system/aaa_server_groups).
+  - aoscx_radius_server - new module to create, update or delete RADIUS servers
+    (system/vrfs/{vrf}/radius_servers).
+  - aoscx_tacacs_server - new module to create, update or delete TACACS+
+    servers (system/vrfs/{vrf}/tacacs_servers).
+  - aoscx connection plugin - allow REST API version 10.16, which is required
+    by the AAA server modules.

--- a/docs/aoscx_aaa_server_group.md
+++ b/docs/aoscx_aaa_server_group.md
@@ -1,0 +1,57 @@
+# module: aoscx_aaa_server_group
+
+description: This module provides configuration management of AAA server
+groups on AOS-CX devices (system/aaa_server_groups). A server group bundles
+RADIUS or TACACS+ servers so they can be referenced together by AAA methods.
+This module requires REST API version 10.16 (set ansible_aoscx_rest_version to
+10.16). The built-in groups (local, none, radius, tacacs) cannot be modified or
+deleted.
+
+##### ARGUMENTS
+
+```YAML
+  group_name:
+    description: >
+      Name of the AAA server group. This is the index of the resource under
+      system/aaa_server_groups (up to 32 characters).
+    required: true
+    type: str
+  group_type:
+    description: >
+      Type of the servers grouped together. Set when the group is created.
+    required: false
+    type: str
+    choices:
+      - none
+      - local
+      - radius
+      - tacacs
+  state:
+    description: Create, update or delete the AAA server group.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create a RADIUS server group
+  aoscx_aaa_server_group:
+    group_name: my-radius
+    group_type: radius
+
+- name: Create a TACACS+ server group
+  aoscx_aaa_server_group:
+    group_name: my-tacacs
+    group_type: tacacs
+
+- name: Delete a server group
+  aoscx_aaa_server_group:
+    group_name: my-radius
+    state: delete
+```

--- a/docs/aoscx_radius_server.md
+++ b/docs/aoscx_radius_server.md
@@ -1,0 +1,146 @@
+# module: aoscx_radius_server
+
+description: This module provides configuration management of RADIUS servers on
+AOS-CX devices (system/vrfs/{vrf}/radius_servers). A RADIUS server is
+identified by the combination of its address, UDP/TCP port and port type within
+a VRF. This module requires REST API version 10.16 (set
+ansible_aoscx_rest_version to 10.16). The address, port, port_type and vrf are
+set when the server is created and cannot be changed afterwards. The passkey is
+write-only; when it is supplied the module always (re)applies it, which is
+reported as a change.
+
+##### ARGUMENTS
+
+```YAML
+  address:
+    description: IP address or hostname of the RADIUS server.
+    required: true
+    type: str
+  vrf:
+    description: Name of the VRF the RADIUS server belongs to.
+    required: false
+    default: default
+    type: str
+  port:
+    description: UDP/TCP port used to reach the RADIUS server (1-65535).
+    required: false
+    default: 1812
+    type: int
+  port_type:
+    description: Transport used to reach the RADIUS server.
+    required: false
+    default: udp
+    type: str
+    choices:
+      - udp
+      - tcp
+  passkey:
+    description: >
+      Shared secret used with the RADIUS server. This value is write-only; the
+      switch only ever returns it encrypted, so when passkey is supplied the
+      module always (re)applies it and reports a change.
+    required: false
+    type: str
+  auth_type:
+    description: Authentication protocol used with the RADIUS server.
+    required: false
+    type: str
+    choices:
+      - pap
+      - chap
+  accounting_udp_port:
+    description: UDP port used for RADIUS accounting (1-65535).
+    required: false
+    type: int
+  retries:
+    description: Number of retransmissions before giving up (0-5).
+    required: false
+    type: int
+  timeout:
+    description: Time in seconds to wait for a server response (1-60).
+    required: false
+    type: int
+  tls_initial_connection_timeout:
+    description: >
+      Time in seconds to wait when establishing a RadSec TLS connection
+      (5-300).
+    required: false
+    type: int
+  msg_authenticator_check:
+    description: Enable Message-Authenticator attribute checking.
+    required: false
+    type: bool
+  tracking_enable:
+    description: Enable server-reachability tracking.
+    required: false
+    type: bool
+  tracking_method:
+    description: Method used to track the server reachability.
+    required: false
+    type: str
+    choices:
+      - status-server
+      - keep-alive
+      - access-request
+  tracking_mode:
+    description: When to track the server reachability.
+    required: false
+    type: str
+    choices:
+      - any
+      - dead-only
+  port_access:
+    description: Method used by port-access to track the server.
+    required: false
+    type: str
+    choices:
+      - status-server
+      - keep-alive
+  server_group:
+    description: >
+      Mapping of AAA server group names to their priority for this server,
+      for example {my-radius: 1}. The referenced groups must already exist.
+      The supplied mapping fully replaces the current group membership.
+    required: false
+    type: dict
+  state:
+    description: Create, update or delete the RADIUS server.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create a RADIUS server
+  aoscx_radius_server:
+    address: 192.0.2.10
+    vrf: default
+    passkey: my-secret
+    auth_type: pap
+    timeout: 10
+
+- name: Create a RADIUS server bound to a server group
+  aoscx_radius_server:
+    address: 192.0.2.11
+    vrf: default
+    passkey: my-secret
+    server_group:
+      my-radius: 1
+
+- name: Update the RADIUS server timeout
+  aoscx_radius_server:
+    address: 192.0.2.10
+    state: update
+    timeout: 20
+
+- name: Delete a RADIUS server
+  aoscx_radius_server:
+    address: 192.0.2.10
+    state: delete
+```

--- a/docs/aoscx_tacacs_server.md
+++ b/docs/aoscx_tacacs_server.md
@@ -1,0 +1,104 @@
+# module: aoscx_tacacs_server
+
+description: This module provides configuration management of TACACS+ servers on
+AOS-CX devices (system/vrfs/{vrf}/tacacs_servers). A TACACS+ server is
+identified by the combination of its address and TCP port within a VRF. This
+module requires REST API version 10.16 (set ansible_aoscx_rest_version to
+10.16). The address, tcp_port and vrf are set when the server is created and
+cannot be changed afterwards. At least one server group must be supplied when
+the server is created. The passkey is write-only; when it is supplied the
+module always (re)applies it, which is reported as a change.
+
+##### ARGUMENTS
+
+```YAML
+  address:
+    description: IP address or hostname of the TACACS+ server.
+    required: true
+    type: str
+  vrf:
+    description: Name of the VRF the TACACS+ server belongs to.
+    required: false
+    default: default
+    type: str
+  tcp_port:
+    description: TCP port used to reach the TACACS+ server (1-65535).
+    required: false
+    default: 49
+    type: int
+  passkey:
+    description: >
+      Shared secret used with the TACACS+ server. This value is write-only;
+      the switch only ever returns it encrypted, so when passkey is supplied
+      the module always (re)applies it and reports a change.
+    required: false
+    type: str
+  group:
+    description: >
+      List of AAA server group names this server belongs to. The referenced
+      groups must already exist. At least one group is required when the
+      server is created. The supplied list fully replaces the current group
+      membership.
+    required: false
+    type: list
+    elements: str
+  default_group_priority:
+    description: >
+      Priority of this server within the default tacacs group (1 or higher).
+    required: false
+    default: 1
+    type: int
+  user_group_priority:
+    description: Priority of this server within a user-defined group.
+    required: false
+    type: int
+  auth_type:
+    description: Authentication protocol used with the TACACS+ server.
+    required: false
+    type: str
+    choices:
+      - pap
+      - chap
+  timeout:
+    description: Time in seconds to wait for a server response (1-60).
+    required: false
+    type: int
+  tracking_enable:
+    description: Enable server-reachability tracking.
+    required: false
+    type: bool
+  state:
+    description: Create, update or delete the TACACS+ server.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create a TACACS+ server
+  aoscx_tacacs_server:
+    address: 192.0.2.20
+    vrf: default
+    passkey: my-secret
+    group:
+      - tacacs
+    auth_type: pap
+    timeout: 10
+
+- name: Update the TACACS+ server timeout
+  aoscx_tacacs_server:
+    address: 192.0.2.20
+    state: update
+    timeout: 20
+
+- name: Delete a TACACS+ server
+  aoscx_tacacs_server:
+    address: 192.0.2.20
+    state: delete
+```

--- a/plugins/connection/aoscx.py
+++ b/plugins/connection/aoscx.py
@@ -120,9 +120,11 @@ options:
       - name: ansible_persistent_log_messages
   rest_version:
     description: >
-      Configures REST version, default version is 10.04, but 10.08 or 10.09
-      can be used in a specific host or globaly if it is set as an environment
-      variable.
+      Configures REST version, default version is 10.04, but 10.08, 10.09 or
+      10.16 can be used in a specific host or globaly if it is set as an
+      environment variable. Version 10.16 is required by the AAA server
+      modules (aoscx_aaa_server_group, aoscx_radius_server,
+      aoscx_tacacs_server).
     default: '10.04'
     env:
       - name: ANSIBLE_AOSCX_REST_VERSION
@@ -208,7 +210,7 @@ class Connection(NetworkConnectionBase):
             password = self.get_option("password")
             self.use_proxy = self.get_option("use_proxy")
             rest_version = self.get_option("rest_version")
-            if rest_version not in ["10.04", "10.08", "10.09"]:
+            if rest_version not in ["10.04", "10.08", "10.09", "10.16"]:
                 raise AnsibleConnectionFailure("Invalid REST version: %s"
                                                % rest_version)
             self.base_url = "https://{0}/rest/v{1}/".format(switchip, rest_version)

--- a/plugins/modules/aoscx_aaa_server_group.py
+++ b/plugins/modules/aoscx_aaa_server_group.py
@@ -1,0 +1,196 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_aaa_server_group
+version_added: "4.6.0"
+short_description: Create, update or delete an AAA server group
+description: >
+  This module provides configuration management of AAA server groups on AOS-CX
+  devices (system/aaa_server_groups). A server group bundles RADIUS or TACACS+
+  servers so they can be referenced together by AAA methods. This module
+  requires REST API version 10.16 (set ansible_aoscx_rest_version to 10.16).
+  The built-in groups (local, none, radius, tacacs) cannot be modified or
+  deleted.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  group_name:
+    description: >
+      Name of the AAA server group. This is the index of the resource under
+      system/aaa_server_groups (up to 32 characters).
+    required: true
+    type: str
+  group_type:
+    description: >
+      Type of the servers grouped together. Set when the group is created.
+    required: false
+    type: str
+    choices:
+      - none
+      - local
+      - radius
+      - tacacs
+  state:
+    description: Create, update or delete the AAA server group.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a RADIUS server group
+  aoscx_aaa_server_group:
+    group_name: my-radius
+    group_type: radius
+
+- name: Create a TACACS+ server group
+  aoscx_aaa_server_group:
+    group_name: my-tacacs
+    group_type: tacacs
+
+- name: Delete a server group
+  aoscx_aaa_server_group:
+    group_name: my-radius
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+BUILTIN_GROUPS = ["local", "none", "radius", "tacacs"]
+
+
+def main():
+    module_args = dict(
+        group_name=dict(type="str", required=True),
+        group_type=dict(
+            type="str",
+            required=False,
+            default=None,
+            choices=["none", "local", "radius", "tacacs"],
+        ),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    group_name = ansible_module.params["group_name"]
+    group_type = ansible_module.params["group_type"]
+    state = ansible_module.params["state"]
+
+    result = dict(changed=False)
+
+    if group_name in BUILTIN_GROUPS:
+        ansible_module.fail_json(
+            msg=(
+                "The built-in AAA server group '{0}' cannot be modified or "
+                "deleted".format(group_name)
+            )
+        )
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        group = session.api.get_module(session, "AaaServerGroup", group_name)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support AAA server groups. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        group.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                group.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete AAA server group: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # --------------------------------------------------------------- create
+    if not exists:
+        if group_type is None:
+            ansible_module.fail_json(
+                msg="group_type is required to create an AAA server group"
+            )
+        group = session.api.get_module(
+            session, "AaaServerGroup", group_name, group_type=group_type
+        )
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                group.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create AAA server group: {0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    # --------------------------------------------------------------- update
+    changed = False
+    if group_type is not None:
+        if getattr(group, "group_type", None) != group_type:
+            changed = True
+            group.group_type = group_type
+            if "group_type" not in group.config_attrs:
+                group.config_attrs.append("group_type")
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            group.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update AAA server group: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_radius_server.py
+++ b/plugins/modules/aoscx_radius_server.py
@@ -29,6 +29,9 @@ description: >
   created and cannot be changed afterwards. The passkey is write-only; when it
   is supplied the module always (re)applies it, which is reported as a change.
 author: Aruba Networks (@ArubaNetworks)
+notes:
+  - When C(passkey) is supplied the module reports changed on every run
+    because the secret cannot be read back from the switch for comparison.
 options:
   address:
     description: IP address or hostname of the RADIUS server.

--- a/plugins/modules/aoscx_radius_server.py
+++ b/plugins/modules/aoscx_radius_server.py
@@ -1,0 +1,392 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_radius_server
+version_added: "4.6.0"
+short_description: Create, update or delete a RADIUS server
+description: >
+  This module provides configuration management of RADIUS servers on AOS-CX
+  devices (system/vrfs/{vrf}/radius_servers). A RADIUS server is identified by
+  the combination of its address, UDP/TCP port and port type within a VRF.
+  This module requires REST API version 10.16 (set ansible_aoscx_rest_version
+  to 10.16). The address, port, port_type and vrf are set when the server is
+  created and cannot be changed afterwards. The passkey is write-only; when it
+  is supplied the module always (re)applies it, which is reported as a change.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  address:
+    description: IP address or hostname of the RADIUS server.
+    required: true
+    type: str
+  vrf:
+    description: Name of the VRF the RADIUS server belongs to.
+    required: false
+    default: default
+    type: str
+  port:
+    description: UDP/TCP port used to reach the RADIUS server (1-65535).
+    required: false
+    default: 1812
+    type: int
+  port_type:
+    description: Transport used to reach the RADIUS server.
+    required: false
+    default: udp
+    type: str
+    choices:
+      - udp
+      - tcp
+  passkey:
+    description: >
+      Shared secret used with the RADIUS server. This value is write-only; the
+      switch only ever returns it encrypted, so when passkey is supplied the
+      module always (re)applies it and reports a change.
+    required: false
+    type: str
+
+  auth_type:
+    description: Authentication protocol used with the RADIUS server.
+    required: false
+    type: str
+    choices:
+      - pap
+      - chap
+  accounting_udp_port:
+    description: UDP port used for RADIUS accounting (1-65535).
+    required: false
+    type: int
+  retries:
+    description: Number of retransmissions before giving up (0-5).
+    required: false
+    type: int
+  timeout:
+    description: Time in seconds to wait for a server response (1-60).
+    required: false
+    type: int
+  tls_initial_connection_timeout:
+    description: >
+      Time in seconds to wait when establishing a RadSec TLS connection
+      (5-300).
+    required: false
+    type: int
+  msg_authenticator_check:
+    description: Enable Message-Authenticator attribute checking.
+    required: false
+    type: bool
+  tracking_enable:
+    description: Enable server-reachability tracking.
+    required: false
+    type: bool
+  tracking_method:
+    description: Method used to track the server reachability.
+    required: false
+    type: str
+    choices:
+      - status-server
+      - keep-alive
+      - access-request
+  tracking_mode:
+    description: When to track the server reachability.
+    required: false
+    type: str
+    choices:
+      - any
+      - dead-only
+  port_access:
+    description: Method used by port-access to track the server.
+    required: false
+    type: str
+    choices:
+      - status-server
+      - keep-alive
+  server_group:
+    description: >
+      Mapping of AAA server group names to their priority for this server,
+      for example {my-radius: 1}. The referenced groups must already exist.
+      The supplied mapping fully replaces the current group membership.
+    required: false
+    type: dict
+  state:
+    description: Create, update or delete the RADIUS server.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a RADIUS server
+  aoscx_radius_server:
+    address: 192.0.2.10
+    vrf: default
+    passkey: my-secret
+    auth_type: pap
+    timeout: 10
+
+- name: Create a RADIUS server bound to a server group
+  aoscx_radius_server:
+    address: 192.0.2.11
+    vrf: default
+    passkey: my-secret
+    server_group:
+      my-radius: 1
+
+- name: Update the RADIUS server timeout
+  aoscx_radius_server:
+    address: 192.0.2.10
+    state: update
+    timeout: 20
+
+- name: Delete a RADIUS server
+  aoscx_radius_server:
+    address: 192.0.2.10
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def server_group_uris(session, ansible_module, mapping):
+    """Validate each group exists and return a {group_uri: priority} dict."""
+    result = {}
+    for name, priority in mapping.items():
+        group = session.api.get_module(session, "AaaServerGroup", name)
+        try:
+            group.get()
+        except Exception:
+            ansible_module.fail_json(
+                msg="Could not find AAA server group {0}".format(name)
+            )
+        uri = "{0}system/aaa_server_groups/{1}".format(
+            session.resource_prefix, name
+        )
+        result[uri] = priority
+    return result
+
+
+def main():
+    module_args = dict(
+        address=dict(type="str", required=True),
+        vrf=dict(type="str", required=False, default="default"),
+        port=dict(type="int", required=False, default=1812),
+        port_type=dict(
+            type="str",
+            required=False,
+            default="udp",
+            choices=["udp", "tcp"],
+        ),
+        passkey=dict(type="str", required=False, default=None, no_log=True),
+        auth_type=dict(
+            type="str",
+            required=False,
+            default=None,
+            choices=["pap", "chap"],
+        ),
+        accounting_udp_port=dict(type="int", required=False, default=None),
+        retries=dict(type="int", required=False, default=None),
+        timeout=dict(type="int", required=False, default=None),
+        tls_initial_connection_timeout=dict(
+            type="int", required=False, default=None
+        ),
+        msg_authenticator_check=dict(
+            type="bool", required=False, default=None
+        ),
+        tracking_enable=dict(type="bool", required=False, default=None),
+        tracking_method=dict(
+            type="str",
+            required=False,
+            default=None,
+            choices=["status-server", "keep-alive", "access-request"],
+        ),
+        tracking_mode=dict(
+            type="str",
+            required=False,
+            default=None,
+            choices=["any", "dead-only"],
+        ),
+        port_access=dict(
+            type="str",
+            required=False,
+            default=None,
+            choices=["status-server", "keep-alive"],
+        ),
+        server_group=dict(type="dict", required=False, default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    address = ansible_module.params["address"]
+    vrf_name = ansible_module.params["vrf"]
+    port = ansible_module.params["port"]
+    port_type = ansible_module.params["port_type"]
+    passkey = ansible_module.params["passkey"]
+    state = ansible_module.params["state"]
+
+    scalar_attrs = [
+        "auth_type",
+        "accounting_udp_port",
+        "retries",
+        "timeout",
+        "tls_initial_connection_timeout",
+        "msg_authenticator_check",
+        "tracking_enable",
+        "tracking_method",
+        "tracking_mode",
+        "port_access",
+    ]
+    supplied = {
+        attr: ansible_module.params[attr]
+        for attr in scalar_attrs
+        if ansible_module.params[attr] is not None
+    }
+
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    vrf = session.api.get_module(session, "Vrf", vrf_name)
+    try:
+        vrf.get()
+    except Exception:
+        ansible_module.fail_json(msg="Could not find VRF, make sure it exists")
+
+    try:
+        server = session.api.get_module(
+            session,
+            "RadiusServer",
+            vrf,
+            address=address,
+            port=port,
+            port_type=port_type,
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support RADIUS servers. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        server.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    desired_groups = None
+    if ansible_module.params["server_group"] is not None:
+        desired_groups = server_group_uris(
+            session, ansible_module, ansible_module.params["server_group"]
+        )
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                server.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete RADIUS server: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # --------------------------------------------------------------- create
+    if not exists:
+        create_kwargs = dict(supplied)
+        if passkey is not None:
+            create_kwargs["passkey"] = passkey
+        if desired_groups is not None:
+            create_kwargs["server_group"] = desired_groups
+        server = session.api.get_module(
+            session,
+            "RadiusServer",
+            vrf,
+            address=address,
+            port=port,
+            port_type=port_type,
+            **create_kwargs
+        )
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                server.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create RADIUS server: {0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    # --------------------------------------------------------------- update
+    changed = False
+    for attr, value in supplied.items():
+        if getattr(server, attr, None) != value:
+            changed = True
+            setattr(server, attr, value)
+            if attr not in server.config_attrs:
+                server.config_attrs.append(attr)
+
+    if desired_groups is not None:
+        if getattr(server, "server_group", None) != desired_groups:
+            changed = True
+            server.server_group = desired_groups
+            if "server_group" not in server.config_attrs:
+                server.config_attrs.append("server_group")
+
+    # passkey is write-only: re-apply whenever it is supplied.
+    if passkey is not None:
+        changed = True
+        server.passkey = passkey
+        if "passkey" not in server.config_attrs:
+            server.config_attrs.append("passkey")
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            server.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update RADIUS server: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_radius_server.py
+++ b/plugins/modules/aoscx_radius_server.py
@@ -131,6 +131,27 @@ options:
       The supplied mapping fully replaces the current group membership.
     required: false
     type: dict
+  ipsec_ah:
+    description: >
+      IPsec Authentication Header settings for the RADIUS server, as a
+      dictionary (for example {ah_null: true}). The C(auth_key) value, when
+      present, is write-only and stored encrypted by the switch.
+    required: false
+    type: dict
+  ipsec_esp:
+    description: >
+      IPsec Encapsulating Security Payload settings for the RADIUS server, as a
+      dictionary (for example {esp_null: true}). Secret values, when present,
+      are write-only and stored encrypted by the switch.
+    required: false
+    type: dict
+  clearpass:
+    description: >
+      ClearPass integration settings for the RADIUS server, as a dictionary.
+      Secret values, when present, are write-only and stored encrypted by the
+      switch.
+    required: false
+    type: dict
   state:
     description: Create, update or delete the RADIUS server.
     required: false
@@ -244,6 +265,9 @@ def main():
             choices=["status-server", "keep-alive"],
         ),
         default_group_priority=dict(type="int", required=False, default=None),
+        ipsec_ah=dict(type="dict", required=False, default=None),
+        ipsec_esp=dict(type="dict", required=False, default=None),
+        clearpass=dict(type="dict", required=False, default=None, no_log=True),
         server_group=dict(type="dict", required=False, default=None),
         state=dict(
             type="str",
@@ -275,6 +299,9 @@ def main():
         "tracking_mode",
         "port_access",
         "default_group_priority",
+        "ipsec_ah",
+        "ipsec_esp",
+        "clearpass",
     ]
     supplied = {
         attr: ansible_module.params[attr]

--- a/plugins/modules/aoscx_radius_server.py
+++ b/plugins/modules/aoscx_radius_server.py
@@ -115,6 +115,12 @@ options:
     choices:
       - status-server
       - keep-alive
+  default_group_priority:
+    description: >
+      Priority of the server within the default server group. Some firmware
+      versions require this value when creating a standalone RADIUS server.
+    required: false
+    type: int
   server_group:
     description: >
       Mapping of AAA server group names to their priority for this server,
@@ -234,6 +240,7 @@ def main():
             default=None,
             choices=["status-server", "keep-alive"],
         ),
+        default_group_priority=dict(type="int", required=False, default=None),
         server_group=dict(type="dict", required=False, default=None),
         state=dict(
             type="str",
@@ -264,6 +271,7 @@ def main():
         "tracking_method",
         "tracking_mode",
         "port_access",
+        "default_group_priority",
     ]
     supplied = {
         attr: ansible_module.params[attr]

--- a/plugins/modules/aoscx_tacacs_server.py
+++ b/plugins/modules/aoscx_tacacs_server.py
@@ -30,6 +30,9 @@ description: >
   server is created. The passkey is write-only; when it is supplied the module
   always (re)applies it, which is reported as a change.
 author: Aruba Networks (@ArubaNetworks)
+notes:
+  - When C(passkey) is supplied the module reports changed on every run
+    because the secret cannot be read back from the switch for comparison.
 options:
   address:
     description: IP address or hostname of the TACACS+ server.

--- a/plugins/modules/aoscx_tacacs_server.py
+++ b/plugins/modules/aoscx_tacacs_server.py
@@ -1,0 +1,334 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_tacacs_server
+version_added: "4.6.0"
+short_description: Create, update or delete a TACACS+ server
+description: >
+  This module provides configuration management of TACACS+ servers on AOS-CX
+  devices (system/vrfs/{vrf}/tacacs_servers). A TACACS+ server is identified by
+  the combination of its address and TCP port within a VRF. This module
+  requires REST API version 10.16 (set ansible_aoscx_rest_version to 10.16).
+  The address, tcp_port and vrf are set when the server is created and cannot
+  be changed afterwards. At least one server group must be supplied when the
+  server is created. The passkey is write-only; when it is supplied the module
+  always (re)applies it, which is reported as a change.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  address:
+    description: IP address or hostname of the TACACS+ server.
+    required: true
+    type: str
+  vrf:
+    description: Name of the VRF the TACACS+ server belongs to.
+    required: false
+    default: default
+    type: str
+  tcp_port:
+    description: TCP port used to reach the TACACS+ server (1-65535).
+    required: false
+    default: 49
+    type: int
+  passkey:
+    description: >
+      Shared secret used with the TACACS+ server. This value is write-only;
+      the switch only ever returns it encrypted, so when passkey is supplied
+      the module always (re)applies it and reports a change.
+    required: false
+    type: str
+  group:
+    description: >
+      List of AAA server group names this server belongs to. The referenced
+      groups must already exist. At least one group is required when the
+      server is created. The supplied list fully replaces the current group
+      membership.
+    required: false
+    type: list
+    elements: str
+  default_group_priority:
+    description: >
+      Priority of this server within the default tacacs group (1 or higher).
+    required: false
+    default: 1
+    type: int
+  user_group_priority:
+    description: Priority of this server within a user-defined group.
+    required: false
+    type: int
+  auth_type:
+    description: Authentication protocol used with the TACACS+ server.
+    required: false
+    type: str
+    choices:
+      - pap
+      - chap
+  timeout:
+    description: Time in seconds to wait for a server response (1-60).
+    required: false
+    type: int
+  tracking_enable:
+    description: Enable server-reachability tracking.
+    required: false
+    type: bool
+  state:
+    description: Create, update or delete the TACACS+ server.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a TACACS+ server
+  aoscx_tacacs_server:
+    address: 192.0.2.20
+    vrf: default
+    passkey: my-secret
+    group:
+      - tacacs
+    auth_type: pap
+    timeout: 10
+
+- name: Update the TACACS+ server timeout
+  aoscx_tacacs_server:
+    address: 192.0.2.20
+    state: update
+    timeout: 20
+
+- name: Delete a TACACS+ server
+  aoscx_tacacs_server:
+    address: 192.0.2.20
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def group_uris(session, ansible_module, names):
+    """Validate each group exists and return a list of group URIs."""
+    uris = []
+    for name in names:
+        group = session.api.get_module(session, "AaaServerGroup", name)
+        try:
+            group.get()
+        except Exception:
+            ansible_module.fail_json(
+                msg="Could not find AAA server group {0}".format(name)
+            )
+        uris.append(
+            "{0}system/aaa_server_groups/{1}".format(
+                session.resource_prefix, name
+            )
+        )
+    return uris
+
+
+def current_group_names(server):
+    """Return the set of group names currently bound to the server."""
+    current = getattr(server, "group", None)
+    if isinstance(current, dict):
+        return set(current.keys())
+    return set()
+
+
+def main():
+    module_args = dict(
+        address=dict(type="str", required=True),
+        vrf=dict(type="str", required=False, default="default"),
+        tcp_port=dict(type="int", required=False, default=49),
+        passkey=dict(type="str", required=False, default=None, no_log=True),
+        group=dict(type="list", elements="str", required=False, default=None),
+        default_group_priority=dict(type="int", required=False, default=1),
+        user_group_priority=dict(type="int", required=False, default=None),
+        auth_type=dict(
+            type="str",
+            required=False,
+            default=None,
+            choices=["pap", "chap"],
+        ),
+        timeout=dict(type="int", required=False, default=None),
+        tracking_enable=dict(type="bool", required=False, default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    address = ansible_module.params["address"]
+    vrf_name = ansible_module.params["vrf"]
+    tcp_port = ansible_module.params["tcp_port"]
+    passkey = ansible_module.params["passkey"]
+    group = ansible_module.params["group"]
+    default_group_priority = ansible_module.params["default_group_priority"]
+    state = ansible_module.params["state"]
+
+    scalar_attrs = [
+        "user_group_priority",
+        "auth_type",
+        "timeout",
+        "tracking_enable",
+    ]
+    supplied = {
+        attr: ansible_module.params[attr]
+        for attr in scalar_attrs
+        if ansible_module.params[attr] is not None
+    }
+
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    vrf = session.api.get_module(session, "Vrf", vrf_name)
+    try:
+        vrf.get()
+    except Exception:
+        ansible_module.fail_json(msg="Could not find VRF, make sure it exists")
+
+    try:
+        server = session.api.get_module(
+            session,
+            "TacacsServer",
+            vrf,
+            address=address,
+            tcp_port=tcp_port,
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support TACACS+ servers. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        server.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    desired_group_uris = None
+    if group is not None:
+        desired_group_uris = group_uris(session, ansible_module, group)
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                server.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete TACACS+ server: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # --------------------------------------------------------------- create
+    if not exists:
+        if not group:
+            ansible_module.fail_json(
+                msg="group is required to create a TACACS+ server"
+            )
+        create_kwargs = dict(supplied)
+        create_kwargs["group"] = desired_group_uris
+        create_kwargs["default_group_priority"] = default_group_priority
+        if passkey is not None:
+            create_kwargs["passkey"] = passkey
+        server = session.api.get_module(
+            session,
+            "TacacsServer",
+            vrf,
+            address=address,
+            tcp_port=tcp_port,
+            **create_kwargs
+        )
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                server.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create TACACS+ server: {0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    # --------------------------------------------------------------- update
+    changed = False
+    for attr, value in supplied.items():
+        if getattr(server, attr, None) != value:
+            changed = True
+            setattr(server, attr, value)
+            if attr not in server.config_attrs:
+                server.config_attrs.append(attr)
+
+    if (
+        ansible_module.params["default_group_priority"] is not None
+        and getattr(server, "default_group_priority", None)
+        != default_group_priority
+    ):
+        changed = True
+        server.default_group_priority = default_group_priority
+        if "default_group_priority" not in server.config_attrs:
+            server.config_attrs.append("default_group_priority")
+
+    if desired_group_uris is not None:
+        if current_group_names(server) != set(group):
+            changed = True
+            server.group = desired_group_uris
+            if "group" not in server.config_attrs:
+                server.config_attrs.append("group")
+
+    # passkey is write-only: re-apply whenever it is supplied.
+    if passkey is not None:
+        changed = True
+        server.passkey = passkey
+        if "passkey" not in server.config_attrs:
+            server.config_attrs.append("passkey")
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            server.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update TACACS+ server: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/aoscx_aaa_server_group/aliases
+++ b/tests/integration/targets/aoscx_aaa_server_group/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_aaa_server_group/tasks/main.yml
+++ b/tests/integration/targets/aoscx_aaa_server_group/tasks/main.yml
@@ -1,0 +1,59 @@
+# Integration tests for the aoscx_aaa_server_group module.
+#
+# Run with:
+#   ansible-test integration aoscx_aaa_server_group --venv
+#
+# Requires an inventory entry named "aoscx" reachable with a pyaoscx release
+# that ships the AaaServerGroup class and a REST API version of 10.16. Uses a
+# temporary group named "ansible-test" and cleans up afterwards.
+
+- name: Make sure the test group does not exist yet
+  arubanetworks.aoscx.aoscx_aaa_server_group:
+    group_name: ansible-test
+    state: delete
+  ignore_errors: true
+
+- name: Create an AAA server group
+  arubanetworks.aoscx.aoscx_aaa_server_group:
+    group_name: ansible-test
+    group_type: radius
+  register: result
+
+- name: Assert the group was created
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Create the group again (idempotent)
+  arubanetworks.aoscx.aoscx_aaa_server_group:
+    group_name: ansible-test
+    group_type: radius
+  register: result
+
+- name: Assert no change on re-create
+  ansible.builtin.assert:
+    that:
+      - not result.changed
+
+- name: Change the group type
+  arubanetworks.aoscx.aoscx_aaa_server_group:
+    group_name: ansible-test
+    state: update
+    group_type: tacacs
+  register: result
+
+- name: Assert the group type changed
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Delete the group
+  arubanetworks.aoscx.aoscx_aaa_server_group:
+    group_name: ansible-test
+    state: delete
+  register: result
+
+- name: Assert the group was deleted
+  ansible.builtin.assert:
+    that:
+      - result.changed

--- a/tests/integration/targets/aoscx_radius_server/aliases
+++ b/tests/integration/targets/aoscx_radius_server/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_radius_server/tasks/main.yml
+++ b/tests/integration/targets/aoscx_radius_server/tasks/main.yml
@@ -1,0 +1,76 @@
+# Integration tests for the aoscx_radius_server module.
+#
+# Run with:
+#   ansible-test integration aoscx_radius_server --venv
+#
+# Requires an inventory entry named "aoscx" reachable with a pyaoscx release
+# that ships the RadiusServer class and a REST API version of 10.16. Uses a
+# documentation-range address (192.0.2.50) and a temporary server group named
+# "ansible-test", and cleans up afterwards.
+
+- name: Make sure the test RADIUS server does not exist yet
+  arubanetworks.aoscx.aoscx_radius_server:
+    address: 192.0.2.50
+    state: delete
+  ignore_errors: true
+
+- name: Create the test server group
+  arubanetworks.aoscx.aoscx_aaa_server_group:
+    group_name: ansible-test
+    group_type: radius
+
+- name: Create a RADIUS server
+  arubanetworks.aoscx.aoscx_radius_server:
+    address: 192.0.2.50
+    vrf: default
+    passkey: testradius
+    auth_type: pap
+    timeout: 10
+    server_group:
+      ansible-test: 1
+  register: result
+
+- name: Assert the server was created
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Update the server timeout
+  arubanetworks.aoscx.aoscx_radius_server:
+    address: 192.0.2.50
+    state: update
+    timeout: 20
+  register: result
+
+- name: Assert the timeout changed
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Update the server timeout again (idempotent)
+  arubanetworks.aoscx.aoscx_radius_server:
+    address: 192.0.2.50
+    state: update
+    timeout: 20
+  register: result
+
+- name: Assert no change on re-update
+  ansible.builtin.assert:
+    that:
+      - not result.changed
+
+- name: Delete the RADIUS server
+  arubanetworks.aoscx.aoscx_radius_server:
+    address: 192.0.2.50
+    state: delete
+  register: result
+
+- name: Assert the server was deleted
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Delete the test server group
+  arubanetworks.aoscx.aoscx_aaa_server_group:
+    group_name: ansible-test
+    state: delete

--- a/tests/integration/targets/aoscx_tacacs_server/aliases
+++ b/tests/integration/targets/aoscx_tacacs_server/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_tacacs_server/tasks/main.yml
+++ b/tests/integration/targets/aoscx_tacacs_server/tasks/main.yml
@@ -1,0 +1,76 @@
+# Integration tests for the aoscx_tacacs_server module.
+#
+# Run with:
+#   ansible-test integration aoscx_tacacs_server --venv
+#
+# Requires an inventory entry named "aoscx" reachable with a pyaoscx release
+# that ships the TacacsServer class and a REST API version of 10.16. Uses a
+# documentation-range address (192.0.2.60) and a temporary server group named
+# "ansible-test", and cleans up afterwards.
+
+- name: Make sure the test TACACS+ server does not exist yet
+  arubanetworks.aoscx.aoscx_tacacs_server:
+    address: 192.0.2.60
+    state: delete
+  ignore_errors: true
+
+- name: Create the test server group
+  arubanetworks.aoscx.aoscx_aaa_server_group:
+    group_name: ansible-test
+    group_type: tacacs
+
+- name: Create a TACACS+ server
+  arubanetworks.aoscx.aoscx_tacacs_server:
+    address: 192.0.2.60
+    vrf: default
+    passkey: testtacacs
+    group:
+      - ansible-test
+    auth_type: pap
+    timeout: 10
+  register: result
+
+- name: Assert the server was created
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Update the server timeout
+  arubanetworks.aoscx.aoscx_tacacs_server:
+    address: 192.0.2.60
+    state: update
+    timeout: 20
+  register: result
+
+- name: Assert the timeout changed
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Update the server timeout again (idempotent)
+  arubanetworks.aoscx.aoscx_tacacs_server:
+    address: 192.0.2.60
+    state: update
+    timeout: 20
+  register: result
+
+- name: Assert no change on re-update
+  ansible.builtin.assert:
+    that:
+      - not result.changed
+
+- name: Delete the TACACS+ server
+  arubanetworks.aoscx.aoscx_tacacs_server:
+    address: 192.0.2.60
+    state: delete
+  register: result
+
+- name: Assert the server was deleted
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Delete the test server group
+  arubanetworks.aoscx.aoscx_aaa_server_group:
+    group_name: ansible-test
+    state: delete

--- a/tests/unit/modules/test_aoscx_aaa_server_group.py
+++ b/tests/unit/modules/test_aoscx_aaa_server_group.py
@@ -1,0 +1,180 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_aaa_server_group module.
+
+The pyaoscx session is fully mocked, so no switch is required.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_aaa_server_group,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_aaa_server_group"
+)
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_group(exists, group_type=None):
+    group = MagicMock()
+    group.config_attrs = []
+    group.group_type = group_type
+    if exists:
+        group.get.return_value = True
+    else:
+        group.get.side_effect = Exception("not found")
+    return group
+
+
+def build_session(existing, new_instance=None):
+    session = MagicMock()
+    session.resource_prefix = "/rest/v10.16/"
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "AaaServerGroup":
+            if "group_type" in kwargs and new_instance is not None:
+                return new_instance
+            return existing
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_aaa_server_group.main()
+    return exc.value.args[0]
+
+
+def test_create():
+    existing = build_group(False)
+    new = build_group(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {"group_name": "grp1", "group_type": "radius"}, session
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_check_mode():
+    existing = build_group(False)
+    new = build_group(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {
+            "group_name": "grp1",
+            "group_type": "radius",
+            "_ansible_check_mode": True,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_not_called()
+
+
+def test_create_requires_group_type():
+    existing = build_group(False)
+    session = build_session(existing)
+    result = run_module({"group_name": "grp1"}, session)
+    assert result["failed"] is True
+
+
+def test_builtin_group_rejected():
+    existing = build_group(True)
+    session = build_session(existing)
+    result = run_module(
+        {"group_name": "radius", "group_type": "radius"}, session
+    )
+    assert result["failed"] is True
+
+
+def test_update_group_type():
+    existing = build_group(True, group_type="radius")
+    session = build_session(existing)
+    result = run_module(
+        {"group_name": "grp1", "state": "update", "group_type": "tacacs"},
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_update_idempotent():
+    existing = build_group(True, group_type="radius")
+    session = build_session(existing)
+    result = run_module(
+        {"group_name": "grp1", "state": "update", "group_type": "radius"},
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_delete():
+    existing = build_group(True)
+    session = build_session(existing)
+    result = run_module({"group_name": "grp1", "state": "delete"}, session)
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+
+
+def test_delete_absent():
+    existing = build_group(False)
+    session = build_session(existing)
+    result = run_module({"group_name": "grp1", "state": "delete"}, session)
+    assert result["changed"] is False
+    existing.delete.assert_not_called()

--- a/tests/unit/modules/test_aoscx_radius_server.py
+++ b/tests/unit/modules/test_aoscx_radius_server.py
@@ -1,0 +1,253 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_radius_server module.
+
+The pyaoscx session is fully mocked, so no switch is required.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_radius_server,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_radius_server"
+)
+
+SCALAR_ATTRS = (
+    "auth_type",
+    "accounting_udp_port",
+    "retries",
+    "timeout",
+    "tls_initial_connection_timeout",
+    "msg_authenticator_check",
+    "tracking_enable",
+    "tracking_method",
+    "tracking_mode",
+    "port_access",
+)
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_server(exists, server_group=None, **attrs):
+    server = MagicMock()
+    server.config_attrs = []
+    for attr in SCALAR_ATTRS:
+        setattr(server, attr, attrs.get(attr))
+    server.server_group = server_group
+    if exists:
+        server.get.return_value = True
+    else:
+        server.get.side_effect = Exception("not found")
+    return server
+
+
+def build_session(existing, new_instance=None):
+    session = MagicMock()
+    session.resource_prefix = "/rest/v10.16/"
+    vrf = MagicMock()
+    vrf.get.return_value = True
+    group = MagicMock()
+    group.get.return_value = True
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "Vrf":
+            return vrf
+        if module == "AaaServerGroup":
+            return group
+        if module == "RadiusServer":
+            has_attrs = any(
+                k in kwargs
+                for k in (
+                    "passkey",
+                    "server_group",
+                    "timeout",
+                    "auth_type",
+                )
+            )
+            if has_attrs and new_instance is not None:
+                return new_instance
+            return existing
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_radius_server.main()
+    return exc.value.args[0]
+
+
+def test_create():
+    existing = build_server(False)
+    new = build_server(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {"address": "192.0.2.10", "passkey": "secret", "timeout": 10},
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_check_mode():
+    existing = build_server(False)
+    new = build_server(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {
+            "address": "192.0.2.10",
+            "passkey": "secret",
+            "_ansible_check_mode": True,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_not_called()
+
+
+def test_create_with_server_group():
+    existing = build_server(False)
+    new = build_server(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {
+            "address": "192.0.2.10",
+            "passkey": "secret",
+            "server_group": {"my-radius": 1},
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_update_timeout():
+    existing = build_server(True, timeout=10)
+    session = build_session(existing)
+    result = run_module(
+        {"address": "192.0.2.10", "state": "update", "timeout": 20},
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_update_idempotent():
+    existing = build_server(True, timeout=10, auth_type="pap")
+    session = build_session(existing)
+    result = run_module(
+        {
+            "address": "192.0.2.10",
+            "state": "update",
+            "timeout": 10,
+            "auth_type": "pap",
+        },
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_update_passkey_always_changes():
+    existing = build_server(True, timeout=10)
+    session = build_session(existing)
+    result = run_module(
+        {"address": "192.0.2.10", "state": "update", "passkey": "secret"},
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_update_server_group():
+    uri = "/rest/v10.16/system/aaa_server_groups/my-radius"
+    existing = build_server(True, server_group={uri: 2})
+    session = build_session(existing)
+    result = run_module(
+        {
+            "address": "192.0.2.10",
+            "state": "update",
+            "server_group": {"my-radius": 1},
+        },
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_update_server_group_idempotent():
+    uri = "/rest/v10.16/system/aaa_server_groups/my-radius"
+    existing = build_server(True, server_group={uri: 1})
+    session = build_session(existing)
+    result = run_module(
+        {
+            "address": "192.0.2.10",
+            "state": "update",
+            "server_group": {"my-radius": 1},
+        },
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_delete():
+    existing = build_server(True)
+    session = build_session(existing)
+    result = run_module({"address": "192.0.2.10", "state": "delete"}, session)
+    assert result["changed"] is True
+    existing.delete.assert_called_once()

--- a/tests/unit/modules/test_aoscx_tacacs_server.py
+++ b/tests/unit/modules/test_aoscx_tacacs_server.py
@@ -1,0 +1,236 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_tacacs_server module.
+
+The pyaoscx session is fully mocked, so no switch is required.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_tacacs_server,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_tacacs_server"
+)
+
+SCALAR_ATTRS = (
+    "user_group_priority",
+    "auth_type",
+    "timeout",
+    "tracking_enable",
+)
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_server(exists, group=None, default_group_priority=1, **attrs):
+    server = MagicMock()
+    server.config_attrs = []
+    for attr in SCALAR_ATTRS:
+        setattr(server, attr, attrs.get(attr))
+    server.group = group
+    server.default_group_priority = default_group_priority
+    if exists:
+        server.get.return_value = True
+    else:
+        server.get.side_effect = Exception("not found")
+    return server
+
+
+def build_session(existing, new_instance=None):
+    session = MagicMock()
+    session.resource_prefix = "/rest/v10.16/"
+    vrf = MagicMock()
+    vrf.get.return_value = True
+    group_obj = MagicMock()
+    group_obj.get.return_value = True
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "Vrf":
+            return vrf
+        if module == "AaaServerGroup":
+            return group_obj
+        if module == "TacacsServer":
+            if "group" in kwargs and new_instance is not None:
+                return new_instance
+            return existing
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_tacacs_server.main()
+    return exc.value.args[0]
+
+
+def test_create():
+    existing = build_server(False)
+    new = build_server(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {
+            "address": "192.0.2.20",
+            "passkey": "secret",
+            "group": ["tacacs"],
+            "timeout": 10,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_requires_group():
+    existing = build_server(False)
+    session = build_session(existing)
+    result = run_module(
+        {"address": "192.0.2.20", "passkey": "secret"}, session
+    )
+    assert result["failed"] is True
+
+
+def test_create_check_mode():
+    existing = build_server(False)
+    new = build_server(False)
+    session = build_session(existing, new_instance=new)
+    result = run_module(
+        {
+            "address": "192.0.2.20",
+            "group": ["tacacs"],
+            "_ansible_check_mode": True,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_not_called()
+
+
+def test_update_timeout():
+    existing = build_server(True, timeout=10)
+    session = build_session(existing)
+    result = run_module(
+        {"address": "192.0.2.20", "state": "update", "timeout": 20},
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_update_idempotent():
+    existing = build_server(True, timeout=10, default_group_priority=1)
+    session = build_session(existing)
+    result = run_module(
+        {"address": "192.0.2.20", "state": "update", "timeout": 10},
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_update_group():
+    existing = build_server(
+        True,
+        group={"tacacs": "/rest/v10.16/system/aaa_server_groups/tacacs"},
+    )
+    session = build_session(existing)
+    result = run_module(
+        {
+            "address": "192.0.2.20",
+            "state": "update",
+            "group": ["my-tacacs"],
+        },
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_update_group_idempotent():
+    existing = build_server(
+        True,
+        group={"tacacs": "/rest/v10.16/system/aaa_server_groups/tacacs"},
+    )
+    session = build_session(existing)
+    result = run_module(
+        {
+            "address": "192.0.2.20",
+            "state": "update",
+            "group": ["tacacs"],
+        },
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_update_passkey_always_changes():
+    existing = build_server(True, timeout=10)
+    session = build_session(existing)
+    result = run_module(
+        {"address": "192.0.2.20", "state": "update", "passkey": "secret"},
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_delete():
+    existing = build_server(True)
+    session = build_session(existing)
+    result = run_module({"address": "192.0.2.20", "state": "delete"}, session)
+    assert result["changed"] is True
+    existing.delete.assert_called_once()


### PR DESCRIPTION
Fixes #186

Collection modules backed by dedicated pyaoscx SDK classes. Depends on SDK PR aruba/pyaoscx#71.

## Depends on
- aruba/pyaoscx#71 — AAA server family (AaaServerGroup, RadiusServer, TacacsServer)
