### PR TITLE
Add aoscx_vxlan_interface module

### DIFF
--- a/changelogs/fragments/aoscx_vxlan_interface.yml
+++ b/changelogs/fragments/aoscx_vxlan_interface.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - Add ``aoscx_vxlan_interface`` module to create, update and delete VXLAN
+    tunnel interfaces (source IP, destination UDP port, admin state and
+    description).

--- a/docs/aoscx_vxlan_interface.md
+++ b/docs/aoscx_vxlan_interface.md
@@ -1,0 +1,79 @@
+# module: aoscx_vxlan_interface
+
+description: This module provides configuration management of the VXLAN tunnel
+interface (for example vxlan1) on AOS-CX devices: its source IPv4 address, the
+destination UDP port, the administrative state and the description. The
+VNI-to-VLAN and VNI-to-VRF mappings carried by the interface are managed with
+the aoscx_vni module.
+
+##### ARGUMENTS
+
+```YAML
+  name:
+    description: >
+      Name of the VXLAN tunnel interface, in the format vxlanN, for example
+      vxlan1.
+    required: true
+    type: str
+  source_ip:
+    description: >
+      Source IPv4 address used for VXLAN encapsulation, for example 10.0.0.1.
+      Equivalent to the CLI source ip command.
+    required: false
+    type: str
+  dest_udp_port:
+    description: >
+      Destination UDP port used by the VXLAN tunnel. When omitted the switch
+      default (4789) is kept.
+    required: false
+    type: int
+  description:
+    description: Description of the VXLAN interface.
+    required: false
+    type: str
+  enabled:
+    description: >
+      Administrative state of the interface. true brings the interface up
+      (no shutdown), false shuts it down. When omitted, a newly created
+      interface is brought up and an existing interface is left unchanged.
+    required: false
+    type: bool
+  state:
+    description: Create, update or delete the VXLAN interface.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create VXLAN interface vxlan1 with a source IP and bring it up
+  aoscx_vxlan_interface:
+    name: vxlan1
+    source_ip: 10.141.254.11
+    enabled: true
+    state: create
+
+- name: Update the destination UDP port and description of vxlan1
+  aoscx_vxlan_interface:
+    name: vxlan1
+    dest_udp_port: 4789
+    description: EVPN-VXLAN overlay
+    state: update
+
+- name: Shut down the VXLAN interface
+  aoscx_vxlan_interface:
+    name: vxlan1
+    enabled: false
+    state: update
+
+- name: Delete the VXLAN interface
+  aoscx_vxlan_interface:
+    name: vxlan1
+    state: delete
+```

--- a/plugins/modules/aoscx_vxlan_interface.py
+++ b/plugins/modules/aoscx_vxlan_interface.py
@@ -1,0 +1,208 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_vxlan_interface
+version_added: "4.6.0"
+short_description: Create, update or delete a VXLAN tunnel interface on AOS-CX.
+description: >
+  This module provides configuration management of the VXLAN tunnel interface
+  (for example C(vxlan1)) on AOS-CX devices: its source IPv4 address, the
+  destination UDP port, the administrative state and the description. The
+  VNI-to-VLAN and VNI-to-VRF mappings carried by the interface are managed with
+  the M(arubanetworks.aoscx.aoscx_vni) module.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: >
+      Name of the VXLAN tunnel interface, in the format C(vxlanN), for example
+      C(vxlan1).
+    type: str
+    required: true
+  source_ip:
+    description: >
+      Source IPv4 address used for VXLAN encapsulation, for example
+      C(10.0.0.1). Equivalent to the CLI C(source ip) command.
+    type: str
+    required: false
+  dest_udp_port:
+    description: >
+      Destination UDP port used by the VXLAN tunnel. When omitted the switch
+      default (4789) is kept.
+    type: int
+    required: false
+  description:
+    description: Description of the VXLAN interface.
+    type: str
+    required: false
+  enabled:
+    description: >
+      Administrative state of the interface. C(true) brings the interface up
+      (C(no shutdown)), C(false) shuts it down. When omitted, a newly created
+      interface is brought up and an existing interface is left unchanged.
+    type: bool
+    required: false
+  state:
+    description: Create, update or delete the VXLAN interface.
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    required: false
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create VXLAN interface vxlan1 with a source IP and bring it up
+  arubanetworks.aoscx.aoscx_vxlan_interface:
+    name: vxlan1
+    source_ip: 10.141.254.11
+    enabled: true
+    state: create
+
+- name: Update the destination UDP port and description of vxlan1
+  arubanetworks.aoscx.aoscx_vxlan_interface:
+    name: vxlan1
+    dest_udp_port: 4789
+    description: EVPN-VXLAN overlay
+    state: update
+
+- name: Shut down the VXLAN interface
+  arubanetworks.aoscx.aoscx_vxlan_interface:
+    name: vxlan1
+    enabled: false
+    state: update
+
+- name: Delete the VXLAN interface
+  arubanetworks.aoscx.aoscx_vxlan_interface:
+    name: vxlan1
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        name=dict(type="str", required=True),
+        source_ip=dict(type="str", required=False, default=None),
+        dest_udp_port=dict(type="int", required=False, default=None),
+        description=dict(type="str", required=False, default=None),
+        enabled=dict(type="bool", required=False, default=None),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    name = ansible_module.params["name"]
+    source_ip = ansible_module.params["source_ip"]
+    dest_udp_port = ansible_module.params["dest_udp_port"]
+    description = ansible_module.params["description"]
+    enabled = ansible_module.params["enabled"]
+    state = ansible_module.params["state"]
+
+    result = dict(changed=False)
+
+    # Defense in depth: the interface name is interpolated into REST URIs, so
+    # reject values that could escape the intended resource path.
+    if name in ("", ".", "..") or "/" in name or "," in name:
+        ansible_module.fail_json(
+            msg="Invalid VXLAN interface name: {0}".format(name)
+        )
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    interface = session.api.get_module(session, "Interface", name)
+    try:
+        interface.get()
+        exists = True
+    except Exception:
+        exists = False
+
+    # ----------------------------------------------------------------- delete
+    if state == "delete":
+        if exists:
+            if getattr(interface, "type", None) != "vxlan":
+                ansible_module.fail_json(
+                    msg="Interface {0} is not a VXLAN interface.".format(name)
+                )
+            if not ansible_module.check_mode:
+                interface.delete()
+            result["changed"] = True
+        ansible_module.exit_json(**result)
+
+    # ----------------------------------------------------------- create/update
+    if exists and getattr(interface, "type", None) != "vxlan":
+        ansible_module.fail_json(
+            msg="Interface {0} already exists and is not a VXLAN "
+            "interface.".format(name)
+        )
+
+    if ansible_module.check_mode:
+        # Report a change when the interface does not exist yet or when any
+        # configurable value is supplied; the actual diff is computed by the
+        # SDK on a real run.
+        result["changed"] = (not exists) or any(
+            value is not None
+            for value in (source_ip, dest_udp_port, description, enabled)
+        )
+        ansible_module.exit_json(**result)
+
+    changed = False
+    if not exists:
+        interface.type = "vxlan"
+        interface.apply()
+        changed = True
+
+    if source_ip is not None:
+        interface.options["local_ip"] = source_ip
+    if dest_udp_port is not None:
+        interface.options["vxlan_dest_udp_port"] = str(dest_udp_port)
+    if description is not None:
+        interface.description = description
+    if enabled is not None:
+        interface.admin_state = "up" if enabled else "down"
+    elif not exists:
+        # A freshly created VXLAN interface is brought up by default.
+        interface.admin_state = "up"
+
+    changed = interface.apply() or changed
+
+    result["changed"] = changed
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/aoscx_vxlan_interface/aliases
+++ b/tests/integration/targets/aoscx_vxlan_interface/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_vxlan_interface/tasks/main.yml
+++ b/tests/integration/targets/aoscx_vxlan_interface/tasks/main.yml
@@ -1,0 +1,86 @@
+# Integration tests for the aoscx_vxlan_interface module.
+#
+# Run with:
+#   ansible-test integration aoscx_vxlan_interface --venv
+#
+# Requires an inventory entry named "aoscx" reachable over httpapi. Creates the
+# VXLAN tunnel interface vxlan1 and cleans it up afterwards.
+
+- name: Make sure the VXLAN interface does not exist yet
+  arubanetworks.aoscx.aoscx_vxlan_interface:
+    name: vxlan1
+    state: delete
+  ignore_errors: true
+
+- name: Create the VXLAN interface with a source IP
+  arubanetworks.aoscx.aoscx_vxlan_interface:
+    name: vxlan1
+    source_ip: 10.141.254.11
+    enabled: true
+    state: create
+  register: create_result
+
+- name: Assert create changed
+  ansible.builtin.assert:
+    that:
+      - create_result is changed
+
+- name: Re-apply identical configuration
+  arubanetworks.aoscx.aoscx_vxlan_interface:
+    name: vxlan1
+    source_ip: 10.141.254.11
+    enabled: true
+    state: create
+  register: idem_result
+
+- name: Assert re-apply did not change
+  ansible.builtin.assert:
+    that:
+      - idem_result is not changed
+
+- name: Update the description and destination UDP port
+  arubanetworks.aoscx.aoscx_vxlan_interface:
+    name: vxlan1
+    description: EVPN-VXLAN overlay
+    dest_udp_port: 4789
+    state: update
+  register: update_result
+
+- name: Assert update changed
+  ansible.builtin.assert:
+    that:
+      - update_result is changed
+
+- name: Shut the interface down
+  arubanetworks.aoscx.aoscx_vxlan_interface:
+    name: vxlan1
+    enabled: false
+    state: update
+  register: shutdown_result
+
+- name: Assert shutdown changed
+  ansible.builtin.assert:
+    that:
+      - shutdown_result is changed
+
+- name: Delete the VXLAN interface
+  arubanetworks.aoscx.aoscx_vxlan_interface:
+    name: vxlan1
+    state: delete
+  register: delete_result
+
+- name: Assert delete changed
+  ansible.builtin.assert:
+    that:
+      - delete_result is changed
+
+- name: Delete again (idempotent)
+  arubanetworks.aoscx.aoscx_vxlan_interface:
+    name: vxlan1
+    state: delete
+  register: delete_idem
+
+- name: Assert second delete did not change
+  ansible.builtin.assert:
+    that:
+      - delete_idem is not changed

--- a/tests/unit/modules/test_aoscx_vxlan_interface.py
+++ b/tests/unit/modules/test_aoscx_vxlan_interface.py
@@ -1,0 +1,203 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_vxlan_interface module.
+
+The pyaoscx session is fully mocked, so no switch is required. The tests cover
+input validation, check mode, idempotency, create, update, delete and error
+handling.
+
+Run with:
+    .venv/bin/python -m pytest \
+        tests/unit/modules/test_aoscx_vxlan_interface.py -v
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_vxlan_interface,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_vxlan_interface"
+)
+
+
+class AnsibleExitJson(Exception):
+    """Raised by the mocked exit_json to stop module execution."""
+
+
+class AnsibleFailJson(Exception):
+    """Raised by the mocked fail_json to stop module execution."""
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_interface(exists, interface_type="vxlan", apply_changed=False):
+    interface = MagicMock()
+    interface.type = interface_type
+    interface.options = {}
+    interface.apply.return_value = apply_changed
+    if exists:
+        interface.get.return_value = True
+    else:
+        interface.get.side_effect = Exception("not found")
+    return interface
+
+
+def build_session(interface):
+    session = MagicMock()
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "Interface":
+            return interface
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_vxlan_interface.main()
+    return exc.value.args[0]
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+def test_invalid_name_rejected():
+    session = build_session(build_interface(False))
+    result = run_module({"name": "vxlan1,extra"}, session)
+    assert result["failed"] is True
+    assert "Invalid VXLAN interface name" in result["msg"]
+
+
+# --------------------------------------------------------------------------
+# Check mode
+# --------------------------------------------------------------------------
+def test_check_mode_create_reports_change():
+    interface = build_interface(False)
+    session = build_session(interface)
+    result = run_module(
+        {"name": "vxlan1", "source_ip": "10.0.0.1", "_ansible_check_mode": True},
+        session,
+    )
+    assert result["changed"] is True
+    interface.apply.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Create / idempotency / update
+# --------------------------------------------------------------------------
+def test_create():
+    interface = build_interface(False, apply_changed=True)
+    session = build_session(interface)
+    result = run_module(
+        {"name": "vxlan1", "source_ip": "10.0.0.1", "enabled": True}, session
+    )
+    assert result["changed"] is True
+    assert interface.type == "vxlan"
+    assert interface.options["local_ip"] == "10.0.0.1"
+    assert interface.admin_state == "up"
+
+
+def test_idempotent_update():
+    interface = build_interface(True, apply_changed=False)
+    session = build_session(interface)
+    result = run_module(
+        {"name": "vxlan1", "source_ip": "10.0.0.1", "state": "update"}, session
+    )
+    assert result["changed"] is False
+
+
+def test_update_changes():
+    interface = build_interface(True, apply_changed=True)
+    session = build_session(interface)
+    result = run_module(
+        {
+            "name": "vxlan1",
+            "description": "overlay",
+            "dest_udp_port": 4789,
+            "state": "update",
+        },
+        session,
+    )
+    assert result["changed"] is True
+    assert interface.options["vxlan_dest_udp_port"] == "4789"
+    assert interface.description == "overlay"
+
+
+def test_create_on_existing_non_vxlan_rejected():
+    interface = build_interface(True, interface_type="system")
+    session = build_session(interface)
+    result = run_module({"name": "vxlan1", "source_ip": "10.0.0.1"}, session)
+    assert result["failed"] is True
+    assert "not a VXLAN" in result["msg"]
+
+
+# --------------------------------------------------------------------------
+# Delete
+# --------------------------------------------------------------------------
+def test_delete():
+    interface = build_interface(True)
+    session = build_session(interface)
+    result = run_module({"name": "vxlan1", "state": "delete"}, session)
+    assert result["changed"] is True
+    interface.delete.assert_called_once()
+
+
+def test_delete_idempotent():
+    interface = build_interface(False)
+    session = build_session(interface)
+    result = run_module({"name": "vxlan1", "state": "delete"}, session)
+    assert result["changed"] is False
+    interface.delete.assert_not_called()
+
+
+def test_delete_non_vxlan_rejected():
+    interface = build_interface(True, interface_type="system")
+    session = build_session(interface)
+    result = run_module({"name": "vxlan1", "state": "delete"}, session)
+    assert result["failed"] is True
+    assert "not a VXLAN" in result["msg"]


### PR DESCRIPTION
Fixes #208

## Summary

Adds the `aoscx_vxlan_interface` module to create, update and delete VXLAN tunnel interfaces: source IPv4 address, destination UDP port, administrative state and description. This completes the VXLAN overlay workflow alongside `aoscx_vni`, which manages the VNI-to-VLAN/VRF mappings.

A dedicated module is consistent with the existing per-subtype interface modules (`aoscx_l2_interface`, `aoscx_l3_interface`, `aoscx_lag_interface`, `aoscx_vlan_interface`).

## Notes

Backed by the pyaoscx `Interface` class (`configure_vxlan`), already shipped upstream — no SDK change required. Includes documentation, changelog fragment, unit and integration tests.

## Testing

- `ansible-test sanity` (pep8, pylint, validate-modules) and `ansible-doc` pass.
- Unit tests pass.
- Validated live on a CX 6300 (FL.10.17, REST `latest`): create / idempotency / update / shutdown / delete.

## Depends on
No pyaoscx changes required — uses existing pyaoscx classes (Device / Vlan / Interface).
