### PR TITLE
Add RADIUS dynamic authorization modules

### DIFF
--- a/changelogs/fragments/radius-dynauth.yml
+++ b/changelogs/fragments/radius-dynauth.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - New module ``aoscx_radius_dynamic_authorization`` to configure the global
+    RADIUS dynamic authorization (Change of Authorization) settings.
+  - New module ``aoscx_radius_dynamic_authorization_client`` to manage RADIUS
+    dynamic authorization clients per VRF.

--- a/plugins/modules/aoscx_radius_dynamic_authorization.py
+++ b/plugins/modules/aoscx_radius_dynamic_authorization.py
@@ -1,0 +1,142 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_radius_dynamic_authorization
+version_added: "4.6.0"
+short_description: Configure global RADIUS dynamic authorization (CoA).
+description:
+  - This module configures the global RADIUS dynamic authorization (Change of
+    Authorization) settings on AOS-CX switches.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  enable:
+    description: Enable or disable RADIUS dynamic authorization globally.
+    required: false
+    type: bool
+  tcp_port:
+    description: TCP port used by the dynamic authorization server.
+    required: false
+    type: int
+  udp_port:
+    description: UDP port used by the dynamic authorization server.
+    required: false
+    type: int
+  state:
+    description: Update or reset the global settings.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Enable RADIUS dynamic authorization
+  arubanetworks.aoscx.aoscx_radius_dynamic_authorization:
+    enable: true
+    state: create
+
+- name: Disable RADIUS dynamic authorization
+  arubanetworks.aoscx.aoscx_radius_dynamic_authorization:
+    enable: false
+    state: update
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+SCALARS = ["enable", "tcp_port", "udp_port"]
+
+
+def main():
+    module_args = dict(
+        enable=dict(type="bool", default=None),
+        tcp_port=dict(type="int", default=None),
+        udp_port=dict(type="int", default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    state = ansible_module.params["state"]
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        dynauth = session.api.get_module(
+            session, "RadiusDynamicAuthorization"
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support RADIUS dynamic "
+                "authorization. Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    dynauth.get()
+    current = dict(dynauth.radius_dynamic_authorization)
+
+    if state == "delete":
+        supplied = {"enable": False}
+    else:
+        supplied = {
+            attr: ansible_module.params[attr]
+            for attr in SCALARS
+            if ansible_module.params[attr] is not None
+        }
+
+    new_config = dict(current)
+    new_config.update(supplied)
+
+    changed = new_config != current
+    if changed:
+        dynauth.radius_dynamic_authorization = new_config
+        if not ansible_module.check_mode:
+            try:
+                dynauth.apply()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not update settings: {0}".format(str(e))
+                )
+
+    result["changed"] = changed
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_radius_dynamic_authorization_client.py
+++ b/plugins/modules/aoscx_radius_dynamic_authorization_client.py
@@ -26,8 +26,12 @@ description:
     identified by its VRF, address and connection type.
 author: Aruba Networks (@ArubaNetworks)
 notes:
-  - When C(secret_key) is supplied the module reports changed on every run
-    because the secret cannot be read back from the switch for comparison.
+  - The switch stores C(secret_key) as a salted ciphertext, so a supplied
+    value never matches the stored representation and the module reports
+    changed on every run when C(secret_key) is set.
+  - The ciphertext returned by the switch cannot be used to restore the same
+    secret; it would be stored as a new plaintext value. Always supply the
+    plaintext shared secret.
 options:
   vrf:
     description: Name of the VRF the client belongs to.

--- a/plugins/modules/aoscx_radius_dynamic_authorization_client.py
+++ b/plugins/modules/aoscx_radius_dynamic_authorization_client.py
@@ -1,0 +1,228 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_radius_dynamic_authorization_client
+version_added: "4.6.0"
+short_description: Manage a RADIUS dynamic authorization (CoA) client.
+description:
+  - This module manages a RADIUS dynamic authorization (Change of
+    Authorization) client on an AOS-CX switch. A client is uniquely
+    identified by its VRF, address and connection type.
+author: Aruba Networks (@ArubaNetworks)
+notes:
+  - When C(secret_key) is supplied the module reports changed on every run
+    because the secret cannot be read back from the switch for comparison.
+options:
+  vrf:
+    description: Name of the VRF the client belongs to.
+    required: false
+    default: default
+    type: str
+  address:
+    description: IP address or hostname of the dynamic authorization client.
+    required: true
+    type: str
+  connection_type:
+    description: Transport used by the client.
+    required: false
+    default: udp
+    choices:
+      - udp
+      - tcp
+    type: str
+  secret_key:
+    description: Shared secret used to communicate with the client.
+    required: false
+    type: str
+  replay_protection_enable:
+    description: Enable replay protection for this client.
+    required: false
+    type: bool
+  rfc5176_enforcement_mode:
+    description: RFC 5176 enforcement mode.
+    required: false
+    choices:
+      - strict
+      - loose
+    type: str
+  time_window:
+    description: Time window in seconds used for replay protection.
+    required: false
+    type: int
+  state:
+    description: Create, update or delete the client.
+    required: false
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a UDP dynamic authorization client
+  arubanetworks.aoscx.aoscx_radius_dynamic_authorization_client:
+    vrf: default
+    address: 10.14.120.70
+    connection_type: udp
+    secret_key: my-secret
+    state: create
+
+- name: Delete a dynamic authorization client
+  arubanetworks.aoscx.aoscx_radius_dynamic_authorization_client:
+    address: 10.14.120.70
+    connection_type: udp
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+SCALARS = [
+    "secret_key",
+    "replay_protection_enable",
+    "rfc5176_enforcement_mode",
+    "time_window",
+]
+
+
+def main():
+    module_args = dict(
+        vrf=dict(type="str", required=False, default="default"),
+        address=dict(type="str", required=True),
+        connection_type=dict(
+            type="str", default="udp", choices=["udp", "tcp"]
+        ),
+        secret_key=dict(type="str", required=False, default=None, no_log=True),
+        replay_protection_enable=dict(type="bool", default=None),
+        rfc5176_enforcement_mode=dict(
+            type="str", default=None, choices=["strict", "loose"]
+        ),
+        time_window=dict(type="int", default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+    ansible_module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+    )
+
+    vrf = ansible_module.params["vrf"]
+    address = ansible_module.params["address"]
+    connection_type = ansible_module.params["connection_type"]
+    state = ansible_module.params["state"]
+
+    result = dict(changed=False)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        client = session.api.get_module(
+            session,
+            "RadiusDynamicAuthorizationClient",
+            vrf,
+            address=address,
+            connection_type=connection_type,
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support RADIUS dynamic "
+                "authorization clients. Upgrade pyaoscx. Details: "
+                "{0}".format(str(e))
+            )
+        )
+
+    try:
+        client.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    supplied = {
+        attr: ansible_module.params[attr]
+        for attr in SCALARS
+        if ansible_module.params[attr] is not None
+    }
+
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                client.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete client: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    if not exists:
+        client = session.api.get_module(
+            session,
+            "RadiusDynamicAuthorizationClient",
+            vrf,
+            address=address,
+            connection_type=connection_type,
+            **supplied
+        )
+        result["changed"] = True
+        if not ansible_module.check_mode:
+            try:
+                client.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create client: {0}".format(str(e))
+                )
+        ansible_module.exit_json(**result)
+
+    changed = False
+    for attr, value in supplied.items():
+        if getattr(client, attr, None) != value:
+            setattr(client, attr, value)
+            if attr not in client.config_attrs:
+                client.config_attrs.append(attr)
+            changed = True
+
+    result["changed"] = changed
+    if changed and not ansible_module.check_mode:
+        try:
+            client.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update client: {0}".format(str(e))
+            )
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds aoscx_radius_dynamic_authorization (global CoA settings) and aoscx_radius_dynamic_authorization_client (per-VRF clients, secret_key marked no_log). Create, idempotency, update and delete verified live on a CX6300 (FL.10.17, REST latest).

Fixes #178
Depends on SDK PR aruba/pyaoscx#95

## Depends on
- aruba/pyaoscx#95 — RadiusDynamicAuthorization + Client
