### PR TITLE
Add aoscx_evpn_vlan_aware_bundle module

### DIFF
--- a/changelogs/fragments/aoscx_evpn_vlan_aware_bundle.yml
+++ b/changelogs/fragments/aoscx_evpn_vlan_aware_bundle.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - Add ``aoscx_evpn_vlan_aware_bundle`` module to create, update and delete
+    EVPN VLAN-aware bundles (route distinguisher, route targets, redistribution
+    and member VLANs mapped through their Ethernet tags). Requires a pyaoscx
+    release that ships the ``EvpnVlanAwareBundle`` class.

--- a/docs/aoscx_evpn_vlan_aware_bundle.md
+++ b/docs/aoscx_evpn_vlan_aware_bundle.md
@@ -1,0 +1,115 @@
+# module: aoscx_evpn_vlan_aware_bundle
+
+description: This module provides configuration management of EVPN VLAN-aware
+bundles on AOS-CX devices. A bundle groups several VLANs under a single EVPN
+instance that shares the same route distinguisher and route targets. The
+member VLANs are mapped through their Ethernet tags. The bundle lives under
+system/evpn/evpn_vlan_aware_bundles and is indexed by its name.
+
+##### ARGUMENTS
+
+```YAML
+  bundle_name:
+    description: Name of the EVPN VLAN-aware bundle.
+    required: true
+    type: str
+  rd:
+    description: >
+      Route distinguisher of the bundle, for example 65000:1 or 1.1.1.1:1.
+      When omitted it is left unchanged.
+    required: false
+    type: str
+  import_route_targets:
+    description: >
+      List of import route targets for the bundle. The supplied list fully
+      replaces the existing import route targets. When omitted they are left
+      unchanged.
+    required: false
+    type: list
+    elements: str
+  export_route_targets:
+    description: >
+      List of export route targets for the bundle. The supplied list fully
+      replaces the existing export route targets. When omitted they are left
+      unchanged.
+    required: false
+    type: list
+    elements: str
+  redistribute:
+    description: >
+      Redistribution settings of the bundle, for example {host-route: true}.
+      Only the supplied keys are reconciled; existing keys that are not
+      mentioned are preserved. When omitted it is left unchanged.
+    required: false
+    type: dict
+  disable:
+    description: >
+      Whether the bundle is administratively disabled. When omitted it is left
+      unchanged.
+    required: false
+    type: bool
+  vlans:
+    description: >
+      Member VLANs of the bundle with their Ethernet tags. The supplied list
+      fully replaces the set of member VLANs. When omitted the VLANs are left
+      unchanged; an empty list removes all member VLANs. The VLANs must already
+      exist on the device. Ignored when state is delete.
+    required: false
+    type: list
+    elements: dict
+    suboptions:
+      id:
+        description: VLAN ID of the member VLAN.
+        required: true
+        type: int
+      ethernet_tag:
+        description: >
+          Ethernet tag mapped to the VLAN. When omitted it defaults to the
+          VLAN ID.
+        required: false
+        type: int
+  state:
+    description: Create, update or delete the EVPN VLAN-aware bundle.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create an EVPN VLAN-aware bundle with two member VLANs
+  aoscx_evpn_vlan_aware_bundle:
+    bundle_name: tenant-blue
+    rd: "65000:1"
+    import_route_targets:
+      - "65000:1"
+    export_route_targets:
+      - "65000:1"
+    vlans:
+      - id: 206
+      - id: 207
+        ethernet_tag: 100
+
+- name: Replace the member VLANs of a bundle
+  aoscx_evpn_vlan_aware_bundle:
+    bundle_name: tenant-blue
+    state: update
+    vlans:
+      - id: 206
+
+- name: Remove all member VLANs from a bundle
+  aoscx_evpn_vlan_aware_bundle:
+    bundle_name: tenant-blue
+    state: update
+    vlans: []
+
+- name: Delete an EVPN VLAN-aware bundle
+  aoscx_evpn_vlan_aware_bundle:
+    bundle_name: tenant-blue
+    state: delete
+```

--- a/plugins/modules/aoscx_evpn_vlan_aware_bundle.py
+++ b/plugins/modules/aoscx_evpn_vlan_aware_bundle.py
@@ -1,0 +1,351 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_evpn_vlan_aware_bundle
+version_added: "4.6.0"
+short_description: Create, update or delete an EVPN VLAN-aware bundle on AOS-CX.
+description: >
+  This module provides configuration management of EVPN VLAN-aware bundles on
+  AOS-CX devices. A bundle groups several VLANs under a single EVPN instance
+  that shares the same route distinguisher and route targets. The member VLANs
+  are mapped through their Ethernet tags. The bundle lives under
+  system/evpn/evpn_vlan_aware_bundles and is indexed by its name.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  bundle_name:
+    description: Name of the EVPN VLAN-aware bundle.
+    type: str
+    required: true
+  rd:
+    description: >
+      Route distinguisher of the bundle, for example C(65000:1) or
+      C(1.1.1.1:1). When omitted it is left unchanged.
+    type: str
+    required: false
+  import_route_targets:
+    description: >
+      List of import route targets for the bundle. The supplied list fully
+      replaces the existing import route targets. When omitted they are left
+      unchanged.
+    type: list
+    elements: str
+    required: false
+  export_route_targets:
+    description: >
+      List of export route targets for the bundle. The supplied list fully
+      replaces the existing export route targets. When omitted they are left
+      unchanged.
+    type: list
+    elements: str
+    required: false
+  redistribute:
+    description: >
+      Redistribution settings of the bundle, for example
+      C({host-route: true}). Only the supplied keys are reconciled; existing
+      keys that are not mentioned are preserved. When omitted it is left
+      unchanged.
+    type: dict
+    required: false
+  disable:
+    description: >
+      Whether the bundle is administratively disabled. When omitted it is left
+      unchanged.
+    type: bool
+    required: false
+  vlans:
+    description: >
+      Member VLANs of the bundle with their Ethernet tags. The supplied list
+      fully replaces the set of member VLANs. When omitted the VLANs are left
+      unchanged; an empty list removes all member VLANs. The VLANs must already
+      exist on the device. Ignored when I(state) is C(delete).
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      id:
+        description: VLAN ID of the member VLAN.
+        type: int
+        required: true
+      ethernet_tag:
+        description: >
+          Ethernet tag mapped to the VLAN. When omitted it defaults to the
+          VLAN ID.
+        type: int
+        required: false
+  state:
+    description: Create, update or delete the EVPN VLAN-aware bundle.
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    required: false
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create an EVPN VLAN-aware bundle with two member VLANs
+  arubanetworks.aoscx.aoscx_evpn_vlan_aware_bundle:
+    bundle_name: tenant-blue
+    rd: "65000:1"
+    import_route_targets:
+      - "65000:1"
+    export_route_targets:
+      - "65000:1"
+    vlans:
+      - id: 206
+      - id: 207
+        ethernet_tag: 100
+    state: create
+
+- name: Replace the member VLANs of a bundle
+  arubanetworks.aoscx.aoscx_evpn_vlan_aware_bundle:
+    bundle_name: tenant-blue
+    vlans:
+      - id: 206
+    state: update
+
+- name: Remove all member VLANs from a bundle
+  arubanetworks.aoscx.aoscx_evpn_vlan_aware_bundle:
+    bundle_name: tenant-blue
+    vlans: []
+    state: update
+
+- name: Delete an EVPN VLAN-aware bundle
+  arubanetworks.aoscx.aoscx_evpn_vlan_aware_bundle:
+    bundle_name: tenant-blue
+    state: delete
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the EVPN VLAN-aware bundle was modified.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def build_vlan_tags(session, ansible_module, vlans):
+    """Resolve the desired vlan_ethernet_tags {vlan_uri: ethernet_tag} map.
+
+    Validates that every member VLAN exists and builds the URI-keyed map the
+    REST API expects.
+    """
+    tags = {}
+    for entry in vlans:
+        vlan_id = entry["id"]
+        ethernet_tag = entry.get("ethernet_tag")
+        if ethernet_tag is None:
+            ethernet_tag = vlan_id
+        vlan_obj = session.api.get_module(session, "Vlan", vlan_id)
+        try:
+            vlan_obj.get()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not find VLAN {0}: {1}".format(vlan_id, str(e))
+            )
+        uri = "{0}system/vlans/{1}".format(
+            session.resource_prefix, vlan_id
+        )
+        tags[uri] = ethernet_tag
+    return tags
+
+
+def normalize_tags(tags):
+    """Reduce a {vlan_uri: tag} map to a comparable {vlan_id: tag} dict."""
+    normalized = {}
+    for uri, tag in (tags or {}).items():
+        vlan_id = str(uri).rstrip("/").rsplit("/", 1)[-1]
+        normalized[vlan_id] = tag
+    return normalized
+
+
+def main():
+    module_args = dict(
+        bundle_name=dict(type="str", required=True),
+        rd=dict(type="str", required=False, default=None),
+        import_route_targets=dict(
+            type="list", elements="str", required=False, default=None
+        ),
+        export_route_targets=dict(
+            type="list", elements="str", required=False, default=None
+        ),
+        redistribute=dict(type="dict", required=False, default=None),
+        disable=dict(type="bool", required=False, default=None),
+        vlans=dict(
+            type="list",
+            elements="dict",
+            required=False,
+            default=None,
+            options=dict(
+                id=dict(type="int", required=True),
+                ethernet_tag=dict(type="int", required=False, default=None),
+            ),
+        ),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    bundle_name = ansible_module.params["bundle_name"]
+    rd = ansible_module.params["rd"]
+    import_route_targets = ansible_module.params["import_route_targets"]
+    export_route_targets = ansible_module.params["export_route_targets"]
+    redistribute = ansible_module.params["redistribute"]
+    disable = ansible_module.params["disable"]
+    vlans = ansible_module.params["vlans"]
+    state = ansible_module.params["state"]
+
+    result = dict(changed=False)
+
+    if bundle_name in ("", ".", "..") or "/" in bundle_name:
+        ansible_module.fail_json(
+            msg="Invalid bundle name: {0}".format(bundle_name)
+        )
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        bundle = session.api.get_module(
+            session, "EvpnVlanAwareBundle", bundle_name
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support EVPN VLAN-aware "
+                "bundles. Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        bundle.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # ----------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                bundle.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete bundle: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # Resolve the desired member VLANs before mutating anything.
+    desired_tags = None
+    if vlans is not None:
+        desired_tags = build_vlan_tags(session, ansible_module, vlans)
+
+    # ----------------------------------------------------------- check mode
+    if ansible_module.check_mode:
+        result["changed"] = (not exists) or any(
+            value is not None
+            for value in (
+                rd,
+                import_route_targets,
+                export_route_targets,
+                redistribute,
+                disable,
+                vlans,
+            )
+        )
+        ansible_module.exit_json(**result)
+
+    # ----------------------------------------------------------- create/update
+    created = False
+    if not exists:
+        try:
+            bundle.create()
+            bundle.get(selector="writable")
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not create bundle: {0}".format(str(e))
+            )
+        created = True
+
+    needs_update = False
+
+    if rd is not None and getattr(bundle, "rd", None) != rd:
+        needs_update = True
+        bundle.rd = rd
+
+    if import_route_targets is not None:
+        current = getattr(bundle, "import_route_targets", None) or []
+        if sorted(current) != sorted(import_route_targets):
+            needs_update = True
+            bundle.import_route_targets = import_route_targets
+
+    if export_route_targets is not None:
+        current = getattr(bundle, "export_route_targets", None) or []
+        if sorted(current) != sorted(export_route_targets):
+            needs_update = True
+            bundle.export_route_targets = export_route_targets
+
+    if redistribute is not None:
+        current = dict(getattr(bundle, "redistribute", None) or {})
+        merged = dict(current)
+        merged.update(redistribute)
+        if merged != current:
+            needs_update = True
+            bundle.redistribute = merged
+
+    if disable is not None and getattr(bundle, "disable", None) != disable:
+        needs_update = True
+        bundle.disable = disable
+
+    if desired_tags is not None:
+        current_tags = getattr(bundle, "vlan_ethernet_tags", None) or {}
+        if normalize_tags(current_tags) != normalize_tags(desired_tags):
+            needs_update = True
+            bundle.vlan_ethernet_tags = desired_tags
+
+    if needs_update:
+        try:
+            bundle.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update bundle: {0}".format(str(e))
+            )
+
+    result["changed"] = created or needs_update
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/aoscx_evpn_vlan_aware_bundle/aliases
+++ b/tests/integration/targets/aoscx_evpn_vlan_aware_bundle/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_evpn_vlan_aware_bundle/tasks/main.yml
+++ b/tests/integration/targets/aoscx_evpn_vlan_aware_bundle/tasks/main.yml
@@ -1,0 +1,118 @@
+# Integration tests for the aoscx_evpn_vlan_aware_bundle module.
+#
+# Run with:
+#   ansible-test integration aoscx_evpn_vlan_aware_bundle --venv
+#
+# Requires an inventory entry named "aoscx" reachable over httpapi with a
+# pyaoscx release that ships the EvpnVlanAwareBundle class. Uses temporary
+# VLANs (3998, 3999) and a temporary bundle, and cleans up afterwards.
+
+- name: Make sure the test bundle does not exist yet
+  arubanetworks.aoscx.aoscx_evpn_vlan_aware_bundle:
+    bundle_name: integration-bundle
+    state: delete
+  ignore_errors: true
+
+- name: Ensure the test VLANs exist
+  arubanetworks.aoscx.aoscx_vlan:
+    vlan_id: "{{ item }}"
+    name: "bundle-integration-{{ item }}"
+    state: create
+  loop:
+    - 3998
+    - 3999
+
+- name: Create the bundle with two member VLANs
+  arubanetworks.aoscx.aoscx_evpn_vlan_aware_bundle:
+    bundle_name: integration-bundle
+    rd: "65000:1"
+    import_route_targets:
+      - "65000:1"
+    export_route_targets:
+      - "65000:1"
+    vlans:
+      - id: 3998
+      - id: 3999
+        ethernet_tag: 100
+    state: create
+  register: create_result
+
+- name: Assert create changed
+  ansible.builtin.assert:
+    that:
+      - create_result is changed
+
+- name: Re-apply identical configuration
+  arubanetworks.aoscx.aoscx_evpn_vlan_aware_bundle:
+    bundle_name: integration-bundle
+    rd: "65000:1"
+    import_route_targets:
+      - "65000:1"
+    export_route_targets:
+      - "65000:1"
+    vlans:
+      - id: 3998
+      - id: 3999
+        ethernet_tag: 100
+    state: create
+  register: idem_result
+
+- name: Assert re-apply did not change
+  ansible.builtin.assert:
+    that:
+      - idem_result is not changed
+
+- name: Replace the member VLANs
+  arubanetworks.aoscx.aoscx_evpn_vlan_aware_bundle:
+    bundle_name: integration-bundle
+    vlans:
+      - id: 3998
+    state: update
+  register: replace_result
+
+- name: Assert replacing VLANs changed
+  ansible.builtin.assert:
+    that:
+      - replace_result is changed
+
+- name: Remove all member VLANs
+  arubanetworks.aoscx.aoscx_evpn_vlan_aware_bundle:
+    bundle_name: integration-bundle
+    vlans: []
+    state: update
+  register: clear_result
+
+- name: Assert clearing VLANs changed
+  ansible.builtin.assert:
+    that:
+      - clear_result is changed
+
+- name: Delete the bundle
+  arubanetworks.aoscx.aoscx_evpn_vlan_aware_bundle:
+    bundle_name: integration-bundle
+    state: delete
+  register: delete_result
+
+- name: Assert delete changed
+  ansible.builtin.assert:
+    that:
+      - delete_result is changed
+
+- name: Delete again (idempotent)
+  arubanetworks.aoscx.aoscx_evpn_vlan_aware_bundle:
+    bundle_name: integration-bundle
+    state: delete
+  register: delete_idem
+
+- name: Assert second delete did not change
+  ansible.builtin.assert:
+    that:
+      - delete_idem is not changed
+
+- name: Remove the test VLANs
+  arubanetworks.aoscx.aoscx_vlan:
+    vlan_id: "{{ item }}"
+    state: delete
+  loop:
+    - 3998
+    - 3999

--- a/tests/unit/modules/test_aoscx_evpn_vlan_aware_bundle.py
+++ b/tests/unit/modules/test_aoscx_evpn_vlan_aware_bundle.py
@@ -1,0 +1,266 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Unit tests for the aoscx_evpn_vlan_aware_bundle module.
+
+The pyaoscx session is fully mocked, so no switch is required. The tests cover
+input validation, check mode, create, idempotency, update, member VLAN
+reconciliation, delete and error handling.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_evpn_vlan_aware_bundle,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_evpn_vlan_aware_bundle"
+)
+
+PREFIX = "/rest/latest/"
+
+
+class AnsibleExitJson(Exception):
+    """Raised by the mocked exit_json to stop module execution."""
+
+
+class AnsibleFailJson(Exception):
+    """Raised by the mocked fail_json to stop module execution."""
+
+
+def exit_json(*args, **kwargs):
+    if "changed" not in kwargs:
+        kwargs["changed"] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    serialized = json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    basic._ANSIBLE_ARGS = to_bytes(serialized)
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule,
+        exit_json=exit_json,
+        fail_json=fail_json,
+    ):
+        yield
+
+
+def build_bundle(exists, **attrs):
+    bundle = MagicMock()
+    for key, value in attrs.items():
+        setattr(bundle, key, value)
+    if exists:
+        bundle.get.return_value = True
+    else:
+        # The first get (existence check) fails; a later get (after create)
+        # succeeds.
+        bundle.get.side_effect = [Exception("not found"), True]
+    return bundle
+
+
+def build_session(bundle, vlan_exists=True):
+    session = MagicMock()
+    session.resource_prefix = PREFIX
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "EvpnVlanAwareBundle":
+            return bundle
+        if module == "Vlan":
+            vlan = MagicMock()
+            if vlan_exists:
+                vlan.get.return_value = True
+            else:
+                vlan.get.side_effect = Exception("no vlan")
+            return vlan
+        raise AssertionError("unexpected module {0}".format(module))
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_evpn_vlan_aware_bundle.main()
+    return exc.value.args[0]
+
+
+# --------------------------------------------------------------------------
+# Validation
+# --------------------------------------------------------------------------
+def test_invalid_bundle_name_rejected():
+    session = build_session(build_bundle(False))
+    result = run_module({"bundle_name": "a/b"}, session)
+    assert result["failed"] is True
+    assert "Invalid bundle name" in result["msg"]
+
+
+def test_missing_vlan_rejected():
+    bundle = build_bundle(False)
+    session = build_session(bundle, vlan_exists=False)
+    result = run_module(
+        {"bundle_name": "blue", "vlans": [{"id": 206}]}, session
+    )
+    assert result["failed"] is True
+    assert "Could not find VLAN" in result["msg"]
+
+
+# --------------------------------------------------------------------------
+# Check mode
+# --------------------------------------------------------------------------
+def test_check_mode_create_reports_change():
+    bundle = build_bundle(False)
+    session = build_session(bundle)
+    result = run_module(
+        {"bundle_name": "blue", "rd": "65000:1", "_ansible_check_mode": True},
+        session,
+    )
+    assert result["changed"] is True
+    bundle.create.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Create / idempotency / update
+# --------------------------------------------------------------------------
+def test_create():
+    bundle = build_bundle(
+        False,
+        rd=None,
+        import_route_targets=[],
+        export_route_targets=[],
+        redistribute={},
+        disable=False,
+        vlan_ethernet_tags={},
+    )
+    session = build_session(bundle)
+    result = run_module(
+        {
+            "bundle_name": "blue",
+            "rd": "65000:1",
+            "vlans": [{"id": 206}, {"id": 207, "ethernet_tag": 100}],
+        },
+        session,
+    )
+    assert result["changed"] is True
+    bundle.create.assert_called_once()
+    bundle.update.assert_called_once()
+    assert bundle.rd == "65000:1"
+    assert bundle.vlan_ethernet_tags == {
+        PREFIX + "system/vlans/206": 206,
+        PREFIX + "system/vlans/207": 100,
+    }
+
+
+def test_idempotent():
+    bundle = build_bundle(
+        True,
+        rd="65000:1",
+        import_route_targets=["65000:1"],
+        export_route_targets=["65000:1"],
+        redistribute={"host-route": False},
+        disable=False,
+        vlan_ethernet_tags={PREFIX + "system/vlans/206": 206},
+    )
+    session = build_session(bundle)
+    result = run_module(
+        {
+            "bundle_name": "blue",
+            "rd": "65000:1",
+            "import_route_targets": ["65000:1"],
+            "export_route_targets": ["65000:1"],
+            "vlans": [{"id": 206}],
+            "state": "update",
+        },
+        session,
+    )
+    assert result["changed"] is False
+    bundle.update.assert_not_called()
+
+
+def test_update_replaces_vlans():
+    bundle = build_bundle(
+        True,
+        rd="65000:1",
+        import_route_targets=["65000:1"],
+        export_route_targets=["65000:1"],
+        redistribute={},
+        disable=False,
+        vlan_ethernet_tags={
+            PREFIX + "system/vlans/206": 206,
+            PREFIX + "system/vlans/207": 207,
+        },
+    )
+    session = build_session(bundle)
+    result = run_module(
+        {"bundle_name": "blue", "vlans": [{"id": 206}], "state": "update"},
+        session,
+    )
+    assert result["changed"] is True
+    bundle.update.assert_called_once()
+    assert bundle.vlan_ethernet_tags == {PREFIX + "system/vlans/206": 206}
+
+
+def test_clear_vlans():
+    bundle = build_bundle(
+        True,
+        rd="65000:1",
+        import_route_targets=[],
+        export_route_targets=[],
+        redistribute={},
+        disable=False,
+        vlan_ethernet_tags={PREFIX + "system/vlans/206": 206},
+    )
+    session = build_session(bundle)
+    result = run_module(
+        {"bundle_name": "blue", "vlans": [], "state": "update"}, session
+    )
+    assert result["changed"] is True
+    assert bundle.vlan_ethernet_tags == {}
+
+
+# --------------------------------------------------------------------------
+# Delete
+# --------------------------------------------------------------------------
+def test_delete():
+    bundle = build_bundle(True)
+    session = build_session(bundle)
+    result = run_module(
+        {"bundle_name": "blue", "state": "delete"}, session
+    )
+    assert result["changed"] is True
+    bundle.delete.assert_called_once()
+
+
+def test_delete_idempotent():
+    bundle = build_bundle(False)
+    session = build_session(bundle)
+    result = run_module(
+        {"bundle_name": "blue", "state": "delete"}, session
+    )
+    assert result["changed"] is False
+    bundle.delete.assert_not_called()


### PR DESCRIPTION
Fixes #210

Depends on SDK PR aruba/pyaoscx#103.

## Summary

Adds the `aoscx_evpn_vlan_aware_bundle` module to create, update and delete EVPN VLAN-aware bundles: route distinguisher, import/export route targets, redistribution, administrative state and member VLANs mapped through their Ethernet tags (`vlan_ethernet_tags`).

A dedicated module is consistent with the existing split between `aoscx_evpn` (singleton) and `aoscx_evpn_vlan` (per-VLAN collection).

## Notes

Requires aruba/pyaoscx#103, which adds the `EvpnVlanAwareBundle` resource class. Includes documentation, changelog fragment, unit and integration tests.

## Testing

- `ansible-test sanity` (pep8, pylint, validate-modules) and `ansible-doc` pass.
- Unit tests pass.
- Validated live on a CX 6300 (FL.10.17, REST `latest`): create / idempotency / member VLAN replacement / clearing / delete.

## Depends on
- aruba/pyaoscx#103 — EvpnVlanAwareBundle
