### PR TITLE
Add IPFIX flow record, exporter and monitor modules

### DIFF
--- a/changelogs/fragments/aoscx_ipfix.yml
+++ b/changelogs/fragments/aoscx_ipfix.yml
@@ -1,0 +1,12 @@
+---
+minor_changes:
+  - Add aoscx_ipfix_flow_record module to manage IPFIX flow records (match and
+    collect fields). Requires REST API version 10.13 or later.
+  - Add aoscx_ipfix_flow_exporter module to manage IPFIX flow exporters
+    (collector or Traffic Insight destinations). Requires REST API version
+    10.13 or later.
+  - Add aoscx_ipfix_flow_monitor module to manage IPFIX flow monitors that bind
+    a flow record to one or more flow exporters. Requires REST API version
+    10.13 or later.
+  - Allow REST API version 10.13 in the aoscx connection plugin, required by
+    the IPFIX modules.

--- a/docs/aoscx_ipfix_flow_exporter.md
+++ b/docs/aoscx_ipfix_flow_exporter.md
@@ -1,0 +1,103 @@
+# module: aoscx_ipfix_flow_exporter
+
+description: This module provides configuration management of IPFIX flow
+exporters on AOS-CX devices. A flow exporter defines the destination to which
+IPFIX flow data is exported, either a collector reachable by hostname or IP
+address through a VRF, or a local Traffic Insight instance. IPFIX requires REST
+API version 10.13 or later (set ansible_aoscx_rest_version to 10.13).
+
+##### ARGUMENTS
+
+```YAML
+  name:
+    description: >
+      Name of the flow exporter. This is the index of the resource under
+      system/ipfix_flow_exporters.
+    required: true
+    type: str
+  description:
+    description: Free form description of the flow exporter.
+    required: false
+    type: str
+  destination_type:
+    description: >
+      Type of the export destination. Use hostname-or-ip-addr to export to a
+      collector, or traffic-insight to export to a local Traffic Insight
+      instance.
+    required: false
+    choices:
+      - hostname-or-ip-addr
+      - traffic-insight
+    type: str
+  destination:
+    description: >
+      Hostname or IP address of the collector. Used when destination_type is
+      hostname-or-ip-addr.
+    required: false
+    type: str
+  vrf:
+    description: >
+      Name of the VRF used to reach the collector. Used together with
+      destination.
+    required: false
+    default: default
+    type: str
+  traffic_insight:
+    description: >
+      Name of the Traffic Insight instance to export to. Used when
+      destination_type is traffic-insight.
+    required: false
+    type: str
+  template_data_timeout:
+    description: >
+      Interval, in seconds, between transmissions of the IPFIX template and
+      options data (0-86400).
+    required: false
+    type: int
+  transport_port:
+    description: >
+      UDP destination port used to export flow data (1-65535).
+    required: false
+    type: int
+  transport_protocol:
+    description: Transport protocol used to export flow data.
+    required: false
+    default: udp
+    choices:
+      - udp
+    type: str
+  state:
+    description: Create, update or delete the flow exporter.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create an IPFIX flow exporter to a collector
+  aoscx_ipfix_flow_exporter:
+    name: collector-1
+    description: Export to collector 1
+    destination_type: hostname-or-ip-addr
+    destination: 10.0.0.5
+    vrf: default
+    transport_port: 4739
+    template_data_timeout: 600
+
+- name: Create an IPFIX flow exporter to a Traffic Insight instance
+  aoscx_ipfix_flow_exporter:
+    name: ti-exporter
+    destination_type: traffic-insight
+    traffic_insight: TI-01
+
+- name: Delete a flow exporter
+  aoscx_ipfix_flow_exporter:
+    name: collector-1
+    state: delete
+```

--- a/docs/aoscx_ipfix_flow_monitor.md
+++ b/docs/aoscx_ipfix_flow_monitor.md
@@ -1,0 +1,81 @@
+# module: aoscx_ipfix_flow_monitor
+
+description: This module provides configuration management of IPFIX flow
+monitors on AOS-CX devices. A flow monitor binds a flow record to one or more
+flow exporters and controls the flow cache timeouts. IPFIX requires REST API
+version 10.13 or later (set ansible_aoscx_rest_version to 10.13). The
+referenced flow record and flow exporters must already exist on the device.
+
+##### ARGUMENTS
+
+```YAML
+  name:
+    description: >
+      Name of the flow monitor. This is the index of the resource under
+      system/ipfix_flow_monitors.
+    required: true
+    type: str
+  description:
+    description: Free form description of the flow monitor.
+    required: false
+    type: str
+  cache_timeout_active:
+    description: >
+      Active flow cache timeout in seconds (30-604800).
+    required: false
+    type: int
+  cache_timeout_inactive:
+    description: >
+      Inactive flow cache timeout in seconds (30-604800).
+    required: false
+    type: int
+  exporters:
+    description: >
+      List of flow exporter names to bind to this monitor. The exporters must
+      already exist on the device.
+    required: false
+    type: list
+    elements: str
+  record:
+    description: >
+      Name of the flow record to bind to this monitor. The record must already
+      exist on the device.
+    required: false
+    type: str
+  state:
+    description: Create, update or delete the flow monitor.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create an IPFIX flow monitor binding a record and an exporter
+  aoscx_ipfix_flow_monitor:
+    name: monitor-1
+    description: Monitor ipv4 flows
+    record: ipv4-record
+    exporters:
+      - collector-1
+    cache_timeout_active: 60
+    cache_timeout_inactive: 30
+
+- name: Update the exporters bound to a flow monitor
+  aoscx_ipfix_flow_monitor:
+    name: monitor-1
+    state: update
+    exporters:
+      - collector-1
+      - collector-2
+
+- name: Delete a flow monitor
+  aoscx_ipfix_flow_monitor:
+    name: monitor-1
+    state: delete
+```

--- a/docs/aoscx_ipfix_flow_record.md
+++ b/docs/aoscx_ipfix_flow_record.md
@@ -1,0 +1,78 @@
+# module: aoscx_ipfix_flow_record
+
+description: This module provides configuration management of IPFIX flow
+records on AOS-CX devices. A flow record defines the key fields (match) and
+non-key fields (collect) included in exported IPFIX flows. IPFIX requires REST
+API version 10.13 or later (set ansible_aoscx_rest_version to 10.13).
+
+##### ARGUMENTS
+
+```YAML
+  name:
+    description: >
+      Name of the flow record. This is the index of the resource under
+      system/ipfix_flow_records.
+    required: true
+    type: str
+  description:
+    description: Free form description of the flow record.
+    required: false
+    type: str
+  match:
+    description: >
+      Key fields for the flow record, as a dictionary mapping a field name to
+      a boolean. Valid keys are ipv4_source_address, ipv4_destination_address,
+      ipv4_protocol, ipv4_version, ipv6_source_address,
+      ipv6_destination_address, ipv6_protocol, ipv6_version,
+      transport_source_port and transport_destination_port. The supplied
+      dictionary fully replaces the current key fields.
+    required: false
+    type: dict
+  collect:
+    description: >
+      Non-key fields for the flow record, as a dictionary mapping a field name
+      to a boolean (for example counter_bytes, counter_packets,
+      application_name, egress_interface). The supplied dictionary fully
+      replaces the current non-key fields.
+    required: false
+    type: dict
+  state:
+    description: Create, update or delete the flow record.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create an IPFIX flow record for IPv4 flows
+  aoscx_ipfix_flow_record:
+    name: ipv4-record
+    description: Record ipv4 flows
+    match:
+      ipv4_source_address: true
+      ipv4_destination_address: true
+      ipv4_protocol: true
+    collect:
+      counter_bytes: true
+      counter_packets: true
+
+- name: Update the collected fields of a flow record
+  aoscx_ipfix_flow_record:
+    name: ipv4-record
+    state: update
+    collect:
+      counter_bytes: true
+      counter_packets: true
+      application_name: true
+
+- name: Delete a flow record
+  aoscx_ipfix_flow_record:
+    name: ipv4-record
+    state: delete
+```

--- a/plugins/connection/aoscx.py
+++ b/plugins/connection/aoscx.py
@@ -120,9 +120,9 @@ options:
       - name: ansible_persistent_log_messages
   rest_version:
     description: >
-      Configures REST version, default version is 10.04, but 10.08 or 10.09
-      can be used in a specific host or globaly if it is set as an environment
-      variable.
+      Configures REST version, default version is 10.04, but 10.08, 10.09 or
+      10.13 can be used in a specific host or globaly if it is set as an
+      environment variable. REST version 10.13 is required for IPFIX modules.
     default: '10.04'
     env:
       - name: ANSIBLE_AOSCX_REST_VERSION
@@ -208,10 +208,13 @@ class Connection(NetworkConnectionBase):
             password = self.get_option("password")
             self.use_proxy = self.get_option("use_proxy")
             rest_version = self.get_option("rest_version")
-            if rest_version not in ["10.04", "10.08", "10.09"]:
-                raise AnsibleConnectionFailure("Invalid REST version: %s"
-                                               % rest_version)
-            self.base_url = "https://{0}/rest/v{1}/".format(switchip, rest_version)
+            if rest_version not in ["10.04", "10.08", "10.09", "10.13"]:
+                raise AnsibleConnectionFailure(
+                    "Invalid REST version: %s" % rest_version
+                )
+            self.base_url = "https://{0}/rest/v{1}/".format(
+                switchip, rest_version
+            )
             # Set Credentials
             self.__username = username
             self.__password = password

--- a/plugins/modules/aoscx_ipfix_flow_exporter.py
+++ b/plugins/modules/aoscx_ipfix_flow_exporter.py
@@ -1,0 +1,259 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_ipfix_flow_exporter
+version_added: "4.6.0"
+short_description: Create, update or delete an IPFIX flow exporter on AOS-CX
+description: >
+  This module provides configuration management of IPFIX flow exporters on
+  AOS-CX devices. A flow exporter defines the destination to which IPFIX flow
+  data is exported, either a collector reachable by hostname or IP address
+  through a VRF, or a local Traffic Insight instance. IPFIX requires REST API
+  version 10.13 or later (set ansible_aoscx_rest_version to 10.13).
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: >
+      Name of the flow exporter. This is the index of the resource under
+      system/ipfix_flow_exporters.
+    required: true
+    type: str
+  description:
+    description: Free form description of the flow exporter.
+    required: false
+    type: str
+  destination_type:
+    description: >
+      Type of the export destination. Use hostname-or-ip-addr to export to a
+      collector, or traffic-insight to export to a local Traffic Insight
+      instance.
+    required: false
+    choices:
+      - hostname-or-ip-addr
+      - traffic-insight
+    type: str
+  destination:
+    description: >
+      Hostname or IP address of the collector. Used when destination_type is
+      hostname-or-ip-addr.
+    required: false
+    type: str
+  vrf:
+    description: >
+      Name of the VRF used to reach the collector. Used together with
+      destination.
+    required: false
+    default: default
+    type: str
+  traffic_insight:
+    description: >
+      Name of the Traffic Insight instance to export to. Used when
+      destination_type is traffic-insight.
+    required: false
+    type: str
+  template_data_timeout:
+    description: >
+      Interval, in seconds, between transmissions of the IPFIX template and
+      options data (0-86400).
+    required: false
+    type: int
+  transport_port:
+    description: >
+      UDP destination port used to export flow data (1-65535).
+    required: false
+    type: int
+  transport_protocol:
+    description: Transport protocol used to export flow data.
+    required: false
+    default: udp
+    choices:
+      - udp
+    type: str
+  state:
+    description: Create, update or delete the flow exporter.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create an IPFIX flow exporter to a collector
+  aoscx_ipfix_flow_exporter:
+    name: collector-1
+    description: Export to collector 1
+    destination_type: hostname-or-ip-addr
+    destination: 10.0.0.5
+    vrf: default
+    transport_port: 4739
+    template_data_timeout: 600
+
+- name: Create an IPFIX flow exporter to a Traffic Insight instance
+  aoscx_ipfix_flow_exporter:
+    name: ti-exporter
+    destination_type: traffic-insight
+    traffic_insight: TI-01
+
+- name: Delete a flow exporter
+  aoscx_ipfix_flow_exporter:
+    name: collector-1
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        name=dict(type="str", required=True),
+        description=dict(type="str", required=False, default=None),
+        destination_type=dict(
+            type="str",
+            required=False,
+            default=None,
+            choices=["hostname-or-ip-addr", "traffic-insight"],
+        ),
+        destination=dict(type="str", required=False, default=None),
+        vrf=dict(type="str", required=False, default="default"),
+        traffic_insight=dict(type="str", required=False, default=None),
+        template_data_timeout=dict(type="int", required=False, default=None),
+        transport_port=dict(type="int", required=False, default=None),
+        transport_protocol=dict(
+            type="str", required=False, default="udp", choices=["udp"]
+        ),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    params = ansible_module.params
+    name = params["name"]
+    state = params["state"]
+
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    # Build the supplied attribute set from the user-friendly parameters.
+    supplied = {}
+    if params["description"] is not None:
+        supplied["description"] = params["description"]
+    if params["destination_type"] is not None:
+        supplied["destination_type"] = params["destination_type"]
+    if params["destination"] is not None:
+        vrf_uri = "{0}system/vrfs/{1}".format(
+            session.resource_prefix, params["vrf"]
+        )
+        supplied["destination_hostname_or_ip_addr"] = {
+            params["destination"]: vrf_uri
+        }
+    if params["traffic_insight"] is not None:
+        supplied["destination_traffic_insight"] = params["traffic_insight"]
+    if params["template_data_timeout"] is not None:
+        supplied["template_data_timeout"] = params["template_data_timeout"]
+    if params["transport_port"] is not None:
+        supplied["transport"] = {
+            "port": params["transport_port"],
+            "protocol": params["transport_protocol"],
+        }
+
+    try:
+        exporter = session.api.get_module(session, "IpfixFlowExporter", name)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support IPFIX. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        exporter.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                exporter.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete flow exporter: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # ------------------------------------------------------- create / update
+    if not exists:
+        exporter = session.api.get_module(
+            session, "IpfixFlowExporter", name, **supplied
+        )
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                exporter.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create flow exporter: {0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+    for attr, value in supplied.items():
+        if getattr(exporter, attr, None) != value:
+            changed = True
+            setattr(exporter, attr, value)
+            if attr not in exporter.config_attrs:
+                exporter.config_attrs.append(attr)
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            exporter.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update flow exporter: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_ipfix_flow_monitor.py
+++ b/plugins/modules/aoscx_ipfix_flow_monitor.py
@@ -1,0 +1,251 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_ipfix_flow_monitor
+version_added: "4.6.0"
+short_description: Create, update or delete an IPFIX flow monitor on AOS-CX
+description: >
+  This module provides configuration management of IPFIX flow monitors on
+  AOS-CX devices. A flow monitor binds a flow record to one or more flow
+  exporters and controls the flow cache timeouts. IPFIX requires REST API
+  version 10.13 or later (set ansible_aoscx_rest_version to 10.13). The
+  referenced flow record and flow exporters must already exist on the device.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: >
+      Name of the flow monitor. This is the index of the resource under
+      system/ipfix_flow_monitors.
+    required: true
+    type: str
+  description:
+    description: Free form description of the flow monitor.
+    required: false
+    type: str
+  cache_timeout_active:
+    description: >
+      Active flow cache timeout in seconds (30-604800).
+    required: false
+    type: int
+  cache_timeout_inactive:
+    description: >
+      Inactive flow cache timeout in seconds (30-604800).
+    required: false
+    type: int
+  exporters:
+    description: >
+      List of flow exporter names to bind to this monitor. The exporters must
+      already exist on the device.
+    required: false
+    type: list
+    elements: str
+  record:
+    description: >
+      Name of the flow record to bind to this monitor. The record must already
+      exist on the device.
+    required: false
+    type: str
+  state:
+    description: Create, update or delete the flow monitor.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create an IPFIX flow monitor binding a record and an exporter
+  aoscx_ipfix_flow_monitor:
+    name: monitor-1
+    description: Monitor ipv4 flows
+    record: ipv4-record
+    exporters:
+      - collector-1
+    cache_timeout_active: 60
+    cache_timeout_inactive: 30
+
+- name: Update the exporters bound to a flow monitor
+  aoscx_ipfix_flow_monitor:
+    name: monitor-1
+    state: update
+    exporters:
+      - collector-1
+      - collector-2
+
+- name: Delete a flow monitor
+  aoscx_ipfix_flow_monitor:
+    name: monitor-1
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        name=dict(type="str", required=True),
+        description=dict(type="str", required=False, default=None),
+        cache_timeout_active=dict(type="int", required=False, default=None),
+        cache_timeout_inactive=dict(type="int", required=False, default=None),
+        exporters=dict(
+            type="list", elements="str", required=False, default=None
+        ),
+        record=dict(type="str", required=False, default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    params = ansible_module.params
+    name = params["name"]
+    state = params["state"]
+
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    def make_exporters(names):
+        return [
+            session.api.get_module(session, "IpfixFlowExporter", n)
+            for n in names
+        ]
+
+    def make_record(record_name):
+        return session.api.get_module(session, "IpfixFlowRecord", record_name)
+
+    scalar_attrs = [
+        "description",
+        "cache_timeout_active",
+        "cache_timeout_inactive",
+    ]
+    supplied = {
+        attr: params[attr] for attr in scalar_attrs if params[attr] is not None
+    }
+
+    try:
+        monitor = session.api.get_module(session, "IpfixFlowMonitor", name)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support IPFIX. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        monitor.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                monitor.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete flow monitor: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # ------------------------------------------------------- create / update
+    if not exists:
+        create_kwargs = dict(supplied)
+        if params["exporters"] is not None:
+            create_kwargs["exporter"] = make_exporters(params["exporters"])
+        if params["record"] is not None:
+            create_kwargs["record"] = make_record(params["record"])
+        monitor = session.api.get_module(
+            session, "IpfixFlowMonitor", name, **create_kwargs
+        )
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                monitor.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create flow monitor: {0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+    for attr, value in supplied.items():
+        if getattr(monitor, attr, None) != value:
+            changed = True
+            setattr(monitor, attr, value)
+            if attr not in monitor.config_attrs:
+                monitor.config_attrs.append(attr)
+
+    # Reconcile the exporter references (order-insensitive comparison by name).
+    if params["exporters"] is not None:
+        current = sorted(
+            obj.name for obj in (getattr(monitor, "exporter", None) or [])
+        )
+        desired = sorted(params["exporters"])
+        if current != desired:
+            changed = True
+            monitor.exporter = make_exporters(params["exporters"])
+            if "exporter" not in monitor.config_attrs:
+                monitor.config_attrs.append("exporter")
+
+    # Reconcile the record reference (single, compared by name).
+    if params["record"] is not None:
+        current_record = getattr(monitor, "record", None)
+        current_name = current_record.name if current_record else None
+        if current_name != params["record"]:
+            changed = True
+            monitor.record = make_record(params["record"])
+            if "record" not in monitor.config_attrs:
+                monitor.config_attrs.append("record")
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            monitor.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update flow monitor: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_ipfix_flow_record.py
+++ b/plugins/modules/aoscx_ipfix_flow_record.py
@@ -1,0 +1,205 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_ipfix_flow_record
+version_added: "4.6.0"
+short_description: Create, update or delete an IPFIX flow record on AOS-CX
+description: >
+  This module provides configuration management of IPFIX flow records on
+  AOS-CX devices. A flow record defines the key fields (match) and non-key
+  fields (collect) included in exported IPFIX flows. IPFIX requires REST API
+  version 10.13 or later (set ansible_aoscx_rest_version to 10.13).
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: >
+      Name of the flow record. This is the index of the resource under
+      system/ipfix_flow_records.
+    required: true
+    type: str
+  description:
+    description: Free form description of the flow record.
+    required: false
+    type: str
+  match:
+    description: >
+      Key fields for the flow record, as a dictionary mapping a field name to
+      a boolean. Valid keys are ipv4_source_address, ipv4_destination_address,
+      ipv4_protocol, ipv4_version, ipv6_source_address,
+      ipv6_destination_address, ipv6_protocol, ipv6_version,
+      transport_source_port and transport_destination_port. The supplied
+      dictionary fully replaces the current key fields.
+    required: false
+    type: dict
+  collect:
+    description: >
+      Non-key fields for the flow record, as a dictionary mapping a field name
+      to a boolean (for example counter_bytes, counter_packets,
+      application_name, egress_interface). The supplied dictionary fully
+      replaces the current non-key fields.
+    required: false
+    type: dict
+  state:
+    description: Create, update or delete the flow record.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create an IPFIX flow record for IPv4 flows
+  aoscx_ipfix_flow_record:
+    name: ipv4-record
+    description: Record ipv4 flows
+    match:
+      ipv4_source_address: true
+      ipv4_destination_address: true
+      ipv4_protocol: true
+    collect:
+      counter_bytes: true
+      counter_packets: true
+
+- name: Update the collected fields of a flow record
+  aoscx_ipfix_flow_record:
+    name: ipv4-record
+    state: update
+    collect:
+      counter_bytes: true
+      counter_packets: true
+      application_name: true
+
+- name: Delete a flow record
+  aoscx_ipfix_flow_record:
+    name: ipv4-record
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        name=dict(type="str", required=True),
+        description=dict(type="str", required=False, default=None),
+        match=dict(type="dict", required=False, default=None),
+        collect=dict(type="dict", required=False, default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    name = ansible_module.params["name"]
+    state = ansible_module.params["state"]
+
+    scalar_attrs = ["description", "match", "collect"]
+    supplied = {
+        attr: ansible_module.params[attr]
+        for attr in scalar_attrs
+        if ansible_module.params[attr] is not None
+    }
+
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        record = session.api.get_module(session, "IpfixFlowRecord", name)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support IPFIX. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        record.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                record.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete flow record: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # ------------------------------------------------------- create / update
+    if not exists:
+        record = session.api.get_module(
+            session, "IpfixFlowRecord", name, **supplied
+        )
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                record.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create flow record: {0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+    for attr, value in supplied.items():
+        if getattr(record, attr, None) != value:
+            changed = True
+            setattr(record, attr, value)
+            if attr not in record.config_attrs:
+                record.config_attrs.append(attr)
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            record.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update flow record: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/aoscx_ipfix_flow_exporter/aliases
+++ b/tests/integration/targets/aoscx_ipfix_flow_exporter/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_ipfix_flow_exporter/tasks/main.yml
+++ b/tests/integration/targets/aoscx_ipfix_flow_exporter/tasks/main.yml
@@ -1,0 +1,71 @@
+# Integration tests for the aoscx_ipfix_flow_exporter module.
+#
+# Run with:
+#   ansible-test integration aoscx_ipfix_flow_exporter --venv
+#
+# Requires an inventory entry named "aoscx" reachable with a pyaoscx release
+# that ships the IpfixFlowExporter class and a REST API version of 10.13 or
+# later. Uses a temporary flow exporter named "ansible-test" and cleans up
+# afterwards.
+
+- name: Make sure the test flow exporter does not exist yet
+  arubanetworks.aoscx.aoscx_ipfix_flow_exporter:
+    name: ansible-test
+    state: delete
+  ignore_errors: true
+
+- name: Create a flow exporter
+  arubanetworks.aoscx.aoscx_ipfix_flow_exporter:
+    name: ansible-test
+    description: ansible exporter
+    destination_type: hostname-or-ip-addr
+    destination: 10.0.0.5
+    vrf: default
+    transport_port: 4739
+    template_data_timeout: 600
+  register: result
+
+- name: Assert the exporter was created
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Re-apply the same configuration (idempotent)
+  arubanetworks.aoscx.aoscx_ipfix_flow_exporter:
+    name: ansible-test
+    state: update
+    description: ansible exporter
+    destination_type: hostname-or-ip-addr
+    destination: 10.0.0.5
+    vrf: default
+    transport_port: 4739
+    template_data_timeout: 600
+  register: result
+
+- name: Assert nothing changed
+  ansible.builtin.assert:
+    that:
+      - not result.changed
+
+- name: Update the template data timeout
+  arubanetworks.aoscx.aoscx_ipfix_flow_exporter:
+    name: ansible-test
+    state: update
+    template_data_timeout: 1200
+  register: result
+
+- name: Assert the exporter changed
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Delete the flow exporter
+  arubanetworks.aoscx.aoscx_ipfix_flow_exporter:
+    name: ansible-test
+    state: delete
+  register: result
+
+- name: Assert the exporter was deleted
+  ansible.builtin.assert:
+    that:
+      - result.changed

--- a/tests/integration/targets/aoscx_ipfix_flow_monitor/aliases
+++ b/tests/integration/targets/aoscx_ipfix_flow_monitor/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_ipfix_flow_monitor/tasks/main.yml
+++ b/tests/integration/targets/aoscx_ipfix_flow_monitor/tasks/main.yml
@@ -1,0 +1,94 @@
+# Integration tests for the aoscx_ipfix_flow_monitor module.
+#
+# Run with:
+#   ansible-test integration aoscx_ipfix_flow_monitor --venv
+#
+# Requires an inventory entry named "aoscx" reachable with a pyaoscx release
+# that ships the IpfixFlowMonitor class and a REST API version of 10.13 or
+# later. Uses temporary flow record, exporter and monitor named "ansible-test"
+# and cleans up afterwards.
+
+- name: Make sure the test flow monitor does not exist yet
+  arubanetworks.aoscx.aoscx_ipfix_flow_monitor:
+    name: ansible-test
+    state: delete
+  ignore_errors: true
+
+- name: Create the referenced flow record
+  arubanetworks.aoscx.aoscx_ipfix_flow_record:
+    name: ansible-test
+    match:
+      ipv4_source_address: true
+
+- name: Create the referenced flow exporter
+  arubanetworks.aoscx.aoscx_ipfix_flow_exporter:
+    name: ansible-test
+    destination_type: hostname-or-ip-addr
+    destination: 10.0.0.5
+    vrf: default
+    transport_port: 4739
+
+- name: Create a flow monitor binding the record and exporter
+  arubanetworks.aoscx.aoscx_ipfix_flow_monitor:
+    name: ansible-test
+    description: ansible monitor
+    record: ansible-test
+    exporters:
+      - ansible-test
+    cache_timeout_active: 60
+    cache_timeout_inactive: 30
+  register: result
+
+- name: Assert the monitor was created
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Re-apply the same configuration (idempotent)
+  arubanetworks.aoscx.aoscx_ipfix_flow_monitor:
+    name: ansible-test
+    state: update
+    record: ansible-test
+    exporters:
+      - ansible-test
+    cache_timeout_active: 60
+    cache_timeout_inactive: 30
+  register: result
+
+- name: Assert nothing changed
+  ansible.builtin.assert:
+    that:
+      - not result.changed
+
+- name: Update the active cache timeout
+  arubanetworks.aoscx.aoscx_ipfix_flow_monitor:
+    name: ansible-test
+    state: update
+    cache_timeout_active: 120
+  register: result
+
+- name: Assert the monitor changed
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Delete the flow monitor
+  arubanetworks.aoscx.aoscx_ipfix_flow_monitor:
+    name: ansible-test
+    state: delete
+  register: result
+
+- name: Assert the monitor was deleted
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Clean up the referenced exporter
+  arubanetworks.aoscx.aoscx_ipfix_flow_exporter:
+    name: ansible-test
+    state: delete
+
+- name: Clean up the referenced record
+  arubanetworks.aoscx.aoscx_ipfix_flow_record:
+    name: ansible-test
+    state: delete

--- a/tests/integration/targets/aoscx_ipfix_flow_record/aliases
+++ b/tests/integration/targets/aoscx_ipfix_flow_record/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_ipfix_flow_record/tasks/main.yml
+++ b/tests/integration/targets/aoscx_ipfix_flow_record/tasks/main.yml
@@ -1,0 +1,76 @@
+# Integration tests for the aoscx_ipfix_flow_record module.
+#
+# Run with:
+#   ansible-test integration aoscx_ipfix_flow_record --venv
+#
+# Requires an inventory entry named "aoscx" reachable with a pyaoscx release
+# that ships the IpfixFlowRecord class and a REST API version of 10.13 or
+# later. Uses a temporary flow record named "ansible-test" and cleans up
+# afterwards.
+
+- name: Make sure the test flow record does not exist yet
+  arubanetworks.aoscx.aoscx_ipfix_flow_record:
+    name: ansible-test
+    state: delete
+  ignore_errors: true
+
+- name: Create a flow record
+  arubanetworks.aoscx.aoscx_ipfix_flow_record:
+    name: ansible-test
+    description: ansible record
+    match:
+      ipv4_source_address: true
+      ipv4_destination_address: true
+    collect:
+      counter_bytes: true
+      counter_packets: true
+  register: result
+
+- name: Assert the record was created
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Re-apply the same configuration (idempotent)
+  arubanetworks.aoscx.aoscx_ipfix_flow_record:
+    name: ansible-test
+    state: update
+    description: ansible record
+    match:
+      ipv4_source_address: true
+      ipv4_destination_address: true
+    collect:
+      counter_bytes: true
+      counter_packets: true
+  register: result
+
+- name: Assert nothing changed
+  ansible.builtin.assert:
+    that:
+      - not result.changed
+
+- name: Update the collected fields
+  arubanetworks.aoscx.aoscx_ipfix_flow_record:
+    name: ansible-test
+    state: update
+    collect:
+      counter_bytes: true
+      counter_packets: true
+      application_name: true
+  register: result
+
+- name: Assert the record changed
+  ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Delete the flow record
+  arubanetworks.aoscx.aoscx_ipfix_flow_record:
+    name: ansible-test
+    state: delete
+  register: result
+
+- name: Assert the record was deleted
+  ansible.builtin.assert:
+    that:
+      - result.changed

--- a/tests/unit/modules/test_aoscx_ipfix_flow_exporter.py
+++ b/tests/unit/modules/test_aoscx_ipfix_flow_exporter.py
@@ -1,0 +1,236 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_ipfix_flow_exporter module.
+
+The pyaoscx session is fully mocked, so no switch is required.
+
+Run with:
+    PYTHONPATH=/tmp/acoll2x .venv/bin/python -m pytest \
+        tests/unit/modules/test_aoscx_ipfix_flow_exporter.py -v
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_ipfix_flow_exporter,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_ipfix_flow_exporter"
+)
+
+
+class AnsibleExitJson(Exception):
+    """Raised by the mocked exit_json to stop module execution."""
+
+
+class AnsibleFailJson(Exception):
+    """Raised by the mocked fail_json to stop module execution."""
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+EXPORTER_ATTRS = (
+    "description",
+    "destination_type",
+    "destination_hostname_or_ip_addr",
+    "destination_traffic_insight",
+    "template_data_timeout",
+    "transport",
+)
+
+
+def build_exporter(exists, **attrs):
+    exporter = MagicMock()
+    exporter.config_attrs = []
+    for attr in EXPORTER_ATTRS:
+        setattr(exporter, attr, attrs.get(attr))
+    if exists:
+        exporter.get.return_value = True
+    else:
+        exporter.get.side_effect = Exception("not found")
+    return exporter
+
+
+def build_session(existing, new_exporter=None):
+    session = MagicMock()
+    session.resource_prefix = "/rest/v10.13/"
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "IpfixFlowExporter":
+            if (
+                any(k in kwargs for k in EXPORTER_ATTRS)
+                and new_exporter is not None
+            ):
+                return new_exporter
+            return existing
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_ipfix_flow_exporter.main()
+    return exc.value.args[0]
+
+
+# --------------------------------------------------------------------------
+# Create
+# --------------------------------------------------------------------------
+def test_create_collector():
+    existing = build_exporter(False)
+    new = build_exporter(False)
+    session = build_session(existing, new_exporter=new)
+    result = run_module(
+        {
+            "name": "collector-1",
+            "destination_type": "hostname-or-ip-addr",
+            "destination": "10.0.0.5",
+            "vrf": "default",
+            "transport_port": 4739,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+    # The destination must be turned into a {host: vrf_uri} mapping.
+    _, kwargs = session.api.get_module.call_args
+    assert kwargs["destination_hostname_or_ip_addr"] == {
+        "10.0.0.5": "/rest/v10.13/system/vrfs/default"
+    }
+    assert kwargs["transport"] == {"port": 4739, "protocol": "udp"}
+
+
+def test_create_traffic_insight():
+    existing = build_exporter(False)
+    new = build_exporter(False)
+    session = build_session(existing, new_exporter=new)
+    result = run_module(
+        {
+            "name": "ti-exporter",
+            "destination_type": "traffic-insight",
+            "traffic_insight": "TI-01",
+        },
+        session,
+    )
+    assert result["changed"] is True
+    _, kwargs = session.api.get_module.call_args
+    assert kwargs["destination_traffic_insight"] == "TI-01"
+
+
+def test_create_check_mode():
+    existing = build_exporter(False)
+    new = build_exporter(False)
+    session = build_session(existing, new_exporter=new)
+    result = run_module(
+        {
+            "name": "collector-1",
+            "destination_type": "traffic-insight",
+            "traffic_insight": "TI-01",
+            "_ansible_check_mode": True,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Update
+# --------------------------------------------------------------------------
+def test_update_timeout():
+    existing = build_exporter(True, template_data_timeout=300)
+    session = build_session(existing)
+    result = run_module(
+        {
+            "name": "collector-1",
+            "state": "update",
+            "template_data_timeout": 600,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    assert existing.template_data_timeout == 600
+    existing.update.assert_called_once()
+
+
+def test_update_idempotent():
+    existing = build_exporter(
+        True,
+        destination_type="traffic-insight",
+        destination_traffic_insight="TI-01",
+    )
+    session = build_session(existing)
+    result = run_module(
+        {
+            "name": "ti-exporter",
+            "state": "update",
+            "destination_type": "traffic-insight",
+            "traffic_insight": "TI-01",
+        },
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Delete
+# --------------------------------------------------------------------------
+def test_delete():
+    existing = build_exporter(True)
+    session = build_session(existing)
+    result = run_module({"name": "collector-1", "state": "delete"}, session)
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+
+
+def test_delete_absent_noop():
+    existing = build_exporter(False)
+    session = build_session(existing)
+    result = run_module({"name": "collector-1", "state": "delete"}, session)
+    assert result["changed"] is False
+    existing.delete.assert_not_called()

--- a/tests/unit/modules/test_aoscx_ipfix_flow_monitor.py
+++ b/tests/unit/modules/test_aoscx_ipfix_flow_monitor.py
@@ -1,0 +1,260 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_ipfix_flow_monitor module.
+
+The pyaoscx session is fully mocked, so no switch is required.
+
+Run with:
+    PYTHONPATH=/tmp/acoll2x .venv/bin/python -m pytest \
+        tests/unit/modules/test_aoscx_ipfix_flow_monitor.py -v
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_ipfix_flow_monitor,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_ipfix_flow_monitor"
+)
+
+
+class AnsibleExitJson(Exception):
+    """Raised by the mocked exit_json to stop module execution."""
+
+
+class AnsibleFailJson(Exception):
+    """Raised by the mocked fail_json to stop module execution."""
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def named_obj(name):
+    obj = MagicMock()
+    obj.name = name
+    return obj
+
+
+MONITOR_ATTRS = (
+    "description",
+    "cache_timeout_active",
+    "cache_timeout_inactive",
+    "exporter",
+    "record",
+)
+
+
+def build_monitor(exists, exporters=None, record=None, **attrs):
+    monitor = MagicMock()
+    monitor.config_attrs = []
+    for attr in (
+        "description",
+        "cache_timeout_active",
+        "cache_timeout_inactive",
+    ):
+        setattr(monitor, attr, attrs.get(attr))
+    monitor.exporter = (
+        [named_obj(n) for n in exporters] if exporters is not None else None
+    )
+    monitor.record = named_obj(record) if record is not None else None
+    if exists:
+        monitor.get.return_value = True
+    else:
+        monitor.get.side_effect = Exception("not found")
+    return monitor
+
+
+def build_session(existing, new_monitor=None):
+    session = MagicMock()
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "IpfixFlowMonitor":
+            if (
+                any(k in kwargs for k in MONITOR_ATTRS)
+                and new_monitor is not None
+            ):
+                return new_monitor
+            return existing
+        if module in ("IpfixFlowExporter", "IpfixFlowRecord"):
+            return named_obj(index)
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_ipfix_flow_monitor.main()
+    return exc.value.args[0]
+
+
+# --------------------------------------------------------------------------
+# Create
+# --------------------------------------------------------------------------
+def test_create():
+    existing = build_monitor(False)
+    new = build_monitor(False)
+    session = build_session(existing, new_monitor=new)
+    result = run_module(
+        {
+            "name": "monitor-1",
+            "record": "ipv4-record",
+            "exporters": ["collector-1"],
+            "cache_timeout_active": 60,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_check_mode():
+    existing = build_monitor(False)
+    new = build_monitor(False)
+    session = build_session(existing, new_monitor=new)
+    result = run_module(
+        {
+            "name": "monitor-1",
+            "record": "ipv4-record",
+            "exporters": ["collector-1"],
+            "_ansible_check_mode": True,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Update
+# --------------------------------------------------------------------------
+def test_update_add_exporter():
+    existing = build_monitor(
+        True, exporters=["collector-1"], record="ipv4-record"
+    )
+    session = build_session(existing)
+    result = run_module(
+        {
+            "name": "monitor-1",
+            "state": "update",
+            "exporters": ["collector-1", "collector-2"],
+        },
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_update_idempotent():
+    existing = build_monitor(
+        True,
+        exporters=["collector-1"],
+        record="ipv4-record",
+        cache_timeout_active=60,
+    )
+    session = build_session(existing)
+    result = run_module(
+        {
+            "name": "monitor-1",
+            "state": "update",
+            "exporters": ["collector-1"],
+            "record": "ipv4-record",
+            "cache_timeout_active": 60,
+        },
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_update_exporter_order_insensitive():
+    existing = build_monitor(True, exporters=["collector-1", "collector-2"])
+    session = build_session(existing)
+    result = run_module(
+        {
+            "name": "monitor-1",
+            "state": "update",
+            "exporters": ["collector-2", "collector-1"],
+        },
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+def test_update_record():
+    existing = build_monitor(True, record="ipv4-record")
+    session = build_session(existing)
+    result = run_module(
+        {
+            "name": "monitor-1",
+            "state": "update",
+            "record": "ipv6-record",
+        },
+        session,
+    )
+    assert result["changed"] is True
+    assert existing.record.name == "ipv6-record"
+    existing.update.assert_called_once()
+
+
+# --------------------------------------------------------------------------
+# Delete
+# --------------------------------------------------------------------------
+def test_delete():
+    existing = build_monitor(True)
+    session = build_session(existing)
+    result = run_module({"name": "monitor-1", "state": "delete"}, session)
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+
+
+def test_delete_absent_noop():
+    existing = build_monitor(False)
+    session = build_session(existing)
+    result = run_module({"name": "monitor-1", "state": "delete"}, session)
+    assert result["changed"] is False
+    existing.delete.assert_not_called()

--- a/tests/unit/modules/test_aoscx_ipfix_flow_record.py
+++ b/tests/unit/modules/test_aoscx_ipfix_flow_record.py
@@ -1,0 +1,200 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_ipfix_flow_record module.
+
+The pyaoscx session is fully mocked, so no switch is required.
+
+Run with:
+    PYTHONPATH=/tmp/acoll2x .venv/bin/python -m pytest \
+        tests/unit/modules/test_aoscx_ipfix_flow_record.py -v
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_ipfix_flow_record,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_ipfix_flow_record"
+)
+
+
+class AnsibleExitJson(Exception):
+    """Raised by the mocked exit_json to stop module execution."""
+
+
+class AnsibleFailJson(Exception):
+    """Raised by the mocked fail_json to stop module execution."""
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_record(exists, **attrs):
+    record = MagicMock()
+    record.config_attrs = []
+    for attr in ("description", "match", "collect"):
+        setattr(record, attr, attrs.get(attr))
+    if exists:
+        record.get.return_value = True
+    else:
+        record.get.side_effect = Exception("not found")
+    return record
+
+
+def build_session(existing, new_record=None):
+    session = MagicMock()
+    scalar_attrs = ("description", "match", "collect")
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "IpfixFlowRecord":
+            if (
+                any(k in kwargs for k in scalar_attrs)
+                and new_record is not None
+            ):
+                return new_record
+            return existing
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_ipfix_flow_record.main()
+    return exc.value.args[0]
+
+
+# --------------------------------------------------------------------------
+# Create
+# --------------------------------------------------------------------------
+def test_create():
+    existing = build_record(False)
+    new = build_record(False)
+    session = build_session(existing, new_record=new)
+    result = run_module(
+        {
+            "name": "ipv4-record",
+            "description": "ipv4",
+            "match": {"ipv4_source_address": True},
+            "collect": {"counter_bytes": True},
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_called_once()
+
+
+def test_create_check_mode():
+    existing = build_record(False)
+    new = build_record(False)
+    session = build_session(existing, new_record=new)
+    result = run_module(
+        {
+            "name": "ipv4-record",
+            "match": {"ipv4_source_address": True},
+            "_ansible_check_mode": True,
+        },
+        session,
+    )
+    assert result["changed"] is True
+    new.create.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Update
+# --------------------------------------------------------------------------
+def test_update_collect():
+    existing = build_record(True, collect={"counter_bytes": True})
+    session = build_session(existing)
+    result = run_module(
+        {
+            "name": "ipv4-record",
+            "state": "update",
+            "collect": {"counter_bytes": True, "counter_packets": True},
+        },
+        session,
+    )
+    assert result["changed"] is True
+    existing.update.assert_called_once()
+
+
+def test_update_idempotent():
+    existing = build_record(
+        True,
+        description="ipv4",
+        match={"ipv4_source_address": True},
+    )
+    session = build_session(existing)
+    result = run_module(
+        {
+            "name": "ipv4-record",
+            "state": "update",
+            "description": "ipv4",
+            "match": {"ipv4_source_address": True},
+        },
+        session,
+    )
+    assert result["changed"] is False
+    existing.update.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Delete
+# --------------------------------------------------------------------------
+def test_delete():
+    existing = build_record(True)
+    session = build_session(existing)
+    result = run_module({"name": "ipv4-record", "state": "delete"}, session)
+    assert result["changed"] is True
+    existing.delete.assert_called_once()
+
+
+def test_delete_absent_noop():
+    existing = build_record(False)
+    session = build_session(existing)
+    result = run_module({"name": "ipv4-record", "state": "delete"}, session)
+    assert result["changed"] is False
+    existing.delete.assert_not_called()


### PR DESCRIPTION
Fixes #187

Collection modules backed by dedicated pyaoscx SDK classes. Depends on SDK PR aruba/pyaoscx#65.

## Depends on
- aruba/pyaoscx#65 — IpfixFlowRecord / Exporter / Monitor
- aruba/pyaoscx#119 — REST API version modules `v10.13` / `v10.16` (needed to reach this feature at the 10.13/10.16 REST schema)
