### PR TITLE
Add RADIUS dynamic authorization proxy modules

### DIFF
--- a/changelogs/fragments/aoscx_radius_dynauth_proxy.yml
+++ b/changelogs/fragments/aoscx_radius_dynauth_proxy.yml
@@ -1,0 +1,8 @@
+minor_changes:
+  - Add ``aoscx_radius_dynauth_proxy_server``,
+    ``aoscx_radius_dynauth_proxy_client_group`` and
+    ``aoscx_radius_dynauth_proxy_profile`` modules to manage RADIUS dynamic
+    authorization (Change of Authorization) proxy servers, client groups and
+    profiles. Requires a pyaoscx release that ships the
+    ``RadiusDynauthProxyServer``, ``RadiusDynauthProxyClientGroup`` and
+    ``RadiusDynauthProxyProfile`` classes.

--- a/docs/aoscx_radius_dynauth_proxy_client_group.md
+++ b/docs/aoscx_radius_dynauth_proxy_client_group.md
@@ -1,0 +1,75 @@
+# module: aoscx_radius_dynauth_proxy_client_group
+
+description: This module provides configuration management of RADIUS dynamic
+authorization (Change of Authorization) proxy client groups on AOS-CX devices.
+A client group references a set of RADIUS dynamic authorization (CoA) clients
+and is identified by its name.
+
+##### ARGUMENTS
+
+```YAML
+  group_name:
+    description: Name of the proxy client group.
+    required: true
+    type: str
+  clients:
+    description: >
+      RADIUS dynamic authorization (CoA) clients that are members of the group.
+      The supplied list fully replaces the members. When omitted the members
+      are left unchanged; an empty list removes all members. Each referenced
+      CoA client must already exist. Ignored when state is delete.
+    required: false
+    type: list
+    elements: dict
+    suboptions:
+      address:
+        description: Address of the CoA client.
+        required: true
+        type: str
+      connection_type:
+        description: Connection type of the CoA client.
+        required: false
+        default: udp
+        choices:
+          - udp
+          - tcp
+        type: str
+      vrf:
+        description: VRF of the CoA client.
+        required: false
+        default: default
+        type: str
+  state:
+    description: Create, update or delete the proxy client group.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create a proxy client group with two CoA clients
+  aoscx_radius_dynauth_proxy_client_group:
+    group_name: coa-group
+    clients:
+      - address: 192.0.2.41
+        connection_type: udp
+      - address: 192.0.2.42
+        connection_type: udp
+
+- name: Remove all members from the group
+  aoscx_radius_dynauth_proxy_client_group:
+    group_name: coa-group
+    clients: []
+    state: update
+
+- name: Delete the proxy client group
+  aoscx_radius_dynauth_proxy_client_group:
+    group_name: coa-group
+    state: delete
+```

--- a/docs/aoscx_radius_dynauth_proxy_profile.md
+++ b/docs/aoscx_radius_dynauth_proxy_profile.md
@@ -1,0 +1,104 @@
+# module: aoscx_radius_dynauth_proxy_profile
+
+description: This module provides configuration management of RADIUS dynamic
+authorization (Change of Authorization) proxy profiles on AOS-CX devices. A
+profile ties together a proxy client group and a proxy server within a VRF, and
+is identified by its name.
+
+##### ARGUMENTS
+
+```YAML
+  profile_name:
+    description: Name of the proxy profile.
+    required: true
+    type: str
+  enabled:
+    description: Whether the proxy profile is enabled.
+    required: false
+    type: bool
+  address:
+    description: Source IPv4 address used by the proxy profile.
+    required: false
+    type: str
+  port:
+    description: Port used by the proxy profile.
+    required: false
+    type: int
+  port_type:
+    description: Transport used by the proxy profile.
+    required: false
+    choices:
+      - udp
+      - tcp
+    type: str
+  vrf:
+    description: VRF the proxy profile belongs to.
+    required: false
+    default: default
+    type: str
+  client_group:
+    description: >
+      Name of the RADIUS dynamic authorization proxy client group referenced by
+      this profile. The client group must already exist. Pass an empty string
+      to clear the reference.
+    required: false
+    type: str
+  server:
+    description: >
+      RADIUS dynamic authorization proxy server referenced by this profile. The
+      server must already exist.
+    required: false
+    type: dict
+    suboptions:
+      address:
+        description: Address of the proxy server.
+        required: true
+        type: str
+      port:
+        description: Port of the proxy server.
+        required: false
+        default: 3799
+        type: int
+      port_type:
+        description: Transport of the proxy server.
+        required: false
+        default: udp
+        choices:
+          - udp
+          - tcp
+        type: str
+      vrf:
+        description: VRF of the proxy server.
+        required: false
+        default: default
+        type: str
+  state:
+    description: Create, update or delete the proxy profile.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create a proxy profile tying a client group and a server
+  aoscx_radius_dynauth_proxy_profile:
+    profile_name: coa-proxy
+    enabled: true
+    vrf: default
+    client_group: coa-group
+    server:
+      address: 192.0.2.30
+      port: 3799
+      port_type: udp
+
+- name: Delete a proxy profile
+  aoscx_radius_dynauth_proxy_profile:
+    profile_name: coa-proxy
+    state: delete
+```

--- a/docs/aoscx_radius_dynauth_proxy_server.md
+++ b/docs/aoscx_radius_dynauth_proxy_server.md
@@ -1,0 +1,69 @@
+# module: aoscx_radius_dynauth_proxy_server
+
+description: This module provides configuration management of RADIUS dynamic
+authorization (Change of Authorization) proxy servers on AOS-CX devices. A
+proxy server lives under a VRF and is identified by the combination of its
+address, port and port type.
+
+##### ARGUMENTS
+
+```YAML
+  vrf:
+    description: VRF the proxy server belongs to.
+    required: false
+    default: default
+    type: str
+  address:
+    description: IPv4 address or hostname of the proxy server.
+    required: true
+    type: str
+  port:
+    description: UDP/TCP port of the proxy server.
+    required: false
+    default: 3799
+    type: int
+  port_type:
+    description: Transport used by the proxy server.
+    required: false
+    default: udp
+    choices:
+      - udp
+      - tcp
+    type: str
+  secret_key:
+    description: >
+      Shared secret used with the proxy server. It is write-only; the switch
+      only ever returns it encrypted, so when secret_key is supplied the
+      module reports changed on every run.
+    required: false
+    type: str
+  state:
+    description: Create, update or delete the proxy server.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create a RADIUS dynamic authorization proxy server
+  aoscx_radius_dynauth_proxy_server:
+    vrf: default
+    address: 192.0.2.30
+    port: 3799
+    port_type: udp
+    secret_key: my-secret
+
+- name: Delete a RADIUS dynamic authorization proxy server
+  aoscx_radius_dynauth_proxy_server:
+    vrf: default
+    address: 192.0.2.30
+    port: 3799
+    port_type: udp
+    state: delete
+```

--- a/plugins/modules/aoscx_radius_dynauth_proxy_client_group.py
+++ b/plugins/modules/aoscx_radius_dynauth_proxy_client_group.py
@@ -1,0 +1,268 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_radius_dynauth_proxy_client_group
+version_added: "4.6.0"
+short_description: >
+  Create, update or delete a RADIUS dynamic authorization proxy client group on
+  AOS-CX.
+description: >
+  This module provides configuration management of RADIUS dynamic
+  authorization (Change of Authorization) proxy client groups on AOS-CX
+  devices. A client group references a set of RADIUS dynamic authorization
+  (CoA) clients and is identified by its name.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  group_name:
+    description: Name of the proxy client group.
+    type: str
+    required: true
+  clients:
+    description: >
+      RADIUS dynamic authorization (CoA) clients that are members of the group.
+      The supplied list fully replaces the members. When omitted the members
+      are left unchanged; an empty list removes all members. Each referenced
+      CoA client must already exist. Ignored when I(state) is C(delete).
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      address:
+        description: Address of the CoA client.
+        type: str
+        required: true
+      connection_type:
+        description: Connection type of the CoA client.
+        type: str
+        required: false
+        default: udp
+        choices:
+          - udp
+          - tcp
+      vrf:
+        description: VRF of the CoA client.
+        type: str
+        required: false
+        default: default
+  state:
+    description: Create, update or delete the proxy client group.
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    required: false
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a proxy client group with two CoA clients
+  arubanetworks.aoscx.aoscx_radius_dynauth_proxy_client_group:
+    group_name: coa-group
+    clients:
+      - address: 192.0.2.41
+        connection_type: udp
+      - address: 192.0.2.42
+        connection_type: udp
+    state: create
+
+- name: Remove all members from the group
+  arubanetworks.aoscx.aoscx_radius_dynauth_proxy_client_group:
+    group_name: coa-group
+    clients: []
+    state: update
+
+- name: Delete the proxy client group
+  arubanetworks.aoscx.aoscx_radius_dynauth_proxy_client_group:
+    group_name: coa-group
+    state: delete
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the proxy client group was modified.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def build_clients(session, ansible_module, clients):
+    """Resolve the desired clients {id: coa_client_uri} map.
+
+    Validates that every referenced CoA client exists and builds the
+    numeric-id keyed map the REST API expects.
+    """
+    result = {}
+    for index, entry in enumerate(clients, start=1):
+        address = entry["address"]
+        connection_type = entry["connection_type"]
+        vrf = entry["vrf"]
+        client = session.api.get_module(
+            session,
+            "RadiusDynamicAuthorizationClient",
+            vrf,
+            address=address,
+            connection_type=connection_type,
+        )
+        try:
+            client.get()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not find CoA client {0},{1} in VRF {2}: {3}".format(
+                    address, connection_type, vrf, str(e)
+                )
+            )
+        sep = session.api.compound_index_separator
+        uri = "{0}system/vrfs/{1}/radius_dynamic_authorization_clients/" \
+              "{2}{3}{4}".format(
+                  session.resource_prefix, vrf, address, sep, connection_type
+              )
+        result[str(index)] = uri
+    return result
+
+
+def normalize_clients(clients):
+    """Reduce a {id: uri} map to the comparable set of client URIs."""
+    return frozenset((clients or {}).values())
+
+
+def main():
+    module_args = dict(
+        group_name=dict(type="str", required=True),
+        clients=dict(
+            type="list",
+            elements="dict",
+            required=False,
+            default=None,
+            options=dict(
+                address=dict(type="str", required=True),
+                connection_type=dict(
+                    type="str", required=False, default="udp",
+                    choices=["udp", "tcp"],
+                ),
+                vrf=dict(type="str", required=False, default="default"),
+            ),
+        ),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    group_name = ansible_module.params["group_name"]
+    clients = ansible_module.params["clients"]
+    state = ansible_module.params["state"]
+
+    result = dict(changed=False)
+
+    if group_name in ("", ".", "..") or "/" in group_name:
+        ansible_module.fail_json(
+            msg="Invalid group name: {0}".format(group_name)
+        )
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        group = session.api.get_module(
+            session, "RadiusDynauthProxyClientGroup", group_name
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support RADIUS dynamic "
+                "authorization proxy client groups. Upgrade pyaoscx. Details: "
+                "{0}".format(str(e))
+            )
+        )
+
+    try:
+        group.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # ----------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                group.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete client group: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    desired = None
+    if clients is not None:
+        desired = build_clients(session, ansible_module, clients)
+
+    # ----------------------------------------------------------- check mode
+    if ansible_module.check_mode:
+        result["changed"] = (not exists) or clients is not None
+        ansible_module.exit_json(**result)
+
+    # ----------------------------------------------------------- create/update
+    created = False
+    if not exists:
+        try:
+            group.create()
+            group.get(selector="writable")
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not create client group: {0}".format(str(e))
+            )
+        created = True
+
+    needs_update = False
+    if desired is not None:
+        current = getattr(group, "clients", None) or {}
+        if normalize_clients(current) != normalize_clients(desired):
+            needs_update = True
+            group.clients = desired
+
+    if needs_update:
+        try:
+            group.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update client group: {0}".format(str(e))
+            )
+
+    result["changed"] = created or needs_update
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_radius_dynauth_proxy_profile.py
+++ b/plugins/modules/aoscx_radius_dynauth_proxy_profile.py
@@ -1,0 +1,353 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_radius_dynauth_proxy_profile
+version_added: "4.6.0"
+short_description: >
+  Create, update or delete a RADIUS dynamic authorization proxy profile on
+  AOS-CX.
+description: >
+  This module provides configuration management of RADIUS dynamic
+  authorization (Change of Authorization) proxy profiles on AOS-CX devices. A
+  profile ties together a proxy client group and a proxy server within a VRF,
+  and is identified by its name.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  profile_name:
+    description: Name of the proxy profile.
+    type: str
+    required: true
+  enabled:
+    description: Whether the proxy profile is enabled.
+    type: bool
+    required: false
+  address:
+    description: Source IPv4 address used by the proxy profile.
+    type: str
+    required: false
+  port:
+    description: Port used by the proxy profile.
+    type: int
+    required: false
+  port_type:
+    description: Transport used by the proxy profile.
+    type: str
+    required: false
+    choices:
+      - udp
+      - tcp
+  vrf:
+    description: VRF the proxy profile belongs to.
+    type: str
+    required: false
+    default: default
+  client_group:
+    description: >
+      Name of the RADIUS dynamic authorization proxy client group referenced by
+      this profile. The client group must already exist. Pass an empty string
+      to clear the reference.
+    type: str
+    required: false
+  server:
+    description: >
+      RADIUS dynamic authorization proxy server referenced by this profile. The
+      server must already exist.
+    type: dict
+    required: false
+    suboptions:
+      address:
+        description: Address of the proxy server.
+        type: str
+        required: true
+      port:
+        description: Port of the proxy server.
+        type: int
+        required: false
+        default: 3799
+      port_type:
+        description: Transport of the proxy server.
+        type: str
+        required: false
+        default: udp
+        choices:
+          - udp
+          - tcp
+      vrf:
+        description: VRF of the proxy server.
+        type: str
+        required: false
+        default: default
+  state:
+    description: Create, update or delete the proxy profile.
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    required: false
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a proxy profile tying a client group and a server
+  arubanetworks.aoscx.aoscx_radius_dynauth_proxy_profile:
+    profile_name: coa-proxy
+    enabled: true
+    vrf: default
+    client_group: coa-group
+    server:
+      address: 192.0.2.30
+      port: 3799
+      port_type: udp
+    state: create
+
+- name: Delete a proxy profile
+  arubanetworks.aoscx.aoscx_radius_dynauth_proxy_profile:
+    profile_name: coa-proxy
+    state: delete
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the proxy profile was modified.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def ref_name(ref):
+    """Return the single key (name) of a {name: uri} reference map."""
+    if isinstance(ref, dict) and ref:
+        return next(iter(ref))
+    return None
+
+
+def main():
+    module_args = dict(
+        profile_name=dict(type="str", required=True),
+        enabled=dict(type="bool", required=False, default=None),
+        address=dict(type="str", required=False, default=None),
+        port=dict(type="int", required=False, default=None),
+        port_type=dict(
+            type="str", required=False, default=None, choices=["udp", "tcp"]
+        ),
+        vrf=dict(type="str", required=False, default="default"),
+        client_group=dict(type="str", required=False, default=None),
+        server=dict(
+            type="dict",
+            required=False,
+            default=None,
+            options=dict(
+                address=dict(type="str", required=True),
+                port=dict(type="int", required=False, default=3799),
+                port_type=dict(
+                    type="str", required=False, default="udp",
+                    choices=["udp", "tcp"],
+                ),
+                vrf=dict(type="str", required=False, default="default"),
+            ),
+        ),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    params = ansible_module.params
+    profile_name = params["profile_name"]
+    enabled = params["enabled"]
+    address = params["address"]
+    port = params["port"]
+    port_type = params["port_type"]
+    vrf = params["vrf"]
+    client_group = params["client_group"]
+    server = params["server"]
+    state = params["state"]
+
+    result = dict(changed=False)
+
+    if profile_name in ("", ".", "..") or "/" in profile_name:
+        ansible_module.fail_json(
+            msg="Invalid profile name: {0}".format(profile_name)
+        )
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        profile = session.api.get_module(
+            session, "RadiusDynauthProxyProfile", profile_name
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support RADIUS dynamic "
+                "authorization proxy profiles. Upgrade pyaoscx. Details: "
+                "{0}".format(str(e))
+            )
+        )
+
+    try:
+        profile.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # ----------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                profile.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete proxy profile: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    rp = session.resource_prefix
+    sep = session.api.compound_index_separator
+
+    # Resolve and validate references before mutating anything.
+    desired_cg = None
+    if client_group is not None:
+        if client_group == "":
+            desired_cg = {}
+        else:
+            cg = session.api.get_module(
+                session, "RadiusDynauthProxyClientGroup", client_group
+            )
+            try:
+                cg.get()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not find client group {0}: {1}".format(
+                        client_group, str(e)
+                    )
+                )
+            desired_cg = {
+                client_group: "{0}system/radius_dynauth_proxy_client_groups/"
+                "{1}".format(rp, client_group)
+            }
+
+    desired_srv = None
+    if server is not None:
+        srv = session.api.get_module(
+            session,
+            "RadiusDynauthProxyServer",
+            server["vrf"],
+            address=server["address"],
+            port=server["port"],
+            port_type=server["port_type"],
+        )
+        try:
+            srv.get()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not find proxy server {0}: {1}".format(
+                    server["address"], str(e)
+                )
+            )
+        srv_index = "{0}{1}{2}{1}{3}".format(
+            server["address"], sep, server["port"], server["port_type"]
+        )
+        desired_srv = {
+            srv_index: "{0}system/vrfs/{1}/radius_dynauth_proxy_servers/"
+            "{2}".format(rp, server["vrf"], srv_index)
+        }
+
+    desired_vrf = {vrf: "{0}system/vrfs/{1}".format(rp, vrf)}
+
+    # ----------------------------------------------------------- check mode
+    if ansible_module.check_mode:
+        result["changed"] = (not exists) or any(
+            v is not None
+            for v in (enabled, address, port, port_type, client_group, server)
+        )
+        ansible_module.exit_json(**result)
+
+    # ----------------------------------------------------------- create/update
+    created = False
+    if not exists:
+        try:
+            profile.create()
+            profile.get(selector="writable")
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not create proxy profile: {0}".format(str(e))
+            )
+        created = True
+
+    needs_update = False
+
+    scalars = {
+        "enabled": enabled,
+        "address": address,
+        "port": port,
+        "port_type": port_type,
+    }
+    for name, value in scalars.items():
+        if value is not None and getattr(profile, name, None) != value:
+            needs_update = True
+            setattr(profile, name, value)
+
+    if ref_name(getattr(profile, "vrf", None) or {}) != vrf:
+        needs_update = True
+        profile.vrf = desired_vrf
+
+    if desired_cg is not None:
+        current = getattr(profile, "dynauth_client_group", None) or {}
+        if ref_name(current) != ref_name(desired_cg):
+            needs_update = True
+            profile.dynauth_client_group = desired_cg
+
+    if desired_srv is not None:
+        current = getattr(profile, "dynauth_server", None) or {}
+        if ref_name(current) != ref_name(desired_srv):
+            needs_update = True
+            profile.dynauth_server = desired_srv
+
+    if needs_update:
+        try:
+            profile.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update proxy profile: {0}".format(str(e))
+            )
+
+    result["changed"] = created or needs_update
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_radius_dynauth_proxy_server.py
+++ b/plugins/modules/aoscx_radius_dynauth_proxy_server.py
@@ -1,0 +1,219 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_radius_dynauth_proxy_server
+version_added: "4.6.0"
+short_description: >
+  Create, update or delete a RADIUS dynamic authorization proxy server on
+  AOS-CX.
+description: >
+  This module provides configuration management of RADIUS dynamic
+  authorization (Change of Authorization) proxy servers on AOS-CX devices. A
+  proxy server lives under a VRF and is identified by the combination of its
+  address, port and port type.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  vrf:
+    description: VRF the proxy server belongs to.
+    type: str
+    required: false
+    default: default
+  address:
+    description: IPv4 address or hostname of the proxy server.
+    type: str
+    required: true
+  port:
+    description: UDP/TCP port of the proxy server.
+    type: int
+    required: false
+    default: 3799
+  port_type:
+    description: Transport used by the proxy server.
+    type: str
+    required: false
+    default: udp
+    choices:
+      - udp
+      - tcp
+  secret_key:
+    description: >
+      Shared secret used with the proxy server. It is write-only; the switch
+      only ever returns it encrypted, so when C(secret_key) is supplied the
+      module reports changed on every run.
+    type: str
+    required: false
+  state:
+    description: Create, update or delete the proxy server.
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    required: false
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a RADIUS dynamic authorization proxy server
+  arubanetworks.aoscx.aoscx_radius_dynauth_proxy_server:
+    vrf: default
+    address: 192.0.2.30
+    port: 3799
+    port_type: udp
+    secret_key: my-secret
+    state: create
+
+- name: Delete a RADIUS dynamic authorization proxy server
+  arubanetworks.aoscx.aoscx_radius_dynauth_proxy_server:
+    vrf: default
+    address: 192.0.2.30
+    port: 3799
+    port_type: udp
+    state: delete
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the proxy server was modified.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def main():
+    module_args = dict(
+        vrf=dict(type="str", required=False, default="default"),
+        address=dict(type="str", required=True),
+        port=dict(type="int", required=False, default=3799),
+        port_type=dict(
+            type="str", required=False, default="udp",
+            choices=["udp", "tcp"],
+        ),
+        secret_key=dict(type="str", required=False, default=None,
+                        no_log=True),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    vrf = ansible_module.params["vrf"]
+    address = ansible_module.params["address"]
+    port = ansible_module.params["port"]
+    port_type = ansible_module.params["port_type"]
+    secret_key = ansible_module.params["secret_key"]
+    state = ansible_module.params["state"]
+
+    result = dict(changed=False)
+
+    if "," in vrf or "/" in vrf or "," in address:
+        ansible_module.fail_json(
+            msg="Invalid vrf or address: {0} {1}".format(vrf, address)
+        )
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        server = session.api.get_module(
+            session,
+            "RadiusDynauthProxyServer",
+            vrf,
+            address=address,
+            port=port,
+            port_type=port_type,
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support RADIUS dynamic "
+                "authorization proxy servers. Upgrade pyaoscx. Details: "
+                "{0}".format(str(e))
+            )
+        )
+
+    try:
+        server.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # ----------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                server.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete proxy server: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # ----------------------------------------------------------- check mode
+    if ansible_module.check_mode:
+        result["changed"] = (not exists) or secret_key is not None
+        ansible_module.exit_json(**result)
+
+    # ----------------------------------------------------------- create/update
+    created = False
+    if not exists:
+        try:
+            server.create()
+            server.get(selector="writable")
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not create proxy server: {0}".format(str(e))
+            )
+        created = True
+
+    needs_update = False
+    if secret_key is not None:
+        # The secret is write-only and salted; always re-apply when supplied.
+        server.secret_key = secret_key
+        needs_update = True
+
+    if needs_update:
+        try:
+            server.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update proxy server: {0}".format(str(e))
+            )
+
+    result["changed"] = created or needs_update
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/aoscx_radius_dynauth_proxy_client_group/aliases
+++ b/tests/integration/targets/aoscx_radius_dynauth_proxy_client_group/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_radius_dynauth_proxy_client_group/tasks/main.yml
+++ b/tests/integration/targets/aoscx_radius_dynauth_proxy_client_group/tasks/main.yml
@@ -1,0 +1,54 @@
+# Integration tests for aoscx_radius_dynauth_proxy_client_group.
+- name: Ensure CoA clients exist
+  arubanetworks.aoscx.aoscx_radius_dynamic_authorization_client:
+    vrf: default
+    address: "{{ item }}"
+    connection_type: udp
+    state: create
+  loop:
+    - 192.0.2.41
+    - 192.0.2.42
+- name: Create client group
+  arubanetworks.aoscx.aoscx_radius_dynauth_proxy_client_group:
+    group_name: integration-cg
+    clients:
+      - address: 192.0.2.41
+      - address: 192.0.2.42
+    state: create
+  register: create_result
+- ansible.builtin.assert:
+    that:
+      - create_result is changed
+- name: Re-apply identical
+  arubanetworks.aoscx.aoscx_radius_dynauth_proxy_client_group:
+    group_name: integration-cg
+    clients:
+      - address: 192.0.2.41
+      - address: 192.0.2.42
+    state: create
+  register: idem_result
+- ansible.builtin.assert:
+    that:
+      - idem_result is not changed
+- name: Clear members
+  arubanetworks.aoscx.aoscx_radius_dynauth_proxy_client_group:
+    group_name: integration-cg
+    clients: []
+    state: update
+  register: clear_result
+- ansible.builtin.assert:
+    that:
+      - clear_result is changed
+- name: Delete client group
+  arubanetworks.aoscx.aoscx_radius_dynauth_proxy_client_group:
+    group_name: integration-cg
+    state: delete
+- name: Remove CoA clients
+  arubanetworks.aoscx.aoscx_radius_dynamic_authorization_client:
+    vrf: default
+    address: "{{ item }}"
+    connection_type: udp
+    state: delete
+  loop:
+    - 192.0.2.41
+    - 192.0.2.42

--- a/tests/integration/targets/aoscx_radius_dynauth_proxy_profile/aliases
+++ b/tests/integration/targets/aoscx_radius_dynauth_proxy_profile/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_radius_dynauth_proxy_profile/tasks/main.yml
+++ b/tests/integration/targets/aoscx_radius_dynauth_proxy_profile/tasks/main.yml
@@ -1,0 +1,67 @@
+# Integration tests for aoscx_radius_dynauth_proxy_profile.
+- name: Set up prerequisites
+  arubanetworks.aoscx.aoscx_radius_dynamic_authorization_client:
+    vrf: default
+    address: 192.0.2.41
+    connection_type: udp
+    state: create
+- arubanetworks.aoscx.aoscx_radius_dynauth_proxy_server:
+    vrf: default
+    address: 192.0.2.30
+    port: 3799
+    port_type: udp
+    state: create
+- arubanetworks.aoscx.aoscx_radius_dynauth_proxy_client_group:
+    group_name: integration-cg
+    clients:
+      - address: 192.0.2.41
+    state: create
+- name: Create profile tying client group and server
+  arubanetworks.aoscx.aoscx_radius_dynauth_proxy_profile:
+    profile_name: integration-proxy
+    enabled: true
+    vrf: default
+    client_group: integration-cg
+    server:
+      address: 192.0.2.30
+      port: 3799
+      port_type: udp
+    state: create
+  register: create_result
+- ansible.builtin.assert:
+    that:
+      - create_result is changed
+- name: Re-apply identical
+  arubanetworks.aoscx.aoscx_radius_dynauth_proxy_profile:
+    profile_name: integration-proxy
+    enabled: true
+    vrf: default
+    client_group: integration-cg
+    server:
+      address: 192.0.2.30
+      port: 3799
+      port_type: udp
+    state: create
+  register: idem_result
+- ansible.builtin.assert:
+    that:
+      - idem_result is not changed
+- name: Tear down
+  block:
+    - arubanetworks.aoscx.aoscx_radius_dynauth_proxy_profile:
+        profile_name: integration-proxy
+        state: delete
+    - arubanetworks.aoscx.aoscx_radius_dynauth_proxy_client_group:
+        group_name: integration-cg
+        state: delete
+    - arubanetworks.aoscx.aoscx_radius_dynauth_proxy_server:
+        vrf: default
+        address: 192.0.2.30
+        port: 3799
+        port_type: udp
+        state: delete
+    - arubanetworks.aoscx.aoscx_radius_dynamic_authorization_client:
+        vrf: default
+        address: 192.0.2.41
+        connection_type: udp
+        state: delete

--- a/tests/integration/targets/aoscx_radius_dynauth_proxy_server/aliases
+++ b/tests/integration/targets/aoscx_radius_dynauth_proxy_server/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_radius_dynauth_proxy_server/tasks/main.yml
+++ b/tests/integration/targets/aoscx_radius_dynauth_proxy_server/tasks/main.yml
@@ -1,0 +1,35 @@
+# Integration tests for aoscx_radius_dynauth_proxy_server.
+- name: Create proxy server
+  arubanetworks.aoscx.aoscx_radius_dynauth_proxy_server:
+    vrf: default
+    address: 192.0.2.30
+    port: 3799
+    port_type: udp
+    secret_key: integration-secret
+    state: create
+  register: create_result
+- ansible.builtin.assert:
+    that:
+      - create_result is changed
+- name: Delete proxy server
+  arubanetworks.aoscx.aoscx_radius_dynauth_proxy_server:
+    vrf: default
+    address: 192.0.2.30
+    port: 3799
+    port_type: udp
+    state: delete
+  register: delete_result
+- ansible.builtin.assert:
+    that:
+      - delete_result is changed
+- name: Delete again (idempotent)
+  arubanetworks.aoscx.aoscx_radius_dynauth_proxy_server:
+    vrf: default
+    address: 192.0.2.30
+    port: 3799
+    port_type: udp
+    state: delete
+  register: delete_idem
+- ansible.builtin.assert:
+    that:
+      - delete_idem is not changed

--- a/tests/unit/modules/test_aoscx_radius_dynauth_proxy_client_group.py
+++ b/tests/unit/modules/test_aoscx_radius_dynauth_proxy_client_group.py
@@ -1,0 +1,168 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for the aoscx_radius_dynauth_proxy_client_group module."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_radius_dynauth_proxy_client_group,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_radius_dynauth_proxy_client_group"
+)
+PREFIX = "/rest/latest/"
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    kwargs.setdefault("changed", False)
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    basic._ANSIBLE_ARGS = to_bytes(
+        json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    )
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json
+    ):
+        yield
+
+
+def coa_uri(address, conn="udp", vrf="default"):
+    return (
+        PREFIX
+        + "system/vrfs/%s/radius_dynamic_authorization_clients/%s,%s"
+        % (vrf, address, conn)
+    )
+
+
+def build_group(exists, clients=None):
+    group = MagicMock()
+    group.clients = clients or {}
+    if exists:
+        group.get.return_value = True
+    else:
+        group.get.side_effect = [Exception("nf"), True]
+    return group
+
+
+def build_session(group, coa_exists=True):
+    session = MagicMock()
+    session.resource_prefix = PREFIX
+    session.api.compound_index_separator = ","
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "RadiusDynauthProxyClientGroup":
+            return group
+        if module == "RadiusDynamicAuthorizationClient":
+            coa = MagicMock()
+            if coa_exists:
+                coa.get.return_value = True
+            else:
+                coa.get.side_effect = Exception("no coa")
+            return coa
+        raise AssertionError(module)
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_radius_dynauth_proxy_client_group.main()
+    return exc.value.args[0]
+
+
+def test_invalid_group_name():
+    session = build_session(build_group(False))
+    result = run_module({"group_name": "a/b"}, session)
+    assert result["failed"] is True
+
+
+def test_missing_coa_client():
+    session = build_session(build_group(False), coa_exists=False)
+    result = run_module(
+        {"group_name": "g", "clients": [{"address": "192.0.2.41"}]}, session
+    )
+    assert result["failed"] is True
+    assert "Could not find CoA client" in result["msg"]
+
+
+def test_create_with_clients():
+    group = build_group(False)
+    session = build_session(group)
+    result = run_module(
+        {
+            "group_name": "g",
+            "clients": [{"address": "192.0.2.41"}, {"address": "192.0.2.42"}],
+        },
+        session,
+    )
+    assert result["changed"] is True
+    group.create.assert_called_once()
+    assert group.clients == {"1": coa_uri("192.0.2.41"),
+                             "2": coa_uri("192.0.2.42")}
+
+
+def test_idempotent():
+    group = build_group(True, clients={"1": coa_uri("192.0.2.41")})
+    session = build_session(group)
+    result = run_module(
+        {"group_name": "g", "clients": [{"address": "192.0.2.41"}],
+         "state": "update"},
+        session,
+    )
+    assert result["changed"] is False
+    group.update.assert_not_called()
+
+
+def test_clear_clients():
+    group = build_group(True, clients={"1": coa_uri("192.0.2.41")})
+    session = build_session(group)
+    result = run_module(
+        {"group_name": "g", "clients": [], "state": "update"}, session
+    )
+    assert result["changed"] is True
+    assert group.clients == {}
+
+
+def test_delete_idempotent():
+    group = build_group(False)
+    session = build_session(group)
+    result = run_module({"group_name": "g", "state": "delete"}, session)
+    assert result["changed"] is False
+    group.delete.assert_not_called()

--- a/tests/unit/modules/test_aoscx_radius_dynauth_proxy_profile.py
+++ b/tests/unit/modules/test_aoscx_radius_dynauth_proxy_profile.py
@@ -1,0 +1,183 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for the aoscx_radius_dynauth_proxy_profile module."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_radius_dynauth_proxy_profile,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_radius_dynauth_proxy_profile"
+)
+PREFIX = "/rest/latest/"
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    kwargs.setdefault("changed", False)
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    basic._ANSIBLE_ARGS = to_bytes(
+        json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    )
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json
+    ):
+        yield
+
+
+def build_profile(exists, **attrs):
+    profile = MagicMock()
+    for k, v in attrs.items():
+        setattr(profile, k, v)
+    if exists:
+        profile.get.return_value = True
+    else:
+        profile.get.side_effect = [Exception("nf"), True]
+    return profile
+
+
+def build_session(profile, ref_exists=True):
+    session = MagicMock()
+    session.resource_prefix = PREFIX
+    session.api.compound_index_separator = ","
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "RadiusDynauthProxyProfile":
+            return profile
+        ref = MagicMock()
+        if ref_exists:
+            ref.get.return_value = True
+        else:
+            ref.get.side_effect = Exception("nf")
+        return ref
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_radius_dynauth_proxy_profile.main()
+    return exc.value.args[0]
+
+
+def test_invalid_profile_name():
+    session = build_session(build_profile(False))
+    result = run_module({"profile_name": "a/b"}, session)
+    assert result["failed"] is True
+
+
+def test_missing_client_group():
+    session = build_session(build_profile(False), ref_exists=False)
+    result = run_module(
+        {"profile_name": "p", "client_group": "cg"}, session
+    )
+    assert result["failed"] is True
+    assert "Could not find client group" in result["msg"]
+
+
+def test_create_ties_refs():
+    profile = build_profile(
+        False, enabled=False, vrf={}, dynauth_client_group={},
+        dynauth_server={},
+    )
+    session = build_session(profile)
+    result = run_module(
+        {
+            "profile_name": "p",
+            "enabled": True,
+            "client_group": "cg",
+            "server": {"address": "192.0.2.30"},
+        },
+        session,
+    )
+    assert result["changed"] is True
+    profile.create.assert_called_once()
+    assert profile.enabled is True
+    assert "cg" in profile.dynauth_client_group
+    assert "192.0.2.30,3799,udp" in profile.dynauth_server
+
+
+def test_idempotent():
+    profile = build_profile(
+        True,
+        enabled=True,
+        vrf={"default": PREFIX + "system/vrfs/default"},
+        dynauth_client_group={
+            "cg": PREFIX + "system/radius_dynauth_proxy_client_groups/cg"
+        },
+        dynauth_server={},
+    )
+    session = build_session(profile)
+    result = run_module(
+        {
+            "profile_name": "p",
+            "enabled": True,
+            "client_group": "cg",
+            "state": "update",
+        },
+        session,
+    )
+    assert result["changed"] is False
+    profile.update.assert_not_called()
+
+
+def test_disable_update():
+    profile = build_profile(
+        True,
+        enabled=True,
+        vrf={"default": PREFIX + "system/vrfs/default"},
+        dynauth_client_group={},
+        dynauth_server={},
+    )
+    session = build_session(profile)
+    result = run_module(
+        {"profile_name": "p", "enabled": False, "state": "update"}, session
+    )
+    assert result["changed"] is True
+    assert profile.enabled is False
+
+
+def test_delete_idempotent():
+    profile = build_profile(False)
+    session = build_session(profile)
+    result = run_module({"profile_name": "p", "state": "delete"}, session)
+    assert result["changed"] is False
+    profile.delete.assert_not_called()

--- a/tests/unit/modules/test_aoscx_radius_dynauth_proxy_server.py
+++ b/tests/unit/modules/test_aoscx_radius_dynauth_proxy_server.py
@@ -1,0 +1,129 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for the aoscx_radius_dynauth_proxy_server module."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_radius_dynauth_proxy_server,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_radius_dynauth_proxy_server"
+)
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    kwargs.setdefault("changed", False)
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    basic._ANSIBLE_ARGS = to_bytes(
+        json.dumps({"ANSIBLE_MODULE_ARGS": args})
+    )
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json
+    ):
+        yield
+
+
+def build_server(exists):
+    server = MagicMock()
+    if exists:
+        server.get.return_value = True
+    else:
+        server.get.side_effect = [Exception("nf"), True]
+    return server
+
+
+def build_session(server):
+    session = MagicMock()
+
+    def get_module(sess, module, index=None, **kwargs):
+        assert module == "RadiusDynauthProxyServer"
+        return server
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_radius_dynauth_proxy_server.main()
+    return exc.value.args[0]
+
+
+def test_invalid_address_rejected():
+    session = build_session(build_server(False))
+    result = run_module({"address": "a,b"}, session)
+    assert result["failed"] is True
+
+
+def test_create_with_secret():
+    server = build_server(False)
+    session = build_session(server)
+    result = run_module(
+        {"address": "192.0.2.30", "secret_key": "s"}, session
+    )
+    assert result["changed"] is True
+    server.create.assert_called_once()
+    server.update.assert_called_once()
+    assert server.secret_key == "s"
+
+
+def test_idempotent_without_secret():
+    server = build_server(True)
+    session = build_session(server)
+    result = run_module({"address": "192.0.2.30"}, session)
+    assert result["changed"] is False
+    server.update.assert_not_called()
+
+
+def test_delete():
+    server = build_server(True)
+    session = build_session(server)
+    result = run_module({"address": "192.0.2.30", "state": "delete"}, session)
+    assert result["changed"] is True
+    server.delete.assert_called_once()
+
+
+def test_delete_idempotent():
+    server = build_server(False)
+    session = build_session(server)
+    result = run_module({"address": "192.0.2.30", "state": "delete"}, session)
+    assert result["changed"] is False
+    server.delete.assert_not_called()


### PR DESCRIPTION
Fixes #214

Depends on SDK PR aruba/pyaoscx#109 and aruba/pyaoscx#95.

## Summary

Adds `aoscx_radius_dynauth_proxy_server`, `aoscx_radius_dynauth_proxy_client_group` and `aoscx_radius_dynauth_proxy_profile` to manage the RADIUS dynamic authorization (Change of Authorization) proxy. The client group references existing CoA clients; the profile ties a client group and a server within a VRF.

## Notes

Requires aruba/pyaoscx#109 (proxy classes) and aruba/pyaoscx#95 (the RADIUS dynamic authorization client class referenced by the client group). Includes documentation, changelog, unit and integration tests.

## Testing

- `ansible-test sanity` (pep8, pylint, validate-modules) and `ansible-doc` pass; unit tests pass.
- Validated live on a CX 6300 (FL.10.17, REST `latest`): full server + client group + profile graph, create / idempotency / update / delete.

## Depends on
- aruba/pyaoscx#109 — RADIUS dynauth proxy classes
