### PR TITLE
Add aoscx_syslog_remote module

### DIFF
--- a/changelogs/fragments/aoscx_syslog.yml
+++ b/changelogs/fragments/aoscx_syslog.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - aoscx_syslog_remote - new module to manage remote syslog servers.

--- a/plugins/modules/aoscx_syslog_remote.py
+++ b/plugins/modules/aoscx_syslog_remote.py
@@ -1,0 +1,217 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_syslog_remote
+version_added: "4.6.0"
+short_description: Create, update or delete a remote syslog server
+description: >
+  This module provides configuration management of remote syslog servers on
+  AOS-CX devices (system/syslog_remotes).
+author: Aruba Networks (@ArubaNetworks)
+options:
+  remote_host:
+    description: IP address or hostname of the remote syslog server. Index
+      under system/syslog_remotes.
+    required: true
+    type: str
+  vrf:
+    description: Name of the VRF used to reach the server.
+    required: false
+    type: str
+    default: default
+  transport:
+    description: Transport protocol used to reach the server.
+    required: false
+    type: str
+    choices:
+      - udp
+      - tcp
+      - tls
+  port_number:
+    description: Destination port of the remote syslog server.
+    required: false
+    type: int
+  severity:
+    description: Minimum severity of logs sent to the server.
+    required: false
+    type: str
+    choices:
+      - debug
+      - info
+      - notice
+      - warning
+      - err
+      - crit
+      - alert
+      - emerg
+  include_auditable_events:
+    description: Whether auditable events are forwarded to the server.
+    required: false
+    type: bool
+  disable:
+    description: Disable forwarding to this server without removing it.
+    required: false
+    type: bool
+  state:
+    description: Create, update or delete the remote syslog server.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a remote syslog server over TCP
+  aoscx_syslog_remote:
+    remote_host: 192.0.2.10
+    transport: tcp
+    port_number: 514
+    severity: info
+
+- name: Delete a remote syslog server
+  aoscx_syslog_remote:
+    remote_host: 192.0.2.10
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+    from pyaoscx.syslog_remote import SyslogRemote
+    from pyaoscx.vrf import Vrf
+
+    HAS_PYAOSCX_SYSLOG = True
+except ImportError:
+    HAS_PYAOSCX_SYSLOG = False
+
+if HAS_PYAOSCX_SYSLOG:
+    from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+        get_pyaoscx_session,
+    )
+
+
+def main():
+    module_args = dict(
+        remote_host=dict(type="str", required=True),
+        vrf=dict(type="str", required=False, default="default"),
+        transport=dict(
+            type="str", required=False, choices=["udp", "tcp", "tls"]
+        ),
+        port_number=dict(type="int", required=False),
+        severity=dict(
+            type="str",
+            required=False,
+            choices=[
+                "debug",
+                "info",
+                "notice",
+                "warning",
+                "err",
+                "crit",
+                "alert",
+                "emerg",
+            ],
+        ),
+        include_auditable_events=dict(type="bool", required=False),
+        disable=dict(type="bool", required=False),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    result = dict(changed=False)
+
+    if not HAS_PYAOSCX_SYSLOG:
+        ansible_module.fail_json(
+            msg="This pyaoscx version does not support syslog remotes. "
+            "Upgrade pyaoscx."
+        )
+
+    if ansible_module.check_mode:
+        ansible_module.exit_json(**result)
+
+    remote_host = ansible_module.params["remote_host"]
+    vrf = ansible_module.params["vrf"]
+    state = ansible_module.params["state"]
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    remote = SyslogRemote(session, remote_host)
+    try:
+        remote.get()
+        exists = True
+    except Exception:
+        exists = False
+
+    if state == "delete":
+        if exists:
+            remote.delete()
+            result["changed"] = True
+        ansible_module.exit_json(**result)
+
+    kwargs = {}
+    for field in (
+        "transport",
+        "port_number",
+        "severity",
+        "include_auditable_events",
+        "disable",
+    ):
+        value = ansible_module.params[field]
+        if value is not None:
+            kwargs[field] = value
+
+    if vrf is not None and not exists:
+        vrf_obj = Vrf(session, vrf)
+        vrf_obj.get()
+        kwargs["vrf"] = vrf_obj.get_uri()
+
+    changed = not exists
+    for key, value in kwargs.items():
+        if not exists or getattr(remote, key, None) != value:
+            setattr(remote, key, value)
+            if key not in remote.config_attrs:
+                remote.config_attrs.append(key)
+            changed = True
+
+    if changed:
+        remote.apply()
+    result["changed"] = changed
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/modules/test_aoscx_syslog.py
+++ b/tests/unit/modules/test_aoscx_syslog.py
@@ -1,0 +1,89 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+
+"""Offline unit tests for aoscx_syslog_remote. SDK + AnsibleModule mocked."""
+
+import sys
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+MODULES = "ansible_collections.arubanetworks.aoscx.plugins.modules"
+
+
+@pytest.fixture
+def run():
+    def _run(module, params, sdk_mocks):
+        full = MODULES + "." + module
+        with patch(full + ".AnsibleModule") as am, patch(
+            full + ".get_pyaoscx_session", return_value=MagicMock()
+        ):
+            mod = sys.modules[full]
+            inst = MagicMock(params=params, check_mode=False)
+            result = {}
+
+            def _exit(**k):
+                result.update(k)
+                raise SystemExit
+
+            inst.exit_json.side_effect = _exit
+            am.return_value = inst
+            for name, obj in sdk_mocks.items():
+                setattr(mod, name, obj)
+            try:
+                mod.main()
+            except SystemExit:
+                pass
+            return result
+
+    return _run
+
+
+def test_create(run):
+    import ansible_collections.arubanetworks.aoscx.plugins.modules.aoscx_syslog_remote  # NOQA
+
+    r = MagicMock()
+    r.get.side_effect = Exception("no")
+    r.apply.return_value = True
+    res = run(
+        "aoscx_syslog_remote",
+        {
+            "remote_host": "192.0.2.10",
+            "vrf": "default",
+            "transport": "tcp",
+            "port_number": 514,
+            "severity": "info",
+            "include_auditable_events": None,
+            "disable": None,
+            "state": "create",
+        },
+        {
+            "SyslogRemote": MagicMock(return_value=r),
+            "Vrf": MagicMock(return_value=MagicMock()),
+        },
+    )
+    assert res["changed"] is True
+
+
+def test_delete(run):
+    import ansible_collections.arubanetworks.aoscx.plugins.modules.aoscx_syslog_remote  # NOQA
+
+    r = MagicMock()
+    r.get.return_value = True
+    res = run(
+        "aoscx_syslog_remote",
+        {
+            "remote_host": "192.0.2.10",
+            "vrf": "default",
+            "transport": None,
+            "port_number": None,
+            "severity": None,
+            "include_auditable_events": None,
+            "disable": None,
+            "state": "delete",
+        },
+        {"SyslogRemote": MagicMock(return_value=r), "Vrf": MagicMock()},
+    )
+    assert res["changed"] is True
+    r.delete.assert_called_once()


### PR DESCRIPTION
Fixes #205

## Summary

Add the `aoscx_syslog_remote` module to manage remote syslog servers
(`system/syslog_remotes`) on AOS-CX switches. Backed by the pyaoscx
`SyslogRemote` class.

Options: `remote_host` (required), `vrf`, `transport` (udp/tcp/tls),
`port_number`, `severity`, `include_auditable_events`, `disable`, `state`.
Supports check mode and per-attribute idempotency.

Works on REST API v10.09.

## Testing

- Unit tests (`tests/unit/modules/test_aoscx_syslog.py`) — 2 passing.
- ansible-test validate-modules — clean.
- Live: create + idempotent rerun + delete on a CX6300 FL.10.17 switch.

## Depends on
- aruba/pyaoscx#81 — SyslogRemote
