### PR TITLE
Add SNMP family modules (snmpv3_user, community, view, trap)

### DIFF
--- a/changelogs/fragments/aoscx_snmp.yml
+++ b/changelogs/fragments/aoscx_snmp.yml
@@ -1,0 +1,8 @@
+---
+minor_changes:
+  - aoscx_snmpv3_user - new module to manage SNMPv3 users.
+  - aoscx_snmp_community - new module to manage SNMP communities.
+  - aoscx_snmp_view - new module to manage SNMP views and their entries.
+  - aoscx_snmp_trap - new module to manage SNMP trap receivers.
+  - aoscx connection plugin - allow REST API versions 10.13 and 10.16,
+    required for the SNMP modules.

--- a/plugins/connection/aoscx.py
+++ b/plugins/connection/aoscx.py
@@ -120,9 +120,9 @@ options:
       - name: ansible_persistent_log_messages
   rest_version:
     description: >
-      Configures REST version, default version is 10.04, but 10.08 or 10.09
-      can be used in a specific host or globaly if it is set as an environment
-      variable.
+      Configures REST version, default version is 10.04, but 10.08, 10.09,
+      10.13 or 10.16 can be used in a specific host or globaly if it is set
+      as an environment variable.
     default: '10.04'
     env:
       - name: ANSIBLE_AOSCX_REST_VERSION
@@ -208,7 +208,13 @@ class Connection(NetworkConnectionBase):
             password = self.get_option("password")
             self.use_proxy = self.get_option("use_proxy")
             rest_version = self.get_option("rest_version")
-            if rest_version not in ["10.04", "10.08", "10.09"]:
+            if rest_version not in [
+                "10.04",
+                "10.08",
+                "10.09",
+                "10.13",
+                "10.16",
+            ]:
                 raise AnsibleConnectionFailure("Invalid REST version: %s"
                                                % rest_version)
             self.base_url = "https://{0}/rest/v{1}/".format(switchip, rest_version)

--- a/plugins/modules/aoscx_snmp_community.py
+++ b/plugins/modules/aoscx_snmp_community.py
@@ -1,0 +1,141 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_snmp_community
+version_added: "4.6.0"
+short_description: Create, update or delete an SNMP community
+description: >
+  This module provides configuration management of SNMP communities on AOS-CX
+  devices (system/snmp_community_attributes). Requires REST API v10.16
+  (set ansible_aoscx_rest_version to 10.16).
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: Name of the SNMP community.
+    required: true
+    type: str
+  snmp_view:
+    description: Name of the SNMP view associated to the community.
+    required: false
+    type: str
+  state:
+    description: Create, update or delete the SNMP community.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create an SNMP community
+  aoscx_snmp_community:
+    name: anstest
+    snmp_view: my_view
+
+- name: Delete an SNMP community
+  aoscx_snmp_community:
+    name: anstest
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+    from pyaoscx.snmp_community import SnmpCommunity
+    from pyaoscx.snmp_view import SnmpView
+
+    HAS_PYAOSCX_SNMP = True
+except ImportError:
+    HAS_PYAOSCX_SNMP = False
+
+if HAS_PYAOSCX_SNMP:
+    from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+        get_pyaoscx_session,
+    )
+
+
+def main():
+    module_args = dict(
+        name=dict(type="str", required=True),
+        snmp_view=dict(type="str", required=False),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    result = dict(changed=False)
+
+    if not HAS_PYAOSCX_SNMP:
+        ansible_module.fail_json(
+            msg="This pyaoscx version does not support SNMP. Upgrade pyaoscx."
+        )
+
+    if ansible_module.check_mode:
+        ansible_module.exit_json(**result)
+
+    name = ansible_module.params["name"]
+    snmp_view = ansible_module.params["snmp_view"]
+    state = ansible_module.params["state"]
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    community = SnmpCommunity(session, name)
+    try:
+        community.get()
+        exists = True
+    except Exception:
+        exists = False
+
+    if state == "delete":
+        if exists:
+            community.delete()
+            result["changed"] = True
+        ansible_module.exit_json(**result)
+
+    kwargs = {}
+    if snmp_view is not None:
+        view = SnmpView(session, snmp_view)
+        view.get()
+        kwargs["snmp_view"] = view.get_uri()
+
+    for key, value in kwargs.items():
+        setattr(community, key, value)
+    result["changed"] = community.apply()
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_snmp_trap.py
+++ b/plugins/modules/aoscx_snmp_trap.py
@@ -1,0 +1,201 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_snmp_trap
+version_added: "4.6.0"
+short_description: Create or delete an SNMP trap receiver
+description: >
+  This module provides configuration management of SNMP trap receivers on
+  AOS-CX devices (system/snmp_traps). Trap receivers are identified by a
+  compound index and are create/delete only. Requires REST API v10.16
+  (set ansible_aoscx_rest_version to 10.16).
+author: Aruba Networks (@ArubaNetworks)
+options:
+  vrf:
+    description: Name of the VRF used to reach the receiver.
+    required: false
+    type: str
+    default: default
+  receiver_address:
+    description: IP address of the trap receiver.
+    required: true
+    type: str
+  receiver_udp_port:
+    description: UDP port of the trap receiver.
+    required: false
+    type: int
+    default: 162
+  type:
+    description: Notification delivery type.
+    required: false
+    type: str
+    choices:
+      - trap
+      - inform
+    default: trap
+  version:
+    description: SNMP version used for the receiver.
+    required: false
+    type: str
+    choices:
+      - v1
+      - v2c
+      - v3
+    default: v2c
+  community_name:
+    description: SNMP community name for v1/v2c receivers.
+    required: false
+    type: str
+  state:
+    description: Create or delete the SNMP trap receiver.
+    required: false
+    choices:
+      - create
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create an SNMP v2c trap receiver
+  aoscx_snmp_trap:
+    receiver_address: 198.51.100.5
+    receiver_udp_port: 162
+    type: trap
+    version: v2c
+    community_name: public
+
+- name: Delete an SNMP trap receiver
+  aoscx_snmp_trap:
+    receiver_address: 198.51.100.5
+    type: trap
+    version: v2c
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+    from pyaoscx.snmp_trap import SnmpTrap
+    from pyaoscx.vrf import Vrf
+
+    HAS_PYAOSCX_SNMP = True
+except ImportError:
+    HAS_PYAOSCX_SNMP = False
+
+if HAS_PYAOSCX_SNMP:
+    from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+        get_pyaoscx_session,
+    )
+
+
+def main():
+    module_args = dict(
+        vrf=dict(type="str", required=False, default="default"),
+        receiver_address=dict(type="str", required=True),
+        receiver_udp_port=dict(type="int", required=False, default=162),
+        type=dict(
+            type="str",
+            required=False,
+            choices=["trap", "inform"],
+            default="trap",
+        ),
+        version=dict(
+            type="str",
+            required=False,
+            choices=["v1", "v2c", "v3"],
+            default="v2c",
+        ),
+        community_name=dict(type="str", required=False),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "delete"],
+        ),
+    )
+
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    result = dict(changed=False)
+
+    if not HAS_PYAOSCX_SNMP:
+        ansible_module.fail_json(
+            msg="This pyaoscx version does not support SNMP. Upgrade pyaoscx."
+        )
+
+    if ansible_module.check_mode:
+        ansible_module.exit_json(**result)
+
+    params = ansible_module.params
+    state = params["state"]
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    vrf = Vrf(session, params["vrf"])
+    try:
+        vrf.get()
+    except Exception:
+        ansible_module.fail_json(
+            msg="VRF {0} doesn't exist.".format(params["vrf"])
+        )
+
+    kwargs = {}
+    if params["community_name"] is not None:
+        kwargs["community_name"] = params["community_name"]
+
+    trap = SnmpTrap(
+        session,
+        vrf,
+        params["receiver_address"],
+        params["receiver_udp_port"],
+        params["type"],
+        params["version"],
+        **kwargs
+    )
+
+    try:
+        trap.get()
+        exists = True
+    except Exception:
+        exists = False
+
+    if state == "delete":
+        if exists:
+            trap.delete()
+            result["changed"] = True
+        ansible_module.exit_json(**result)
+
+    if not exists:
+        trap.create()
+        result["changed"] = True
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_snmp_view.py
+++ b/plugins/modules/aoscx_snmp_view.py
@@ -174,7 +174,8 @@ def main():
     except Exception:
         existing_entries = {}
     for index, existing in existing_entries.items():
-        existing.get()
+        if not existing.materialized:
+            existing.get()
         key = (
             existing.oid_tree,
             getattr(existing, "type", "included"),

--- a/plugins/modules/aoscx_snmp_view.py
+++ b/plugins/modules/aoscx_snmp_view.py
@@ -26,6 +26,9 @@ description: >
   so the requested entries fully replace the existing ones. Requires REST API
   v10.16 (set ansible_aoscx_rest_version to 10.16).
 author: Aruba Networks (@ArubaNetworks)
+notes:
+  - On some firmware releases an SNMP view stores a single entry; if multiple
+    entries are supplied only the last one is retained by the switch.
 options:
   name:
     description: Name of the SNMP view.

--- a/plugins/modules/aoscx_snmp_view.py
+++ b/plugins/modules/aoscx_snmp_view.py
@@ -1,0 +1,203 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_snmp_view
+version_added: "4.6.0"
+short_description: Create, update or delete an SNMP view
+description: >
+  This module provides configuration management of SNMP views and their
+  entries on AOS-CX devices (system/snmp_views). View entries are immutable,
+  so the requested entries fully replace the existing ones. Requires REST API
+  v10.16 (set ansible_aoscx_rest_version to 10.16).
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: Name of the SNMP view.
+    required: true
+    type: str
+  entries:
+    description: Full list of OID-tree entries for the view. Existing entries
+      not present in this list are removed.
+    required: false
+    type: list
+    elements: dict
+    suboptions:
+      oid_tree:
+        description: OID subtree of the entry.
+        required: true
+        type: str
+      type:
+        description: Whether the subtree is included or excluded.
+        required: false
+        type: str
+        choices:
+          - included
+          - excluded
+        default: included
+      mask:
+        description: Bitmask applied to the OID subtree.
+        required: false
+        type: str
+  state:
+    description: Create, update or delete the SNMP view.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create an SNMP view with two entries
+  aoscx_snmp_view:
+    name: my_view
+    entries:
+      - oid_tree: "1.3.6.1"
+        type: included
+      - oid_tree: "1.3.6.1.6.3"
+        type: excluded
+
+- name: Delete an SNMP view
+  aoscx_snmp_view:
+    name: my_view
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+    from pyaoscx.snmp_view import SnmpView
+    from pyaoscx.snmp_view_entry import SnmpViewEntry
+
+    HAS_PYAOSCX_SNMP = True
+except ImportError:
+    HAS_PYAOSCX_SNMP = False
+
+if HAS_PYAOSCX_SNMP:
+    from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+        get_pyaoscx_session,
+    )
+
+
+def main():
+    entry_spec = dict(
+        oid_tree=dict(type="str", required=True),
+        type=dict(
+            type="str",
+            required=False,
+            choices=["included", "excluded"],
+            default="included",
+        ),
+        mask=dict(type="str", required=False),
+    )
+    module_args = dict(
+        name=dict(type="str", required=True),
+        entries=dict(type="list", elements="dict", options=entry_spec),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    result = dict(changed=False)
+
+    if not HAS_PYAOSCX_SNMP:
+        ansible_module.fail_json(
+            msg="This pyaoscx version does not support SNMP. Upgrade pyaoscx."
+        )
+
+    if ansible_module.check_mode:
+        ansible_module.exit_json(**result)
+
+    name = ansible_module.params["name"]
+    entries = ansible_module.params["entries"] or []
+    state = ansible_module.params["state"]
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    view = SnmpView(session, name)
+    try:
+        view.get()
+        exists = True
+    except Exception:
+        exists = False
+
+    if state == "delete":
+        if exists:
+            view.delete()
+            result["changed"] = True
+        ansible_module.exit_json(**result)
+
+    if not exists:
+        view.create()
+        result["changed"] = True
+
+    desired = set()
+    for entry in entries:
+        desired.add(
+            (entry["oid_tree"], entry["type"], entry.get("mask"))
+        )
+
+    current = {}
+    try:
+        existing_entries = SnmpViewEntry.get_all(session, view)
+    except Exception:
+        existing_entries = {}
+    for index, existing in existing_entries.items():
+        existing.get()
+        key = (
+            existing.oid_tree,
+            getattr(existing, "type", "included"),
+            getattr(existing, "mask", None),
+        )
+        current[key] = existing
+
+    for key, existing in current.items():
+        if key not in desired:
+            existing.delete()
+            result["changed"] = True
+
+    for oid_tree, etype, mask in desired:
+        if (oid_tree, etype, mask) in current:
+            continue
+        kwargs = {"oid_tree": oid_tree, "type": etype}
+        if mask is not None:
+            kwargs["mask"] = mask
+        SnmpViewEntry(session, None, view, **kwargs).create()
+        result["changed"] = True
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_snmpv3_user.py
+++ b/plugins/modules/aoscx_snmpv3_user.py
@@ -25,6 +25,10 @@ description: >
   devices (system/snmpv3_users). Requires REST API v10.16
   (set ansible_aoscx_rest_version to 10.16).
 author: Aruba Networks (@ArubaNetworks)
+notes:
+  - When C(auth_pass_phrase) or C(priv_pass_phrase) are supplied the module
+    reports changed on every run because the secret cannot be read back from
+    the switch for comparison.
 options:
   user_name:
     description: Name of the SNMPv3 user. Index under system/snmpv3_users.

--- a/plugins/modules/aoscx_snmpv3_user.py
+++ b/plugins/modules/aoscx_snmpv3_user.py
@@ -1,0 +1,209 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_snmpv3_user
+version_added: "4.6.0"
+short_description: Create, update or delete an SNMPv3 user
+description: >
+  This module provides configuration management of SNMPv3 users on AOS-CX
+  devices (system/snmpv3_users). Requires REST API v10.16
+  (set ansible_aoscx_rest_version to 10.16).
+author: Aruba Networks (@ArubaNetworks)
+options:
+  user_name:
+    description: Name of the SNMPv3 user. Index under system/snmpv3_users.
+    required: true
+    type: str
+  access_level:
+    description: Access level granted to the user.
+    required: false
+    type: str
+    choices:
+      - ro
+      - rw
+  auth_protocol:
+    description: Authentication protocol of the user.
+    required: false
+    type: str
+    choices:
+      - md5
+      - sha
+      - sha224
+      - sha256
+      - sha384
+      - sha512
+      - none
+  auth_pass_phrase:
+    description: Authentication pass phrase. Required when auth_protocol is
+      not none.
+    required: false
+    type: str
+  priv_protocol:
+    description: Privacy protocol of the user.
+    required: false
+    type: str
+    choices:
+      - aes
+      - aes192
+      - aes256
+      - des
+      - none
+  priv_pass_phrase:
+    description: Privacy pass phrase. Required when priv_protocol is not none.
+    required: false
+    type: str
+  remote_engine_id:
+    description: Remote engine ID for the user.
+    required: false
+    type: str
+  state:
+    description: Create, update or delete the SNMPv3 user.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create an SNMPv3 user with auth and priv
+  aoscx_snmpv3_user:
+    user_name: monitor
+    access_level: ro
+    auth_protocol: sha
+    auth_pass_phrase: my_auth_secret
+    priv_protocol: aes
+    priv_pass_phrase: my_priv_secret
+
+- name: Delete an SNMPv3 user
+  aoscx_snmpv3_user:
+    user_name: monitor
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+    from pyaoscx.snmpv3_user import Snmpv3User
+
+    HAS_PYAOSCX_SNMP = True
+except ImportError:
+    HAS_PYAOSCX_SNMP = False
+
+if HAS_PYAOSCX_SNMP:
+    from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+        get_pyaoscx_session,
+    )
+
+
+def main():
+    module_args = dict(
+        user_name=dict(type="str", required=True),
+        access_level=dict(type="str", required=False, choices=["ro", "rw"]),
+        auth_protocol=dict(
+            type="str",
+            required=False,
+            choices=[
+                "md5",
+                "sha",
+                "sha224",
+                "sha256",
+                "sha384",
+                "sha512",
+                "none",
+            ],
+        ),
+        auth_pass_phrase=dict(type="str", required=False, no_log=True),
+        priv_protocol=dict(
+            type="str",
+            required=False,
+            choices=["aes", "aes192", "aes256", "des", "none"],
+        ),
+        priv_pass_phrase=dict(type="str", required=False, no_log=True),
+        remote_engine_id=dict(type="str", required=False),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    result = dict(changed=False)
+
+    if not HAS_PYAOSCX_SNMP:
+        ansible_module.fail_json(
+            msg="This pyaoscx version does not support SNMP. Upgrade pyaoscx."
+        )
+
+    if ansible_module.check_mode:
+        ansible_module.exit_json(**result)
+
+    user_name = ansible_module.params["user_name"]
+    state = ansible_module.params["state"]
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    user = Snmpv3User(session, user_name)
+    try:
+        user.get()
+        exists = True
+    except Exception:
+        exists = False
+
+    if state == "delete":
+        if exists:
+            user.delete()
+            result["changed"] = True
+        ansible_module.exit_json(**result)
+
+    kwargs = {}
+    for field in (
+        "access_level",
+        "auth_protocol",
+        "auth_pass_phrase",
+        "priv_protocol",
+        "priv_pass_phrase",
+        "remote_engine_id",
+    ):
+        value = ansible_module.params[field]
+        if value is not None:
+            kwargs[field] = value
+
+    for key, value in kwargs.items():
+        setattr(user, key, value)
+    result["changed"] = user.apply()
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/modules/test_aoscx_snmp.py
+++ b/tests/unit/modules/test_aoscx_snmp.py
@@ -1,0 +1,103 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+
+"""Offline unit tests for the SNMP family modules. AnsibleModule and the
+pyaoscx SDK are mocked, so no switch is needed."""
+
+import sys
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+MODULES = "ansible_collections.arubanetworks.aoscx.plugins.modules"
+
+
+@pytest.fixture
+def run():
+    def _run(module, params, sdk_mocks):
+        full = MODULES + "." + module
+        with patch(full + ".AnsibleModule") as am, patch(
+            full + ".get_pyaoscx_session", return_value=MagicMock()
+        ):
+            mod = sys.modules[full]
+            inst = MagicMock(params=params, check_mode=False)
+            result = {}
+
+            def _exit(**k):
+                result.update(k)
+                raise SystemExit
+
+            inst.exit_json.side_effect = _exit
+            am.return_value = inst
+            for name, obj in sdk_mocks.items():
+                setattr(mod, name, obj)
+            try:
+                mod.main()
+            except SystemExit:
+                pass
+            return result
+
+    return _run
+
+
+def test_user_create(run):
+    import ansible_collections.arubanetworks.aoscx.plugins.modules.aoscx_snmpv3_user  # NOQA
+
+    user = MagicMock()
+    user.get.side_effect = Exception("no")
+    user.apply.return_value = True
+    res = run(
+        "aoscx_snmpv3_user",
+        {
+            "user_name": "u1",
+            "access_level": "ro",
+            "auth_protocol": None,
+            "auth_pass_phrase": None,
+            "priv_protocol": None,
+            "priv_pass_phrase": None,
+            "remote_engine_id": None,
+            "state": "create",
+        },
+        {"Snmpv3User": MagicMock(return_value=user)},
+    )
+    assert res["changed"] is True
+
+
+def test_community_delete(run):
+    import ansible_collections.arubanetworks.aoscx.plugins.modules.aoscx_snmp_community  # NOQA
+
+    comm = MagicMock()
+    comm.get.return_value = True
+    res = run(
+        "aoscx_snmp_community",
+        {"name": "c1", "snmp_view": None, "state": "delete"},
+        {"SnmpCommunity": MagicMock(return_value=comm)},
+    )
+    assert res["changed"] is True
+    comm.delete.assert_called_once()
+
+
+def test_trap_create(run):
+    import ansible_collections.arubanetworks.aoscx.plugins.modules.aoscx_snmp_trap  # NOQA
+
+    trap = MagicMock()
+    trap.get.side_effect = Exception("no")
+    res = run(
+        "aoscx_snmp_trap",
+        {
+            "vrf": "default",
+            "receiver_address": "198.51.100.5",
+            "receiver_udp_port": 162,
+            "type": "trap",
+            "version": "v2c",
+            "community_name": "public",
+            "state": "create",
+        },
+        {
+            "SnmpTrap": MagicMock(return_value=trap),
+            "Vrf": MagicMock(return_value=MagicMock()),
+        },
+    )
+    assert res["changed"] is True
+    trap.create.assert_called_once()


### PR DESCRIPTION
Fixes #204

## Summary

Add the SNMP family of modules:

- `aoscx_snmpv3_user` — SNMPv3 users (access level, auth/priv protocols
  and pass phrases marked `no_log`, remote engine ID).
- `aoscx_snmp_community` — SNMP communities, optional view link.
- `aoscx_snmp_view` — SNMP views; the requested entries fully replace the
  existing ones (view entries are immutable on the device).
- `aoscx_snmp_trap` — SNMP trap receivers (create/delete, compound key).

The connection plugin now also accepts REST API versions 10.13 and 10.16;
the SNMP endpoints require at least 10.13.

All modules support check mode.

## Testing

- Unit tests: `tests/unit/modules/test_aoscx_snmp.py` (3 passing).
- `ansible-test sanity --test validate-modules` — clean.
- Live lifecycle (create + idempotency + delete) on a CX6300 FL.10.17
  switch at REST v10.16.

## Dependency

Depends on SDK PR aruba/pyaoscx#77

## Depends on
- aruba/pyaoscx#77 — SNMP family classes
- aruba/pyaoscx#119 — REST API version modules `v10.13` / `v10.16` (needed to reach this feature at the 10.13/10.16 REST schema)
