### PR TITLE
Add physical and protection options to aoscx_interface

### DIFF
--- a/changelogs/fragments/interface-physical.yml
+++ b/changelogs/fragments/interface-physical.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - aoscx_interface - add ``pause``, ``eee``, ``error_control``, ``speed_downshift``,
+    ``udld_enable``, ``udld_interval``, ``udld_retries``, ``loop_protect_enable``,
+    ``loop_protect_action``, ``urpf_check`` and ``ip_mtu`` options.

--- a/changelogs/fragments/interface_sflow_snooping.yml
+++ b/changelogs/fragments/interface_sflow_snooping.yml
@@ -1,0 +1,10 @@
+---
+minor_changes:
+  - aoscx_interface - add the C(sflow_enabled) option to enable or disable sFlow
+    sampling per interface (the per-port C(no sflow) override).
+  - aoscx_interface - add the C(arp_inspection_trust) option to mark the
+    interface as trusted for Dynamic ARP Inspection.
+  - aoscx_interface - add the C(dhcpv4_snooping_trust),
+    C(dhcpv4_snooping_max_bindings), C(dhcpv6_snooping_trust) and
+    C(dhcpv6_snooping_max_bindings) options to configure the per-interface
+    DHCP snooping trust and binding limits.

--- a/plugins/modules/aoscx_interface.py
+++ b/plugins/modules/aoscx_interface.py
@@ -186,6 +186,63 @@ options:
       - none
       - global
     required: false
+  pause:
+    description: Flow control (pause) mode applied to the interface.
+    type: str
+    required: false
+  eee:
+    description: Enable or disable Energy Efficient Ethernet on the interface.
+    type: bool
+    required: false
+  error_control:
+    description: Forward error correction (FEC) mode of the interface.
+    type: str
+    choices:
+      - auto
+      - none
+      - base-r-fec
+      - rs-fec
+    required: false
+  speed_downshift:
+    description: Enable or disable speed downshift on the interface.
+    type: bool
+    required: false
+  udld_enable:
+    description: Enable or disable UDLD on the interface.
+    type: bool
+    required: false
+  udld_interval:
+    description: UDLD probe interval in milliseconds.
+    type: int
+    required: false
+  udld_retries:
+    description: Number of UDLD retries before a port is marked down.
+    type: int
+    required: false
+  loop_protect_enable:
+    description: Enable or disable loop protection on the interface.
+    type: bool
+    required: false
+  loop_protect_action:
+    description: Action taken when a loop is detected.
+    type: str
+    choices:
+      - do-not-disable
+      - tx-disable
+      - tx-rx-disable
+    required: false
+  urpf_check:
+    description: Unicast Reverse Path Forwarding mode on the interface.
+    type: str
+    choices:
+      - disable
+      - loose
+      - strict
+    required: false
+  ip_mtu:
+    description: IP MTU of the interface.
+    type: int
+    required: false
   state:
     description: Create, Update or Delete the Interface.
     type: str
@@ -430,6 +487,64 @@ def get_argument_spec():
             "required": False,
             "choices": ["cos", "dscp", "none", "global"],
         },
+        "pause": {
+            "type": "str",
+            "required": False,
+            "default": None,
+        },
+        "eee": {
+            "type": "bool",
+            "required": False,
+            "default": None,
+        },
+        "error_control": {
+            "type": "str",
+            "required": False,
+            "default": None,
+            "choices": ["auto", "none", "base-r-fec", "rs-fec"],
+        },
+        "speed_downshift": {
+            "type": "bool",
+            "required": False,
+            "default": None,
+        },
+        "udld_enable": {
+            "type": "bool",
+            "required": False,
+            "default": None,
+        },
+        "udld_interval": {
+            "type": "int",
+            "required": False,
+            "default": None,
+        },
+        "udld_retries": {
+            "type": "int",
+            "required": False,
+            "default": None,
+        },
+        "loop_protect_enable": {
+            "type": "bool",
+            "required": False,
+            "default": None,
+        },
+        "loop_protect_action": {
+            "type": "str",
+            "required": False,
+            "default": None,
+            "choices": ["do-not-disable", "tx-disable", "tx-rx-disable"],
+        },
+        "urpf_check": {
+            "type": "str",
+            "required": False,
+            "default": None,
+            "choices": ["disable", "loose", "strict"],
+        },
+        "ip_mtu": {
+            "type": "int",
+            "required": False,
+            "default": None,
+        },
         "qos_rate": {
             "type": "dict",
             "required": False,
@@ -532,6 +647,18 @@ def main():
     qos_trust_mode = ansible_module.params["qos_trust_mode"]
     qos_rate = ansible_module.params["qos_rate"]
 
+    pause = ansible_module.params["pause"]
+    eee = ansible_module.params["eee"]
+    error_control = ansible_module.params["error_control"]
+    speed_downshift = ansible_module.params["speed_downshift"]
+    udld_enable = ansible_module.params["udld_enable"]
+    udld_interval = ansible_module.params["udld_interval"]
+    udld_retries = ansible_module.params["udld_retries"]
+    loop_protect_enable = ansible_module.params["loop_protect_enable"]
+    loop_protect_action = ansible_module.params["loop_protect_action"]
+    urpf_check = ansible_module.params["urpf_check"]
+    ip_mtu = ansible_module.params["ip_mtu"]
+
     configure_speed = ansible_module.params["configure_speed"]
     autoneg = ansible_module.params["autoneg"]
     duplex = ansible_module.params["duplex"]
@@ -583,6 +710,33 @@ def main():
         interface.admin_state = "up" if enabled else "down"
     if mtu:
         interface.mtu = mtu
+    # Physical user_config attributes
+    user_cfg = {
+        "pause": pause,
+        "eee": eee,
+        "error_control": error_control,
+        "speed_downshift": speed_downshift,
+    }
+    for key, val in user_cfg.items():
+        if val is not None:
+            if not isinstance(interface.user_config, dict):
+                interface.user_config = {}
+            interface.user_config[key] = val
+    # Top-level attributes
+    top_level = {
+        "udld_enable": udld_enable,
+        "udld_interval": udld_interval,
+        "udld_retries": udld_retries,
+        "loop_protect_enable": loop_protect_enable,
+        "loop_protect_action": loop_protect_action,
+        "urpf_check": urpf_check,
+        "ip_mtu": ip_mtu,
+    }
+    for key, val in top_level.items():
+        if val is not None:
+            setattr(interface, key, val)
+            if key not in interface.config_attrs:
+                interface.config_attrs.append(key)
     if vsx_sync:
         if not device.materialized:
             device.get()

--- a/plugins/modules/aoscx_interface.py
+++ b/plugins/modules/aoscx_interface.py
@@ -243,6 +243,36 @@ options:
     description: IP MTU of the interface.
     type: int
     required: false
+  sflow_enabled:
+    description: >
+      Enable or disable sFlow sampling on the interface. Set to false to apply
+      C(no sflow) on the port (overriding the global sFlow setting).
+    type: bool
+    required: false
+  arp_inspection_trust:
+    description: >
+      Mark the interface as trusted for Dynamic ARP Inspection. When true,
+      ARP packets received on the port are not inspected.
+    type: bool
+    required: false
+  dhcpv4_snooping_trust:
+    description: Mark the interface as trusted for DHCPv4 snooping.
+    type: bool
+    required: false
+  dhcpv4_snooping_max_bindings:
+    description: >
+      Maximum number of DHCPv4 snooping bindings allowed on the port (1-8192).
+    type: int
+    required: false
+  dhcpv6_snooping_trust:
+    description: Mark the interface as trusted for DHCPv6 snooping.
+    type: bool
+    required: false
+  dhcpv6_snooping_max_bindings:
+    description: >
+      Maximum number of DHCPv6 snooping bindings allowed on the port (1-8192).
+    type: int
+    required: false
   state:
     description: Create, Update or Delete the Interface.
     type: str
@@ -545,6 +575,36 @@ def get_argument_spec():
             "required": False,
             "default": None,
         },
+        "sflow_enabled": {
+            "type": "bool",
+            "required": False,
+            "default": None,
+        },
+        "arp_inspection_trust": {
+            "type": "bool",
+            "required": False,
+            "default": None,
+        },
+        "dhcpv4_snooping_trust": {
+            "type": "bool",
+            "required": False,
+            "default": None,
+        },
+        "dhcpv4_snooping_max_bindings": {
+            "type": "int",
+            "required": False,
+            "default": None,
+        },
+        "dhcpv6_snooping_trust": {
+            "type": "bool",
+            "required": False,
+            "default": None,
+        },
+        "dhcpv6_snooping_max_bindings": {
+            "type": "int",
+            "required": False,
+            "default": None,
+        },
         "qos_rate": {
             "type": "dict",
             "required": False,
@@ -658,6 +718,16 @@ def main():
     loop_protect_action = ansible_module.params["loop_protect_action"]
     urpf_check = ansible_module.params["urpf_check"]
     ip_mtu = ansible_module.params["ip_mtu"]
+    sflow_enabled = ansible_module.params["sflow_enabled"]
+    arp_inspection_trust = ansible_module.params["arp_inspection_trust"]
+    dhcpv4_snooping_trust = ansible_module.params["dhcpv4_snooping_trust"]
+    dhcpv4_snooping_max_bindings = ansible_module.params[
+        "dhcpv4_snooping_max_bindings"
+    ]
+    dhcpv6_snooping_trust = ansible_module.params["dhcpv6_snooping_trust"]
+    dhcpv6_snooping_max_bindings = ansible_module.params[
+        "dhcpv6_snooping_max_bindings"
+    ]
 
     configure_speed = ansible_module.params["configure_speed"]
     autoneg = ansible_module.params["autoneg"]
@@ -722,6 +792,36 @@ def main():
             if not isinstance(interface.user_config, dict):
                 interface.user_config = {}
             interface.user_config[key] = val
+    # sFlow per-interface enable lives in the other_config dict.
+    if sflow_enabled is not None:
+        if not isinstance(interface.other_config, dict):
+            interface.other_config = {}
+        interface.other_config["sflow-enabled"] = sflow_enabled
+        if "other_config" not in interface.config_attrs:
+            interface.config_attrs.append("other_config")
+    # ARP inspection and DHCP snooping trust live in nested dicts.
+    nested_updates = {
+        "arp_inspection": {"trust": arp_inspection_trust},
+        "dhcpv4_snooping_configuration": {
+            "trusted": dhcpv4_snooping_trust,
+            "max_bindings": dhcpv4_snooping_max_bindings,
+        },
+        "dhcpv6_snooping_configuration": {
+            "trusted": dhcpv6_snooping_trust,
+            "max_bindings": dhcpv6_snooping_max_bindings,
+        },
+    }
+    for target, updates in nested_updates.items():
+        wanted = {k: v for k, v in updates.items() if v is not None}
+        if not wanted:
+            continue
+        if not isinstance(getattr(interface, target, None), dict):
+            setattr(interface, target, {})
+        current = getattr(interface, target)
+        for key, value in wanted.items():
+            current[key] = value
+        if target not in interface.config_attrs:
+            interface.config_attrs.append(target)
     # Top-level attributes
     top_level = {
         "udld_enable": udld_enable,


### PR DESCRIPTION
Adds pause/flow-control, EEE, FEC (error_control), speed downshift, UDLD, loop protection, uRPF and IP MTU options to aoscx_interface. Verified live on a CX6300 (FL.10.17, REST v10.09): apply, idempotency, update and reset.

Fixes #166

## Depends on
No pyaoscx changes required — uses existing pyaoscx classes (Device / Vlan / Interface).
