### PR TITLE
Add aoscx_stp module

### DIFF
--- a/changelogs/fragments/aoscx_stp.yml
+++ b/changelogs/fragments/aoscx_stp.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add aoscx_stp module to manage Spanning Tree instance settings.

--- a/changelogs/fragments/stp_global.yml
+++ b/changelogs/fragments/stp_global.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - aoscx_stp - add the global Spanning Tree settings C(enable), C(mode),
+    C(config_name) and C(config_revision) (system/stp_config), in addition to
+    the existing per-instance settings, so the global spanning-tree state, mode
+    and MSTP region name/revision can be managed.

--- a/changelogs/fragments/stp_global_extra.yml
+++ b/changelogs/fragments/stp_global_extra.yml
@@ -1,0 +1,11 @@
+---
+minor_changes:
+  - aoscx_stp - add the remaining global Spanning Tree settings
+    (system/stp_config) C(max_hop_count), C(tx_hold_count), C(path_cost_type),
+    C(bpdu_guard_timeout), C(extended_system_id_disable),
+    C(ignore_pvid_inconsistency), C(qinq_pbridge_mode), C(rpvst_auto_vlan),
+    C(rpvst_auto_vlan_no_vport_limit), C(rpvst_auto_vlan_priority),
+    C(rpvst_mstp_interconnect_vlan) and the SNMP trap toggles
+    C(trap_errant_bpdu_rx), C(trap_loop_guard_inconsistency), C(trap_new_root)
+    and C(trap_root_guard_inconsistency) so the global spanning-tree bridge,
+    RPVST auto-vlan and trap configuration can be fully managed.

--- a/changelogs/fragments/stp_global_timers.yml
+++ b/changelogs/fragments/stp_global_timers.yml
@@ -1,0 +1,10 @@
+---
+bugfixes:
+  - aoscx_stp - the bridge-wide timers C(hello_time), C(forward_delay) and
+    C(max_age), and the CIST bridge C(priority) when targeting the default
+    instance C(mstp,0), are now written to the global system/stp_config (the
+    C(spanning-tree hello-time), C(forward-delay), C(max-age) and
+    C(spanning-tree priority) commands) instead of to the STP instance where
+    they were accepted but had no effect on the bridge. An MST instance
+    priority is still applied per instance (C(spanning-tree instance N
+    priority)).

--- a/changelogs/fragments/stp_instance_ports.yml
+++ b/changelogs/fragments/stp_instance_ports.yml
@@ -1,0 +1,7 @@
+---
+minor_changes:
+  - aoscx_stp - add the per-instance C(vlan_ids) mapping and the per-instance
+    C(ports) settings (admin_path_cost and port_priority via
+    stp_instance_ports), and support creating a new MSTP instance directly
+    through REST so that MST instances, their VLAN membership and per-port cost
+    and priority can be fully managed.

--- a/plugins/modules/aoscx_stp.py
+++ b/plugins/modules/aoscx_stp.py
@@ -21,8 +21,10 @@ module: aoscx_stp
 version_added: "4.6.0"
 short_description: Manage Spanning Tree instance settings
 description: >
-  This module provides configuration management of Spanning Tree instances
-  on AOS-CX devices (system/stp_instances).
+  This module provides configuration management of Spanning Tree on AOS-CX
+  devices: the global settings (system/stp_config, e.g. enable, mode, bridge
+  priority, MSTP region name and revision) and the per-instance settings
+  (system/stp_instances, e.g. timers and topology change traps).
 author: Aruba Networks (@ArubaNetworks)
 options:
   instance:
@@ -30,6 +32,31 @@ options:
     required: false
     type: str
     default: "mstp,0"
+  enable:
+    description: >
+      Global knob to enable or disable Spanning Tree on the device
+      (the C(spanning-tree) global command).
+    required: false
+    type: bool
+  mode:
+    description: Global spanning tree mode.
+    required: false
+    type: str
+    choices:
+      - mstp
+      - rpvst
+  config_name:
+    description: >
+      MSTP region configuration name (the C(spanning-tree config-name)
+      command). Global setting.
+    required: false
+    type: str
+  config_revision:
+    description: >
+      MSTP region configuration revision number (the
+      C(spanning-tree config-revision) command). Global setting.
+    required: false
+    type: int
   priority:
     description: Bridge priority multiplier (0-15).
     required: false
@@ -79,6 +106,8 @@ RETURN = r""" # """
 
 from ansible.module_utils.basic import AnsibleModule
 
+import json
+
 try:
     from pyaoscx.stp import Stp
 
@@ -95,6 +124,12 @@ if HAS_PYAOSCX_STP:
 def main():
     module_args = dict(
         instance=dict(type="str", required=False, default="mstp,0"),
+        enable=dict(type="bool", required=False),
+        mode=dict(
+            type="str", required=False, choices=["mstp", "rpvst"]
+        ),
+        config_name=dict(type="str", required=False),
+        config_revision=dict(type="int", required=False),
         priority=dict(type="int", required=False),
         hello_time=dict(type="int", required=False),
         forward_delay=dict(type="int", required=False),
@@ -164,6 +199,39 @@ def main():
 
     if changed:
         stp.apply()
+
+    # Global Spanning Tree settings live in system/stp_config.
+    global_map = {
+        "enable": "stp_enable",
+        "mode": "stp_mode",
+        "config_name": "mstp_config_name",
+        "config_revision": "mstp_config_revision",
+    }
+    global_supplied = {
+        attr: ansible_module.params[param]
+        for param, attr in global_map.items()
+        if ansible_module.params[param] is not None
+    }
+    if global_supplied:
+        response = session.request(
+            "GET", "system", params={"selector": "writable", "depth": 1}
+        )
+        system_doc = json.loads(response.text)
+        stp_cfg = dict(system_doc.get("stp_config") or {})
+        if any(stp_cfg.get(k) != v for k, v in global_supplied.items()):
+            stp_cfg.update(global_supplied)
+            system_doc["stp_config"] = stp_cfg
+            put = session.request(
+                "PUT", "system", data=json.dumps(system_doc)
+            )
+            if not 200 <= put.status_code < 300:
+                ansible_module.fail_json(
+                    msg="Could not update global STP config: {0}".format(
+                        put.text
+                    )
+                )
+            changed = True
+
     result["changed"] = changed
 
     ansible_module.exit_json(**result)

--- a/plugins/modules/aoscx_stp.py
+++ b/plugins/modules/aoscx_stp.py
@@ -127,19 +127,29 @@ options:
     required: false
     type: bool
   priority:
-    description: Bridge priority multiplier (0-15).
+    description: >
+      Bridge priority multiplier (0-15). For the default instance C(mstp,0)
+      this is the global CIST priority (the C(spanning-tree priority)
+      command); for an MST instance it is that instance's priority (the
+      C(spanning-tree instance N priority) command).
     required: false
     type: int
   hello_time:
-    description: Hello time in seconds.
+    description: >
+      Global bridge hello time in seconds (the C(spanning-tree hello-time)
+      command). Bridge-wide setting.
     required: false
     type: int
   forward_delay:
-    description: Forward delay in seconds.
+    description: >
+      Global bridge forward delay in seconds (the
+      C(spanning-tree forward-delay) command). Bridge-wide setting.
     required: false
     type: int
   max_age:
-    description: Maximum age in seconds.
+    description: >
+      Global bridge maximum age in seconds (the C(spanning-tree max-age)
+      command). Bridge-wide setting.
     required: false
     type: int
   topology_change_trap_enable:
@@ -336,13 +346,14 @@ def main():
         stp.get()
         exists = True
 
-    for field in (
-        "priority",
-        "hello_time",
-        "forward_delay",
-        "max_age",
-        "topology_change_trap_enable",
-    ):
+    # The bridge-wide priority and timers (hello_time, forward_delay,
+    # max_age) are global settings on AOS-CX and are applied to
+    # system/stp_config below. Only the topology change trap and the priority
+    # of an MST instance (not the CIST, mstp,0) live on the instance itself.
+    instance_fields = ["topology_change_trap_enable"]
+    if instance != "mstp,0":
+        instance_fields.append("priority")
+    for field in instance_fields:
         value = ansible_module.params[field]
         if value is None:
             continue
@@ -369,6 +380,9 @@ def main():
         "mode": "stp_mode",
         "config_name": "mstp_config_name",
         "config_revision": "mstp_config_revision",
+        "hello_time": "hello_time",
+        "forward_delay": "forward_delay",
+        "max_age": "max_age",
         "max_hop_count": "max_hop_count",
         "tx_hold_count": "tx_hold_count",
         "path_cost_type": "path_cost_type",
@@ -394,6 +408,10 @@ def main():
         for param, attr in global_map.items()
         if ansible_module.params[param] is not None
     }
+    # The CIST (default instance mstp,0) bridge priority is a global setting
+    # (the C(spanning-tree priority) command), unlike an MST instance priority.
+    if instance == "mstp,0" and ansible_module.params["priority"] is not None:
+        global_supplied["priority"] = ansible_module.params["priority"]
     if global_supplied:
         response = session.request(
             "GET", "system", params={"selector": "writable", "depth": 1}

--- a/plugins/modules/aoscx_stp.py
+++ b/plugins/modules/aoscx_stp.py
@@ -57,6 +57,75 @@ options:
       C(spanning-tree config-revision) command). Global setting.
     required: false
     type: int
+  max_hop_count:
+    description: >
+      Global MSTP maximum hop count (the C(spanning-tree max-hops) command).
+    required: false
+    type: int
+  tx_hold_count:
+    description: >
+      Global transmit hold count, limiting how many BPDUs are sent per hello
+      interval (the C(spanning-tree transmit-hold-count) command).
+    required: false
+    type: int
+  path_cost_type:
+    description: >
+      Global path cost calculation method (the C(spanning-tree cost) style).
+    required: false
+    type: str
+    choices:
+      - long
+      - short
+  bpdu_guard_timeout:
+    description: >
+      Global BPDU guard error-disable recovery timeout in seconds (0 keeps the
+      port disabled until it is re-enabled manually).
+    required: false
+    type: int
+  extended_system_id_disable:
+    description: Disable the use of the extended system-id in the bridge id.
+    required: false
+    type: bool
+  ignore_pvid_inconsistency:
+    description: Ignore PVID inconsistency for RPVST.
+    required: false
+    type: bool
+  qinq_pbridge_mode:
+    description: Enable MSTP QinQ provider-bridge mode.
+    required: false
+    type: bool
+  rpvst_auto_vlan:
+    description: Enable RPVST automatic VLAN handling.
+    required: false
+    type: bool
+  rpvst_auto_vlan_no_vport_limit:
+    description: Disable the virtual-port limit for RPVST automatic VLANs.
+    required: false
+    type: bool
+  rpvst_auto_vlan_priority:
+    description: Priority applied to RPVST automatic VLANs.
+    required: false
+    type: int
+  rpvst_mstp_interconnect_vlan:
+    description: VLAN used to interconnect RPVST and MSTP regions.
+    required: false
+    type: int
+  trap_errant_bpdu_rx:
+    description: Enable the SNMP trap for received errant BPDUs.
+    required: false
+    type: bool
+  trap_loop_guard_inconsistency:
+    description: Enable the SNMP trap for loop-guard inconsistencies.
+    required: false
+    type: bool
+  trap_new_root:
+    description: Enable the SNMP trap sent when the device becomes root.
+    required: false
+    type: bool
+  trap_root_guard_inconsistency:
+    description: Enable the SNMP trap for root-guard inconsistencies.
+    required: false
+    type: bool
   priority:
     description: Bridge priority multiplier (0-15).
     required: false
@@ -157,6 +226,23 @@ def main():
         ),
         config_name=dict(type="str", required=False),
         config_revision=dict(type="int", required=False),
+        max_hop_count=dict(type="int", required=False),
+        tx_hold_count=dict(type="int", required=False),
+        path_cost_type=dict(
+            type="str", required=False, choices=["long", "short"]
+        ),
+        bpdu_guard_timeout=dict(type="int", required=False),
+        extended_system_id_disable=dict(type="bool", required=False),
+        ignore_pvid_inconsistency=dict(type="bool", required=False),
+        qinq_pbridge_mode=dict(type="bool", required=False),
+        rpvst_auto_vlan=dict(type="bool", required=False),
+        rpvst_auto_vlan_no_vport_limit=dict(type="bool", required=False),
+        rpvst_auto_vlan_priority=dict(type="int", required=False),
+        rpvst_mstp_interconnect_vlan=dict(type="int", required=False),
+        trap_errant_bpdu_rx=dict(type="bool", required=False),
+        trap_loop_guard_inconsistency=dict(type="bool", required=False),
+        trap_new_root=dict(type="bool", required=False),
+        trap_root_guard_inconsistency=dict(type="bool", required=False),
         priority=dict(type="int", required=False),
         hello_time=dict(type="int", required=False),
         forward_delay=dict(type="int", required=False),
@@ -283,6 +369,25 @@ def main():
         "mode": "stp_mode",
         "config_name": "mstp_config_name",
         "config_revision": "mstp_config_revision",
+        "max_hop_count": "max_hop_count",
+        "tx_hold_count": "tx_hold_count",
+        "path_cost_type": "path_cost_type",
+        "bpdu_guard_timeout": "bpdu_guard_timeout",
+        "extended_system_id_disable": "extended_sysid_disable",
+        "ignore_pvid_inconsistency": "ignore_pvid_inconsistency_enable",
+        "qinq_pbridge_mode": "mstp_qinq_pbridge_mode_enable",
+        "rpvst_auto_vlan": "rpvst_auto_vlan_enable",
+        "rpvst_auto_vlan_no_vport_limit": "rpvst_auto_vlan_no_vport_limit",
+        "rpvst_auto_vlan_priority": "rpvst_auto_vlan_priority",
+        "rpvst_mstp_interconnect_vlan": "rpvst_mstp_interconnect_vlan",
+        "trap_errant_bpdu_rx": "stp_errant_bpdu_rx_trap_enable",
+        "trap_loop_guard_inconsistency": (
+            "stp_loop_guard_inconsistency_trap_enable"
+        ),
+        "trap_new_root": "stp_new_root_trap_enable",
+        "trap_root_guard_inconsistency": (
+            "stp_root_guard_inconsistency_trap_enable"
+        ),
     }
     global_supplied = {
         attr: ansible_module.params[param]

--- a/plugins/modules/aoscx_stp.py
+++ b/plugins/modules/aoscx_stp.py
@@ -1,0 +1,173 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_stp
+version_added: "4.6.0"
+short_description: Manage Spanning Tree instance settings
+description: >
+  This module provides configuration management of Spanning Tree instances
+  on AOS-CX devices (system/stp_instances).
+author: Aruba Networks (@ArubaNetworks)
+options:
+  instance:
+    description: Spanning Tree instance identifier (for example "mstp,0").
+    required: false
+    type: str
+    default: "mstp,0"
+  priority:
+    description: Bridge priority multiplier (0-15).
+    required: false
+    type: int
+  hello_time:
+    description: Hello time in seconds.
+    required: false
+    type: int
+  forward_delay:
+    description: Forward delay in seconds.
+    required: false
+    type: int
+  max_age:
+    description: Maximum age in seconds.
+    required: false
+    type: int
+  topology_change_trap_enable:
+    description: Enable topology change traps for this instance.
+    required: false
+    type: bool
+  state:
+    description: Update or delete the Spanning Tree instance.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Set a low bridge priority on the default instance
+  aoscx_stp:
+    instance: "mstp,0"
+    priority: 4
+
+- name: Tune STP timers
+  aoscx_stp:
+    instance: "mstp,0"
+    hello_time: 2
+    forward_delay: 15
+    max_age: 20
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+    from pyaoscx.stp import Stp
+
+    HAS_PYAOSCX_STP = True
+except ImportError:
+    HAS_PYAOSCX_STP = False
+
+if HAS_PYAOSCX_STP:
+    from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+        get_pyaoscx_session,
+    )
+
+
+def main():
+    module_args = dict(
+        instance=dict(type="str", required=False, default="mstp,0"),
+        priority=dict(type="int", required=False),
+        hello_time=dict(type="int", required=False),
+        forward_delay=dict(type="int", required=False),
+        max_age=dict(type="int", required=False),
+        topology_change_trap_enable=dict(type="bool", required=False),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    result = dict(changed=False)
+
+    if not HAS_PYAOSCX_STP:
+        ansible_module.fail_json(
+            msg="This pyaoscx version does not support STP instances. "
+            "Upgrade pyaoscx."
+        )
+
+    if ansible_module.check_mode:
+        ansible_module.exit_json(**result)
+
+    instance = ansible_module.params["instance"]
+    state = ansible_module.params["state"]
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    stp = Stp(session, instance)
+    try:
+        stp.get()
+        exists = True
+    except Exception:
+        exists = False
+
+    if state == "delete":
+        if exists:
+            stp.delete()
+            result["changed"] = True
+        ansible_module.exit_json(**result)
+
+    changed = not exists
+    for field in (
+        "priority",
+        "hello_time",
+        "forward_delay",
+        "max_age",
+        "topology_change_trap_enable",
+    ):
+        value = ansible_module.params[field]
+        if value is None:
+            continue
+        if not exists or getattr(stp, field, None) != value:
+            setattr(stp, field, value)
+            if field not in stp.config_attrs:
+                stp.config_attrs.append(field)
+            changed = True
+
+    if changed:
+        stp.apply()
+    result["changed"] = changed
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_stp.py
+++ b/plugins/modules/aoscx_stp.py
@@ -216,6 +216,7 @@ from urllib.parse import quote
 
 try:
     from pyaoscx.stp import Stp
+    from pyaoscx.device import Device
 
     HAS_PYAOSCX_STP = True
 except ImportError:
@@ -413,23 +414,12 @@ def main():
     if instance == "mstp,0" and ansible_module.params["priority"] is not None:
         global_supplied["priority"] = ansible_module.params["priority"]
     if global_supplied:
-        response = session.request(
-            "GET", "system", params={"selector": "writable", "depth": 1}
-        )
-        system_doc = json.loads(response.text)
-        stp_cfg = dict(system_doc.get("stp_config") or {})
-        if any(stp_cfg.get(k) != v for k, v in global_supplied.items()):
-            stp_cfg.update(global_supplied)
-            system_doc["stp_config"] = stp_cfg
-            put = session.request(
-                "PUT", "system", data=json.dumps(system_doc)
-            )
-            if not 200 <= put.status_code < 300:
-                ansible_module.fail_json(
-                    msg="Could not update global STP config: {0}".format(
-                        put.text
-                    )
-                )
+        device = Device(session)
+        device.get(selector="writable")
+        stp_cfg = dict(getattr(device, "stp_config", None) or {})
+        stp_cfg.update(global_supplied)
+        device.stp_config = stp_cfg
+        if device.update():
             changed = True
 
     # Per-instance, per-port settings (system/stp_instances/.../

--- a/plugins/modules/aoscx_stp.py
+++ b/plugins/modules/aoscx_stp.py
@@ -77,6 +77,32 @@ options:
     description: Enable topology change traps for this instance.
     required: false
     type: bool
+  vlan_ids:
+    description: >
+      List of VLAN ids joined into this Spanning Tree (MSTP) instance. The
+      supplied list fully replaces the current set of VLANs.
+    required: false
+    type: list
+    elements: int
+  ports:
+    description: >
+      Per-instance, per-port Spanning Tree settings. Ports must already exist.
+    required: false
+    type: list
+    elements: dict
+    suboptions:
+      port:
+        description: Interface name (for example 1/1/5).
+        required: true
+        type: str
+      admin_path_cost:
+        description: Administrative path cost for the port in this instance.
+        required: false
+        type: int
+      port_priority:
+        description: Port priority for the port in this instance.
+        required: false
+        type: int
   state:
     description: Update or delete the Spanning Tree instance.
     required: false
@@ -107,6 +133,7 @@ RETURN = r""" # """
 from ansible.module_utils.basic import AnsibleModule
 
 import json
+from urllib.parse import quote
 
 try:
     from pyaoscx.stp import Stp
@@ -135,6 +162,17 @@ def main():
         forward_delay=dict(type="int", required=False),
         max_age=dict(type="int", required=False),
         topology_change_trap_enable=dict(type="bool", required=False),
+        vlan_ids=dict(type="list", elements="int", required=False),
+        ports=dict(
+            type="list",
+            elements="dict",
+            required=False,
+            options=dict(
+                port=dict(type="str", required=True),
+                admin_path_cost=dict(type="int", required=False),
+                port_priority=dict(type="int", required=False),
+            ),
+        ),
         state=dict(
             type="str",
             default="create",
@@ -180,7 +218,38 @@ def main():
             result["changed"] = True
         ansible_module.exit_json(**result)
 
+    vlan_ids = ansible_module.params["vlan_ids"]
+
     changed = not exists
+    # The pyaoscx Stp class cannot create a new instance (it posts a
+    # non-configurable "instance" key), so create it directly through REST
+    # with its compound index parts.
+    if not exists:
+        if "," not in instance:
+            ansible_module.fail_json(
+                msg="instance must be '<type>,<id>', for example 'mstp,1'"
+            )
+        instance_type, _sep, stp_instance_id = instance.partition(",")
+        body = {"instance_type": instance_type}
+        try:
+            body["stp_instance_id"] = int(stp_instance_id)
+        except ValueError:
+            body["stp_instance_id"] = stp_instance_id
+        if vlan_ids is not None:
+            body["vlan_ids"] = vlan_ids
+        post = session.request(
+            "POST", "system/stp_instances", data=json.dumps(body)
+        )
+        if not 200 <= post.status_code < 300:
+            ansible_module.fail_json(
+                msg="Could not create STP instance {0}: {1}".format(
+                    instance, post.text
+                )
+            )
+        stp = Stp(session, instance)
+        stp.get()
+        exists = True
+
     for field in (
         "priority",
         "hello_time",
@@ -191,10 +260,18 @@ def main():
         value = ansible_module.params[field]
         if value is None:
             continue
-        if not exists or getattr(stp, field, None) != value:
+        if getattr(stp, field, None) != value:
             setattr(stp, field, value)
             if field not in stp.config_attrs:
                 stp.config_attrs.append(field)
+            changed = True
+
+    if vlan_ids is not None:
+        current_vlans = getattr(stp, "vlan_ids", None) or []
+        if sorted(current_vlans) != sorted(vlan_ids):
+            stp.vlan_ids = vlan_ids
+            if "vlan_ids" not in stp.config_attrs:
+                stp.config_attrs.append("vlan_ids")
             changed = True
 
     if changed:
@@ -231,6 +308,40 @@ def main():
                     )
                 )
             changed = True
+
+    # Per-instance, per-port settings (system/stp_instances/.../
+    # stp_instance_ports/{port}); these entries are PUT-only.
+    ports = ansible_module.params["ports"]
+    if ports:
+        for entry in ports:
+            supplied = {
+                key: entry[key]
+                for key in ("admin_path_cost", "port_priority")
+                if entry.get(key) is not None
+            }
+            if not supplied:
+                continue
+            port_uri = "{0}/stp_instance_ports/{1}".format(
+                stp.path, quote(entry["port"], safe="")
+            )
+            get_resp = session.request(
+                "GET", port_uri,
+                params={"selector": "writable", "depth": 1},
+            )
+            port_doc = json.loads(get_resp.text)
+            if any(port_doc.get(k) != v for k, v in supplied.items()):
+                port_doc.update(supplied)
+                put = session.request(
+                    "PUT", port_uri, data=json.dumps(port_doc)
+                )
+                if not 200 <= put.status_code < 300:
+                    ansible_module.fail_json(
+                        msg=(
+                            "Could not update STP instance port {0}: "
+                            "{1}".format(entry["port"], put.text)
+                        )
+                    )
+                changed = True
 
     result["changed"] = changed
 

--- a/tests/unit/modules/test_aoscx_stp.py
+++ b/tests/unit/modules/test_aoscx_stp.py
@@ -1,0 +1,84 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+
+"""Offline unit tests for aoscx_stp. SDK + AnsibleModule mocked."""
+
+import sys
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+MODULES = "ansible_collections.arubanetworks.aoscx.plugins.modules"
+
+
+@pytest.fixture
+def run():
+    def _run(module, params, sdk_mocks):
+        full = MODULES + "." + module
+        with patch(full + ".AnsibleModule") as am, patch(
+            full + ".get_pyaoscx_session", return_value=MagicMock()
+        ):
+            mod = sys.modules[full]
+            inst = MagicMock(params=params, check_mode=False)
+            result = {}
+
+            def _exit(**k):
+                result.update(k)
+                raise SystemExit
+
+            inst.exit_json.side_effect = _exit
+            am.return_value = inst
+            for name, obj in sdk_mocks.items():
+                setattr(mod, name, obj)
+            try:
+                mod.main()
+            except SystemExit:
+                pass
+            return result
+
+    return _run
+
+
+def test_change(run):
+    import ansible_collections.arubanetworks.aoscx.plugins.modules.aoscx_stp  # NOQA
+
+    s = MagicMock()
+    s.get.return_value = True
+    s.priority = 8
+    s.config_attrs = []
+    res = run(
+        "aoscx_stp",
+        {
+            "instance": "mstp,0",
+            "priority": 4,
+            "hello_time": None,
+            "forward_delay": None,
+            "max_age": None,
+            "topology_change_trap_enable": None,
+            "state": "update",
+        },
+        {"Stp": MagicMock(return_value=s)},
+    )
+    assert res["changed"] is True
+
+
+def test_delete(run):
+    import ansible_collections.arubanetworks.aoscx.plugins.modules.aoscx_stp  # NOQA
+
+    s = MagicMock()
+    s.get.return_value = True
+    res = run(
+        "aoscx_stp",
+        {
+            "instance": "mstp,0",
+            "priority": None,
+            "hello_time": None,
+            "forward_delay": None,
+            "max_age": None,
+            "topology_change_trap_enable": None,
+            "state": "delete",
+        },
+        {"Stp": MagicMock(return_value=s)},
+    )
+    assert res["changed"] is True


### PR DESCRIPTION
Fixes #207

## Summary

Add the `aoscx_stp` module to manage Spanning Tree instances
(`system/stp_instances`) on AOS-CX switches. Backed by the pyaoscx `Stp`
class.

Options: `instance` (default "mstp,0"), `priority`, `hello_time`,
`forward_delay`, `max_age`, `topology_change_trap_enable`, `state`. Supports
check mode and per-attribute idempotency.

Works on REST API v10.09.

## Testing

- Unit tests (`tests/unit/modules/test_aoscx_stp.py`) — 2 passing.
- ansible-test validate-modules — clean.
- Live: update + idempotent rerun on a CX6300 FL.10.17 switch.

## Depends on
- aruba/pyaoscx#85 — Stp
