### PR TITLE
Add aoscx_app_recognition module and REST v10.17 support

### DIFF
--- a/changelogs/fragments/app-recognition.yml
+++ b/changelogs/fragments/app-recognition.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - New module ``aoscx_app_recognition`` to configure global application
+    recognition settings (enable, mode, ABP session limit action).
+  - aoscx connection plugin now accepts REST version ``10.17``.

--- a/changelogs/fragments/app-recognition.yml
+++ b/changelogs/fragments/app-recognition.yml
@@ -2,4 +2,4 @@
 minor_changes:
   - New module ``aoscx_app_recognition`` to configure global application
     recognition settings (enable, mode, ABP session limit action).
-  - aoscx connection plugin now accepts REST version ``10.17``.
+  - aoscx connection plugin now accepts REST version ``latest``.

--- a/plugins/connection/aoscx.py
+++ b/plugins/connection/aoscx.py
@@ -120,9 +120,9 @@ options:
       - name: ansible_persistent_log_messages
   rest_version:
     description: >
-      Configures REST version, default version is 10.04, but 10.08 or 10.09
-      can be used in a specific host or globaly if it is set as an environment
-      variable.
+      Configures REST version, default version is 10.04, but 10.08, 10.09 or
+      10.17 can be used in a specific host or globaly if it is set as an
+      environment variable.
     default: '10.04'
     env:
       - name: ANSIBLE_AOSCX_REST_VERSION
@@ -208,7 +208,7 @@ class Connection(NetworkConnectionBase):
             password = self.get_option("password")
             self.use_proxy = self.get_option("use_proxy")
             rest_version = self.get_option("rest_version")
-            if rest_version not in ["10.04", "10.08", "10.09"]:
+            if rest_version not in ["10.04", "10.08", "10.09", "10.17"]:
                 raise AnsibleConnectionFailure("Invalid REST version: %s"
                                                % rest_version)
             self.base_url = "https://{0}/rest/v{1}/".format(switchip, rest_version)

--- a/plugins/connection/aoscx.py
+++ b/plugins/connection/aoscx.py
@@ -121,7 +121,7 @@ options:
   rest_version:
     description: >
       Configures REST version, default version is 10.04, but 10.08, 10.09 or
-      10.17 can be used in a specific host or globaly if it is set as an
+      latest can be used in a specific host or globaly if it is set as an
       environment variable.
     default: '10.04'
     env:
@@ -208,10 +208,12 @@ class Connection(NetworkConnectionBase):
             password = self.get_option("password")
             self.use_proxy = self.get_option("use_proxy")
             rest_version = self.get_option("rest_version")
-            if rest_version not in ["10.04", "10.08", "10.09", "10.17"]:
+            if rest_version not in ["10.04", "10.08", "10.09", "latest"]:
                 raise AnsibleConnectionFailure("Invalid REST version: %s"
                                                % rest_version)
-            self.base_url = "https://{0}/rest/v{1}/".format(switchip, rest_version)
+            _prefix = rest_version if rest_version == "latest" \
+                else "v{0}".format(rest_version)
+            self.base_url = "https://{0}/rest/{1}/".format(switchip, _prefix)
             # Set Credentials
             self.__username = username
             self.__password = password

--- a/plugins/modules/aoscx_app_recognition.py
+++ b/plugins/modules/aoscx_app_recognition.py
@@ -1,0 +1,145 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_app_recognition
+version_added: "4.6.0"
+short_description: Configure global application recognition settings.
+description:
+  - This module configures the global application recognition settings on
+    AOS-CX switches.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  enable:
+    description: Enable or disable application recognition globally.
+    required: false
+    type: bool
+  mode:
+    description: Application recognition mode.
+    required: false
+    type: str
+    choices:
+      - fast
+      - default
+  abp_session_limit_exceed_action:
+    description: Action when the ABP session limit is exceeded.
+    required: false
+    type: str
+    choices:
+      - drop-new-flows
+      - log-only
+  state:
+    description: Update or reset the global settings.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Enable application recognition
+  arubanetworks.aoscx.aoscx_app_recognition:
+    enable: true
+    mode: default
+    state: create
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+SCALARS = ["enable", "mode", "abp_session_limit_exceed_action"]
+
+
+def main():
+    module_args = dict(
+        enable=dict(type="bool", default=None),
+        mode=dict(type="str", default=None, choices=["fast", "default"]),
+        abp_session_limit_exceed_action=dict(
+            type="str", default=None, choices=["drop-new-flows", "log-only"]
+        ),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    state = ansible_module.params["state"]
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        app = session.api.get_module(session, "AppRecognition")
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support application "
+                "recognition. Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    app.get(selector="writable")
+
+    if state == "delete":
+        supplied = {"enable": False}
+    else:
+        supplied = {
+            attr: ansible_module.params[attr]
+            for attr in SCALARS
+            if ansible_module.params[attr] is not None
+        }
+
+    changed = False
+    for attr, value in supplied.items():
+        if getattr(app, attr, None) != value:
+            setattr(app, attr, value)
+            if attr not in app.config_attrs:
+                app.config_attrs.append(attr)
+            changed = True
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            app.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update settings: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds aoscx_app_recognition to configure global application recognition (enable, mode, ABP session limit action) and allows REST version "latest" in the connection plugin. Create, idempotency and update verified live on a CX6300 (FL.10.17, REST latest).

Fixes #174
Depends on SDK PRs aruba/pyaoscx#88 (latest REST version) and aruba/pyaoscx#89 (AppRecognition class)

## Depends on
- aruba/pyaoscx#89 — AppRecognition
- aruba/pyaoscx#119 — REST API version modules `v10.13` / `v10.16` (needed to reach this feature at the 10.13/10.16 REST schema)
