### PR TITLE
Add DHCP snooping guard, IPv6 destination guard and static IP binding modules

### DIFF
--- a/changelogs/fragments/dhcp-snooping-guard.yml
+++ b/changelogs/fragments/dhcp-snooping-guard.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - New module ``aoscx_dhcpv4_snooping_guard`` to manage DHCPv4 snooping guard policies.
+  - New module ``aoscx_dhcpv6_snooping_guard`` to manage DHCPv6 snooping guard policies.
+  - New module ``aoscx_ipv6_destination_guard`` to manage IPv6 destination guard policies.
+  - New module ``aoscx_static_ip_binding`` to manage static IP source bindings.

--- a/changelogs/fragments/dhcpv6_snooping_guard_match.yml
+++ b/changelogs/fragments/dhcpv6_snooping_guard_match.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - aoscx_dhcpv6_snooping_guard - add the C(client_prefix_list) and
+    C(server_preference_range) options to restrict the IPv6 prefixes a client
+    may use and the allowed DHCPv6 server preference value range.

--- a/plugins/modules/aoscx_dhcpv4_snooping_guard.py
+++ b/plugins/modules/aoscx_dhcpv4_snooping_guard.py
@@ -149,7 +149,7 @@ def main():
         current = getattr(policy, attr, None)
         if isinstance(current, dict):
             current = next(iter(current.values()), "")
-        if str(current).rstrip("/").split("/")[-1] != value.rstrip("/").split("/")[-1]:
+        if str(current).rstrip("/").rsplit("/", 1)[-1] != value.rstrip("/").rsplit("/", 1)[-1]:
             setattr(policy, attr, value)
             if attr not in policy.config_attrs:
                 policy.config_attrs.append(attr)

--- a/plugins/modules/aoscx_dhcpv4_snooping_guard.py
+++ b/plugins/modules/aoscx_dhcpv4_snooping_guard.py
@@ -1,0 +1,168 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_dhcpv4_snooping_guard
+version_added: "4.6.0"
+short_description: Create, update or delete a DHCPv4 snooping guard policy.
+description:
+  - This module manages DHCPv4 snooping guard policies on AOS-CX switches.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: Name of the DHCPv4 snooping guard policy.
+    required: true
+    type: str
+  server_access_list:
+    description: >
+      Name of the existing IPv4 ACL used to filter packets from trusted DHCP
+      servers. When omitted server filtering is left unchanged.
+    required: false
+    type: str
+  state:
+    description: Create, update or delete the policy.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a DHCPv4 snooping guard policy
+  arubanetworks.aoscx.aoscx_dhcpv4_snooping_guard:
+    name: v4-guard-1
+    server_access_list: trusted-servers
+    state: create
+
+- name: Delete a DHCPv4 snooping guard policy
+  arubanetworks.aoscx.aoscx_dhcpv4_snooping_guard:
+    name: v4-guard-1
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        name=dict(type="str", required=True),
+        server_access_list=dict(type="str", required=False, default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    name = ansible_module.params["name"]
+    server_access_list = ansible_module.params["server_access_list"]
+    state = ansible_module.params["state"]
+
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    supplied = {}
+    if server_access_list is not None:
+        acl = session.api.get_module(
+            session, "ACL", server_access_list, list_type="ipv4"
+        )
+        supplied["match_server_access_list"] = acl.get_uri()
+
+    try:
+        policy = session.api.get_module(
+            session, "Dhcpv4SnoopingGuardPolicy", name
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support DHCPv4 snooping guard "
+                "policies. Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        policy.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                policy.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete policy: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    if not exists:
+        policy = session.api.get_module(
+            session, "Dhcpv4SnoopingGuardPolicy", name, **supplied
+        )
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                policy.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create policy: {0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+    for attr, value in supplied.items():
+        if getattr(policy, attr, None) != value:
+            setattr(policy, attr, value)
+            if attr not in policy.config_attrs:
+                policy.config_attrs.append(attr)
+            changed = True
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            policy.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update policy: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_dhcpv4_snooping_guard.py
+++ b/plugins/modules/aoscx_dhcpv4_snooping_guard.py
@@ -146,7 +146,10 @@ def main():
 
     changed = False
     for attr, value in supplied.items():
-        if getattr(policy, attr, None) != value:
+        current = getattr(policy, attr, None)
+        if isinstance(current, dict):
+            current = next(iter(current.values()), "")
+        if str(current).rstrip("/").split("/")[-1] != value.rstrip("/").split("/")[-1]:
             setattr(policy, attr, value)
             if attr not in policy.config_attrs:
                 policy.config_attrs.append(attr)

--- a/plugins/modules/aoscx_dhcpv6_snooping_guard.py
+++ b/plugins/modules/aoscx_dhcpv6_snooping_guard.py
@@ -34,7 +34,28 @@ options:
       servers. When omitted server filtering is left unchanged.
     required: false
     type: str
-
+  client_prefix_list:
+    description: >
+      Name of the existing prefix list of IPv6 prefixes that a client is
+      allowed to use. The prefix list must already exist. When omitted the
+      client prefix filtering is left unchanged.
+    required: false
+    type: str
+  server_preference_range:
+    description: >
+      Allowed DHCPv6 server preference value range. The supplied dictionary
+      fully replaces the current settings.
+    required: false
+    type: dict
+    suboptions:
+      preference_min:
+        description: Minimum allowed preference value (0-255).
+        required: false
+        type: int
+      preference_max:
+        description: Maximum allowed preference value (0-255).
+        required: false
+        type: int
   state:
     description: Create, update or delete the policy.
     required: false
@@ -71,6 +92,20 @@ def main():
     module_args = dict(
         name=dict(type="str", required=True),
         server_access_list=dict(type="str", required=False, default=None),
+        client_prefix_list=dict(type="str", required=False, default=None),
+        server_preference_range=dict(
+            type="dict",
+            required=False,
+            default=None,
+            options=dict(
+                preference_min=dict(
+                    type="int", required=False, default=None
+                ),
+                preference_max=dict(
+                    type="int", required=False, default=None
+                ),
+            ),
+        ),
         state=dict(
             type="str",
             default="create",
@@ -84,6 +119,8 @@ def main():
 
     name = ansible_module.params["name"]
     server_access_list = ansible_module.params["server_access_list"]
+    client_prefix_list = ansible_module.params["client_prefix_list"]
+    server_preference_range = ansible_module.params["server_preference_range"]
     state = ansible_module.params["state"]
 
     result = dict(changed=False)
@@ -101,6 +138,13 @@ def main():
             session, "ACL", server_access_list, list_type="ipv6"
         )
         supplied["match_server_access_list"] = acl.get_uri()
+    if client_prefix_list is not None:
+        prefix_list = session.api.get_module(
+            session, "PrefixList", client_prefix_list
+        )
+        supplied["match_client_prefix_list"] = "{0}{1}".format(
+            session.resource_prefix, prefix_list.path
+        )
 
     try:
         policy = session.api.get_module(
@@ -132,8 +176,15 @@ def main():
         ansible_module.exit_json(**result)
 
     if not exists:
+        create_kwargs = dict(supplied)
+        if server_preference_range is not None:
+            create_kwargs["server_preference_range"] = {
+                k: v
+                for k, v in server_preference_range.items()
+                if v is not None
+            }
         policy = session.api.get_module(
-            session, "Dhcpv6SnoopingGuardPolicy", name, **supplied
+            session, "Dhcpv6SnoopingGuardPolicy", name, **create_kwargs
         )
         result["changed"] = True
         if not ansible_module.check_mode:
@@ -154,6 +205,19 @@ def main():
             setattr(policy, attr, value)
             if attr not in policy.config_attrs:
                 policy.config_attrs.append(attr)
+            changed = True
+
+    if server_preference_range is not None:
+        want = {
+            k: v for k, v in server_preference_range.items() if v is not None
+        }
+        current_range = getattr(policy, "server_preference_range", None) or {}
+        if any(current_range.get(k) != v for k, v in want.items()):
+            merged = dict(current_range)
+            merged.update(want)
+            policy.server_preference_range = merged
+            if "server_preference_range" not in policy.config_attrs:
+                policy.config_attrs.append("server_preference_range")
             changed = True
 
     result["changed"] = changed

--- a/plugins/modules/aoscx_dhcpv6_snooping_guard.py
+++ b/plugins/modules/aoscx_dhcpv6_snooping_guard.py
@@ -147,7 +147,10 @@ def main():
 
     changed = False
     for attr, value in supplied.items():
-        if getattr(policy, attr, None) != value:
+        current = getattr(policy, attr, None)
+        if isinstance(current, dict):
+            current = next(iter(current.values()), "")
+        if str(current).rstrip("/").split("/")[-1] != value.rstrip("/").split("/")[-1]:
             setattr(policy, attr, value)
             if attr not in policy.config_attrs:
                 policy.config_attrs.append(attr)

--- a/plugins/modules/aoscx_dhcpv6_snooping_guard.py
+++ b/plugins/modules/aoscx_dhcpv6_snooping_guard.py
@@ -150,7 +150,7 @@ def main():
         current = getattr(policy, attr, None)
         if isinstance(current, dict):
             current = next(iter(current.values()), "")
-        if str(current).rstrip("/").split("/")[-1] != value.rstrip("/").split("/")[-1]:
+        if str(current).rstrip("/").rsplit("/", 1)[-1] != value.rstrip("/").rsplit("/", 1)[-1]:
             setattr(policy, attr, value)
             if attr not in policy.config_attrs:
                 policy.config_attrs.append(attr)

--- a/plugins/modules/aoscx_dhcpv6_snooping_guard.py
+++ b/plugins/modules/aoscx_dhcpv6_snooping_guard.py
@@ -1,0 +1,169 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_dhcpv6_snooping_guard
+version_added: "4.6.0"
+short_description: Create, update or delete a DHCPv6 snooping guard policy.
+description:
+  - This module manages DHCPv6 snooping guard policies on AOS-CX switches.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: Name of the DHCPv6 snooping guard policy.
+    required: true
+    type: str
+  server_access_list:
+    description: >
+      Name of the existing IPv6 ACL used to filter packets from trusted DHCP
+      servers. When omitted server filtering is left unchanged.
+    required: false
+    type: str
+
+  state:
+    description: Create, update or delete the policy.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a DHCPv6 snooping guard policy
+  arubanetworks.aoscx.aoscx_dhcpv6_snooping_guard:
+    name: v6-guard-1
+    server_access_list: trusted-servers-v6
+    state: create
+
+- name: Delete a DHCPv6 snooping guard policy
+  arubanetworks.aoscx.aoscx_dhcpv6_snooping_guard:
+    name: v6-guard-1
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        name=dict(type="str", required=True),
+        server_access_list=dict(type="str", required=False, default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    name = ansible_module.params["name"]
+    server_access_list = ansible_module.params["server_access_list"]
+    state = ansible_module.params["state"]
+
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    supplied = {}
+    if server_access_list is not None:
+        acl = session.api.get_module(
+            session, "ACL", server_access_list, list_type="ipv6"
+        )
+        supplied["match_server_access_list"] = acl.get_uri()
+
+    try:
+        policy = session.api.get_module(
+            session, "Dhcpv6SnoopingGuardPolicy", name
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support DHCPv6 snooping guard "
+                "policies. Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        policy.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                policy.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete policy: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    if not exists:
+        policy = session.api.get_module(
+            session, "Dhcpv6SnoopingGuardPolicy", name, **supplied
+        )
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                policy.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create policy: {0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+    for attr, value in supplied.items():
+        if getattr(policy, attr, None) != value:
+            setattr(policy, attr, value)
+            if attr not in policy.config_attrs:
+                policy.config_attrs.append(attr)
+            changed = True
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            policy.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update policy: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_ipv6_destination_guard.py
+++ b/plugins/modules/aoscx_ipv6_destination_guard.py
@@ -1,0 +1,172 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_ipv6_destination_guard
+version_added: "4.6.0"
+short_description: Create, update or delete an IPv6 destination guard policy.
+description:
+  - This module manages IPv6 destination guard policies on AOS-CX switches.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: Name of the IPv6 destination guard policy.
+    required: true
+    type: str
+  enforcement:
+    description: Enforcement mode applied by the policy.
+    required: false
+    type: str
+  nd_cache_threshold:
+    description: >
+      Neighbor discovery cache utilization threshold, expressed as a
+      percentage, above which destination guard recovery is triggered.
+    required: false
+    type: int
+  state:
+    description: Create, update or delete the policy.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create an IPv6 destination guard policy
+  arubanetworks.aoscx.aoscx_ipv6_destination_guard:
+    name: dst-guard-1
+    nd_cache_threshold: 80
+    state: create
+
+- name: Delete an IPv6 destination guard policy
+  arubanetworks.aoscx.aoscx_ipv6_destination_guard:
+    name: dst-guard-1
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        name=dict(type="str", required=True),
+        enforcement=dict(type="str", required=False, default=None),
+        nd_cache_threshold=dict(type="int", required=False, default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    name = ansible_module.params["name"]
+    state = ansible_module.params["state"]
+
+    scalar_attrs = ["enforcement", "nd_cache_threshold"]
+    supplied = {
+        attr: ansible_module.params[attr]
+        for attr in scalar_attrs
+        if ansible_module.params[attr] is not None
+    }
+
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        policy = session.api.get_module(
+            session, "Ipv6DestinationGuardPolicy", name
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support IPv6 destination "
+                "guard policies. Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        policy.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                policy.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete policy: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    if not exists:
+        policy = session.api.get_module(
+            session, "Ipv6DestinationGuardPolicy", name, **supplied
+        )
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                policy.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create policy: {0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+    for attr, value in supplied.items():
+        if getattr(policy, attr, None) != value:
+            setattr(policy, attr, value)
+            if attr not in policy.config_attrs:
+                policy.config_attrs.append(attr)
+            changed = True
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            policy.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update policy: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_static_ip_binding.py
+++ b/plugins/modules/aoscx_static_ip_binding.py
@@ -124,7 +124,8 @@ def main():
     supplied = {
         "address_family": address_family,
     }
-    vlan_uri = "{0}system/vlans/{1}".format(session.resource_prefix, vlan)
+    vlan_obj = session.api.get_module(session, "Vlan", vlan)
+    vlan_uri = vlan_obj.get_uri()
     if mac is not None:
         supplied["mac"] = mac
     if port is not None:

--- a/plugins/modules/aoscx_static_ip_binding.py
+++ b/plugins/modules/aoscx_static_ip_binding.py
@@ -179,7 +179,21 @@ def main():
 
     changed = False
     for attr, value in supplied.items():
-        if getattr(binding, attr, None) != value:
+        current = getattr(binding, attr, None)
+        if attr == "address_family":
+            # Not returned by the writable selector; set only on create.
+            continue
+        # URI references may be returned with a different prefix, or as a
+        # dict mapping; compare the last path segment to avoid spurious
+        # changes.
+        if attr == "port" and current and value:
+            if isinstance(current, dict):
+                current = next(iter(current.values()), "")
+            different = str(current).rstrip("/").split("/")[-1] != \
+                value.rstrip("/").split("/")[-1]
+        else:
+            different = current != value
+        if different:
             setattr(binding, attr, value)
             if attr not in binding.config_attrs:
                 binding.config_attrs.append(attr)

--- a/plugins/modules/aoscx_static_ip_binding.py
+++ b/plugins/modules/aoscx_static_ip_binding.py
@@ -190,8 +190,8 @@ def main():
         if attr == "port" and current and value:
             if isinstance(current, dict):
                 current = next(iter(current.values()), "")
-            different = str(current).rstrip("/").split("/")[-1] != \
-                value.rstrip("/").split("/")[-1]
+            different = str(current).rstrip("/").rsplit("/", 1)[-1] != \
+                value.rstrip("/").rsplit("/", 1)[-1]
         else:
             different = current != value
         if different:

--- a/plugins/modules/aoscx_static_ip_binding.py
+++ b/plugins/modules/aoscx_static_ip_binding.py
@@ -1,0 +1,201 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_static_ip_binding
+version_added: "4.6.0"
+short_description: Create, update or delete a static IP source binding.
+description:
+  - This module manages static IP source bindings on AOS-CX switches. A
+    binding is uniquely identified by its VLAN and IP address.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  vlan:
+    description: VLAN identifier the binding applies to.
+    required: true
+    type: int
+  ip_address:
+    description: IP address of the binding.
+    required: true
+    type: str
+  address_family:
+    description: Address family of the binding.
+    required: false
+    choices:
+      - ipv4
+      - ipv6
+    default: ipv4
+    type: str
+  mac:
+    description: MAC address bound to the IP address.
+    required: false
+    type: str
+  port:
+    description: Name of the interface the binding is bound to.
+    required: false
+    type: str
+  state:
+    description: Create, update or delete the binding.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a static IP binding
+  arubanetworks.aoscx.aoscx_static_ip_binding:
+    vlan: 10
+    ip_address: 10.0.0.5
+    mac: "00:11:22:33:44:55"
+    port: 1/1/1
+    state: create
+
+- name: Delete a static IP binding
+  arubanetworks.aoscx.aoscx_static_ip_binding:
+    vlan: 10
+    ip_address: 10.0.0.5
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        vlan=dict(type="int", required=True),
+        ip_address=dict(type="str", required=True),
+        address_family=dict(
+            type="str", required=False, default="ipv4",
+            choices=["ipv4", "ipv6"],
+        ),
+        mac=dict(type="str", required=False, default=None),
+        port=dict(type="str", required=False, default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    vlan = ansible_module.params["vlan"]
+    ip_address = ansible_module.params["ip_address"]
+    address_family = ansible_module.params["address_family"]
+    mac = ansible_module.params["mac"]
+    port = ansible_module.params["port"]
+    state = ansible_module.params["state"]
+
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    supplied = {
+        "address_family": address_family,
+    }
+    vlan_uri = "{0}system/vlans/{1}".format(session.resource_prefix, vlan)
+    if mac is not None:
+        supplied["mac"] = mac
+    if port is not None:
+        interface = session.api.get_module(session, "Interface", port)
+        supplied["port"] = interface.get_uri()
+
+    try:
+        binding = session.api.get_module(
+            session, "StaticIpBinding", vlan, ip_address=ip_address
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support static IP bindings. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        binding.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                binding.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete binding: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    if not exists:
+        binding = session.api.get_module(
+            session, "StaticIpBinding", vlan, ip_address=ip_address, **supplied
+        )
+        binding.vlan = vlan_uri
+        if "vlan" not in binding.config_attrs:
+            binding.config_attrs.append("vlan")
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                binding.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create binding: {0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+    for attr, value in supplied.items():
+        if getattr(binding, attr, None) != value:
+            setattr(binding, attr, value)
+            if attr not in binding.config_attrs:
+                binding.config_attrs.append(attr)
+            changed = True
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            binding.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update binding: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds modules aoscx_dhcpv4_snooping_guard, aoscx_dhcpv6_snooping_guard, aoscx_ipv6_destination_guard and aoscx_static_ip_binding. Create, idempotency, update and delete verified live on a CX6300 (FL.10.17, REST v10.09).

Fixes #164
Depends on SDK PR aruba/pyaoscx#86

## Depends on
- aruba/pyaoscx#86 — DHCP/IPv6 snooping guard + StaticIpBinding
