### PR TITLE
Add RADIUS proxy modules

### DIFF
--- a/changelogs/fragments/aoscx_radius_proxy.yml
+++ b/changelogs/fragments/aoscx_radius_proxy.yml
@@ -1,0 +1,6 @@
+minor_changes:
+  - Add ``aoscx_radius_proxy_client_group`` and ``aoscx_radius_proxy_profile``
+    modules to manage RADIUS proxy client groups (downstream NAS clients) and
+    proxy profiles (tying a client group and an AAA server group within a VRF).
+    Requires a pyaoscx release that ships the ``RadiusProxyClientGroup`` and
+    ``RadiusProxyProfile`` classes.

--- a/docs/aoscx_radius_proxy_client_group.md
+++ b/docs/aoscx_radius_proxy_client_group.md
@@ -1,0 +1,75 @@
+# module: aoscx_radius_proxy_client_group
+
+description: This module provides configuration management of RADIUS proxy
+client groups on AOS-CX devices. A client group defines the downstream RADIUS
+clients (NAS devices) handled by the proxy and is identified by its name.
+
+##### ARGUMENTS
+
+```YAML
+  group_name:
+    description: Name of the RADIUS proxy client group.
+    required: true
+    type: str
+  clients:
+    description: >
+      RADIUS clients (NAS devices) that are members of the group. The supplied
+      list fully replaces the members. When omitted the members are left
+      unchanged; an empty list removes all members. Ignored when state is
+      delete.
+    required: false
+    type: list
+    elements: dict
+    suboptions:
+      address:
+        description: Address of the RADIUS client (NAS).
+        required: true
+        type: str
+      connection_type:
+        description: Connection type of the client.
+        required: false
+        default: udp
+        choices:
+          - udp
+          - tcp
+        type: str
+      secret_key:
+        description: >
+          Shared secret used with the client. It is write-only; the switch only
+          ever returns it encrypted, so when a secret is supplied the module
+          reports changed on every run.
+        required: false
+        type: str
+  state:
+    description: Create, update or delete the RADIUS proxy client group.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create a RADIUS proxy client group with one client
+  aoscx_radius_proxy_client_group:
+    group_name: nas-group
+    clients:
+      - address: 192.0.2.50
+        connection_type: udp
+        secret_key: nas-secret
+
+- name: Remove all members from the group
+  aoscx_radius_proxy_client_group:
+    group_name: nas-group
+    clients: []
+    state: update
+
+- name: Delete the RADIUS proxy client group
+  aoscx_radius_proxy_client_group:
+    group_name: nas-group
+    state: delete
+```

--- a/docs/aoscx_radius_proxy_profile.md
+++ b/docs/aoscx_radius_proxy_profile.md
@@ -1,0 +1,100 @@
+# module: aoscx_radius_proxy_profile
+
+description: This module provides configuration management of RADIUS proxy
+profiles on AOS-CX devices. A profile ties together a RADIUS proxy client group
+and an AAA server group within a VRF, and is identified by its name.
+
+##### ARGUMENTS
+
+```YAML
+  profile_name:
+    description: Name of the RADIUS proxy profile.
+    required: true
+    type: str
+  enabled:
+    description: Whether the proxy profile is enabled.
+    required: false
+    type: bool
+  address:
+    description: Source IPv4 address used by the proxy profile.
+    required: false
+    type: str
+  port:
+    description: Authentication UDP/TCP port used by the proxy profile.
+    required: false
+    type: int
+  port_type:
+    description: Transport used by the proxy profile.
+    required: false
+    choices:
+      - udp
+      - tcp
+    type: str
+  accounting_udp_port:
+    description: Accounting UDP port used by the proxy profile.
+    required: false
+    type: int
+  nas_id:
+    description: NAS identifier sent by the proxy.
+    required: false
+    type: str
+  nas_ip_addr:
+    description: NAS IP address sent by the proxy.
+    required: false
+    type: str
+  timeout:
+    description: Request timeout in seconds.
+    required: false
+    type: int
+  vrf:
+    description: VRF the proxy profile belongs to.
+    required: false
+    default: default
+    type: str
+  client_group:
+    description: >
+      Name of the RADIUS proxy client group referenced by this profile. The
+      client group must already exist. Pass an empty string to clear it.
+    required: false
+    type: str
+  server_group:
+    description: >
+      Name of the AAA server group referenced by this profile. The server group
+      must already exist.
+    required: false
+    type: str
+  server_group_type:
+    description: Type of the referenced AAA server group.
+    required: false
+    default: radius
+    choices:
+      - radius
+      - tacacs
+    type: str
+  state:
+    description: Create, update or delete the RADIUS proxy profile.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Create a RADIUS proxy profile tying a client group and a server group
+  aoscx_radius_proxy_profile:
+    profile_name: radius-proxy
+    enabled: true
+    vrf: default
+    client_group: nas-group
+    server_group: my-radius-group
+
+- name: Delete a RADIUS proxy profile
+  aoscx_radius_proxy_profile:
+    profile_name: radius-proxy
+    state: delete
+```

--- a/plugins/modules/aoscx_radius_proxy_client_group.py
+++ b/plugins/modules/aoscx_radius_proxy_client_group.py
@@ -1,0 +1,245 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_radius_proxy_client_group
+version_added: "4.6.0"
+short_description: Create, update or delete a RADIUS proxy client group on AOS-CX.
+description: >
+  This module provides configuration management of RADIUS proxy client groups
+  on AOS-CX devices. A client group defines the downstream RADIUS clients (NAS
+  devices) handled by the proxy and is identified by its name.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  group_name:
+    description: Name of the RADIUS proxy client group.
+    type: str
+    required: true
+  clients:
+    description: >
+      RADIUS clients (NAS devices) that are members of the group. The supplied
+      list fully replaces the members. When omitted the members are left
+      unchanged; an empty list removes all members. Ignored when I(state) is
+      C(delete).
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      address:
+        description: Address of the RADIUS client (NAS).
+        type: str
+        required: true
+      connection_type:
+        description: Connection type of the client.
+        type: str
+        required: false
+        default: udp
+        choices:
+          - udp
+          - tcp
+      secret_key:
+        description: >
+          Shared secret used with the client. It is write-only; the switch only
+          ever returns it encrypted, so when a secret is supplied the module
+          reports changed on every run.
+        type: str
+        required: false
+  state:
+    description: Create, update or delete the RADIUS proxy client group.
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    required: false
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a RADIUS proxy client group with one client
+  arubanetworks.aoscx.aoscx_radius_proxy_client_group:
+    group_name: nas-group
+    clients:
+      - address: 192.0.2.50
+        connection_type: udp
+        secret_key: nas-secret
+    state: create
+
+- name: Remove all members from the group
+  arubanetworks.aoscx.aoscx_radius_proxy_client_group:
+    group_name: nas-group
+    clients: []
+    state: update
+
+- name: Delete the RADIUS proxy client group
+  arubanetworks.aoscx.aoscx_radius_proxy_client_group:
+    group_name: nas-group
+    state: delete
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the RADIUS proxy client group was modified.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def build_clients(clients):
+    """Build the {address: {connection_type, secret_key}} map and report
+    whether any secret was supplied (which makes the result non-idempotent).
+    """
+    result = {}
+    has_secret = False
+    for entry in clients:
+        member = {"connection_type": entry["connection_type"]}
+        if entry["secret_key"] is not None:
+            member["secret_key"] = entry["secret_key"]
+            has_secret = True
+        result[entry["address"]] = member
+    return result, has_secret
+
+
+def main():
+    module_args = dict(
+        group_name=dict(type="str", required=True),
+        clients=dict(
+            type="list",
+            elements="dict",
+            required=False,
+            default=None,
+            options=dict(
+                address=dict(type="str", required=True),
+                connection_type=dict(
+                    type="str", required=False, default="udp",
+                    choices=["udp", "tcp"],
+                ),
+                secret_key=dict(
+                    type="str", required=False, default=None, no_log=True
+                ),
+            ),
+        ),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    group_name = ansible_module.params["group_name"]
+    clients = ansible_module.params["clients"]
+    state = ansible_module.params["state"]
+
+    result = dict(changed=False)
+
+    if group_name in ("", ".", "..") or "/" in group_name:
+        ansible_module.fail_json(
+            msg="Invalid group name: {0}".format(group_name)
+        )
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        group = session.api.get_module(
+            session, "RadiusProxyClientGroup", group_name
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support RADIUS proxy client "
+                "groups. Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        group.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # ----------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                group.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete client group: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    desired = None
+    has_secret = False
+    if clients is not None:
+        desired, has_secret = build_clients(clients)
+
+    # ----------------------------------------------------------- check mode
+    if ansible_module.check_mode:
+        result["changed"] = (not exists) or clients is not None
+        ansible_module.exit_json(**result)
+
+    # ----------------------------------------------------------- create/update
+    created = False
+    if not exists:
+        try:
+            group.create()
+            group.get(selector="writable")
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not create client group: {0}".format(str(e))
+            )
+        created = True
+
+    needs_update = False
+    if desired is not None:
+        current = getattr(group, "clients", None) or {}
+        # Compare by the set of client addresses; a supplied secret cannot be
+        # verified, so it forces an update.
+        if set(current) != set(desired) or has_secret:
+            needs_update = True
+            group.clients = desired
+
+    if needs_update:
+        try:
+            group.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update client group: {0}".format(str(e))
+            )
+
+    result["changed"] = created or needs_update
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_radius_proxy_profile.py
+++ b/plugins/modules/aoscx_radius_proxy_profile.py
@@ -1,0 +1,341 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_radius_proxy_profile
+version_added: "4.6.0"
+short_description: Create, update or delete a RADIUS proxy profile on AOS-CX.
+description: >
+  This module provides configuration management of RADIUS proxy profiles on
+  AOS-CX devices. A profile ties together a RADIUS proxy client group and an
+  AAA server group within a VRF, and is identified by its name.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  profile_name:
+    description: Name of the RADIUS proxy profile.
+    type: str
+    required: true
+  enabled:
+    description: Whether the proxy profile is enabled.
+    type: bool
+    required: false
+  address:
+    description: Source IPv4 address used by the proxy profile.
+    type: str
+    required: false
+  port:
+    description: Authentication UDP/TCP port used by the proxy profile.
+    type: int
+    required: false
+  port_type:
+    description: Transport used by the proxy profile.
+    type: str
+    required: false
+    choices:
+      - udp
+      - tcp
+  accounting_udp_port:
+    description: Accounting UDP port used by the proxy profile.
+    type: int
+    required: false
+  nas_id:
+    description: NAS identifier sent by the proxy.
+    type: str
+    required: false
+  nas_ip_addr:
+    description: NAS IP address sent by the proxy.
+    type: str
+    required: false
+  timeout:
+    description: Request timeout in seconds.
+    type: int
+    required: false
+  vrf:
+    description: VRF the proxy profile belongs to.
+    type: str
+    required: false
+    default: default
+  client_group:
+    description: >
+      Name of the RADIUS proxy client group referenced by this profile. The
+      client group must already exist. Pass an empty string to clear it.
+    type: str
+    required: false
+  server_group:
+    description: >
+      Name of the AAA server group referenced by this profile. The server group
+      must already exist.
+    type: str
+    required: false
+  server_group_type:
+    description: Type of the referenced AAA server group.
+    type: str
+    required: false
+    default: radius
+    choices:
+      - radius
+      - tacacs
+  state:
+    description: Create, update or delete the RADIUS proxy profile.
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    required: false
+    type: str
+"""
+
+EXAMPLES = """
+- name: Create a RADIUS proxy profile tying a client group and a server group
+  arubanetworks.aoscx.aoscx_radius_proxy_profile:
+    profile_name: radius-proxy
+    enabled: true
+    vrf: default
+    client_group: nas-group
+    server_group: my-radius-group
+    state: create
+
+- name: Delete a RADIUS proxy profile
+  arubanetworks.aoscx.aoscx_radius_proxy_profile:
+    profile_name: radius-proxy
+    state: delete
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the RADIUS proxy profile was modified.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+
+def ref_name(ref):
+    """Return the single key (name) of a {name: uri} reference map."""
+    if isinstance(ref, dict) and ref:
+        return next(iter(ref))
+    return None
+
+
+def main():
+    module_args = dict(
+        profile_name=dict(type="str", required=True),
+        enabled=dict(type="bool", required=False, default=None),
+        address=dict(type="str", required=False, default=None),
+        port=dict(type="int", required=False, default=None),
+        port_type=dict(
+            type="str", required=False, default=None, choices=["udp", "tcp"]
+        ),
+        accounting_udp_port=dict(type="int", required=False, default=None),
+        nas_id=dict(type="str", required=False, default=None),
+        nas_ip_addr=dict(type="str", required=False, default=None),
+        timeout=dict(type="int", required=False, default=None),
+        vrf=dict(type="str", required=False, default="default"),
+        client_group=dict(type="str", required=False, default=None),
+        server_group=dict(type="str", required=False, default=None),
+        server_group_type=dict(
+            type="str", required=False, default="radius",
+            choices=["radius", "tacacs"],
+        ),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    p = ansible_module.params
+    profile_name = p["profile_name"]
+    vrf = p["vrf"]
+    client_group = p["client_group"]
+    server_group = p["server_group"]
+    server_group_type = p["server_group_type"]
+    state = p["state"]
+
+    result = dict(changed=False)
+
+    if profile_name in ("", ".", "..") or "/" in profile_name:
+        ansible_module.fail_json(
+            msg="Invalid profile name: {0}".format(profile_name)
+        )
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    try:
+        profile = session.api.get_module(
+            session, "RadiusProxyProfile", profile_name
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support RADIUS proxy profiles. "
+                "Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        profile.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # ----------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                profile.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete proxy profile: {0}".format(str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    rp = session.resource_prefix
+    sep = session.api.compound_index_separator
+
+    desired_cg = None
+    if client_group is not None:
+        if client_group == "":
+            desired_cg = {}
+        else:
+            cg = session.api.get_module(
+                session, "RadiusProxyClientGroup", client_group
+            )
+            try:
+                cg.get()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not find client group {0}: {1}".format(
+                        client_group, str(e)
+                    )
+                )
+            desired_cg = {
+                client_group: "{0}system/radius_proxy_client_groups/"
+                "{1}".format(rp, client_group)
+            }
+
+    desired_sg = None
+    if server_group is not None:
+        grp_index = "{0}{1}{2}".format(server_group, sep, server_group_type)
+        sg = session.api.get_module(
+            session, "AaaServerGroup", server_group,
+            group_type=server_group_type,
+        )
+        try:
+            sg.get()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not find AAA server group {0}: {1}".format(
+                    server_group, str(e)
+                )
+            )
+        # The switch normalizes the reference key to the group name only, so
+        # compare against the name (not the compound name,type index).
+        desired_sg = {
+            server_group:
+                "{0}system/aaa_server_groups/{1}".format(rp, grp_index)
+        }
+
+    desired_vrf = {vrf: "{0}system/vrfs/{1}".format(rp, vrf)}
+
+    # ----------------------------------------------------------- check mode
+    if ansible_module.check_mode:
+        result["changed"] = (not exists) or any(
+            p[k] is not None
+            for k in (
+                "enabled", "address", "port", "port_type",
+                "accounting_udp_port", "nas_id", "nas_ip_addr", "timeout",
+                "client_group", "server_group",
+            )
+        )
+        ansible_module.exit_json(**result)
+
+    # ----------------------------------------------------------- create/update
+    created = False
+    if not exists:
+        try:
+            profile.create()
+            profile.get(selector="writable")
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not create proxy profile: {0}".format(str(e))
+            )
+        created = True
+
+    needs_update = False
+
+    scalars = {
+        "enabled": p["enabled"],
+        "address": p["address"],
+        "port": p["port"],
+        "port_type": p["port_type"],
+        "accounting_udp_port": p["accounting_udp_port"],
+        "nas_id": p["nas_id"],
+        "nas_ip_addr": p["nas_ip_addr"],
+        "timeout": p["timeout"],
+    }
+    for name, value in scalars.items():
+        if value is not None and getattr(profile, name, None) != value:
+            needs_update = True
+            setattr(profile, name, value)
+
+    if ref_name(getattr(profile, "vrf", None) or {}) != vrf:
+        needs_update = True
+        profile.vrf = desired_vrf
+
+    if desired_cg is not None:
+        current = getattr(profile, "client_group", None) or {}
+        if ref_name(current) != ref_name(desired_cg):
+            needs_update = True
+            profile.client_group = desired_cg
+
+    if desired_sg is not None:
+        current = getattr(profile, "server_group", None) or {}
+        if ref_name(current) != ref_name(desired_sg):
+            needs_update = True
+            profile.server_group = desired_sg
+
+    if needs_update:
+        try:
+            profile.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update proxy profile: {0}".format(str(e))
+            )
+
+    result["changed"] = created or needs_update
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/aoscx_radius_proxy_client_group/aliases
+++ b/tests/integration/targets/aoscx_radius_proxy_client_group/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_radius_proxy_client_group/tasks/main.yml
+++ b/tests/integration/targets/aoscx_radius_proxy_client_group/tasks/main.yml
@@ -1,0 +1,37 @@
+# Integration tests for aoscx_radius_proxy_client_group.
+- name: Create client group with one NAS client
+  arubanetworks.aoscx.aoscx_radius_proxy_client_group:
+    group_name: integration-nas
+    clients:
+      - address: 192.0.2.50
+        connection_type: udp
+        secret_key: nas-secret
+    state: create
+  register: create_result
+- ansible.builtin.assert:
+    that:
+      - create_result is changed
+- name: Re-apply without secret (idempotent)
+  arubanetworks.aoscx.aoscx_radius_proxy_client_group:
+    group_name: integration-nas
+    clients:
+      - address: 192.0.2.50
+        connection_type: udp
+    state: update
+  register: idem_result
+- ansible.builtin.assert:
+    that:
+      - idem_result is not changed
+- name: Clear members
+  arubanetworks.aoscx.aoscx_radius_proxy_client_group:
+    group_name: integration-nas
+    clients: []
+    state: update
+  register: clear_result
+- ansible.builtin.assert:
+    that:
+      - clear_result is changed
+- name: Delete client group
+  arubanetworks.aoscx.aoscx_radius_proxy_client_group:
+    group_name: integration-nas
+    state: delete

--- a/tests/integration/targets/aoscx_radius_proxy_profile/aliases
+++ b/tests/integration/targets/aoscx_radius_proxy_profile/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_radius_proxy_profile/tasks/main.yml
+++ b/tests/integration/targets/aoscx_radius_proxy_profile/tasks/main.yml
@@ -1,0 +1,47 @@
+# Integration tests for aoscx_radius_proxy_profile.
+- name: Set up prerequisites
+  arubanetworks.aoscx.aoscx_aaa_server_group:
+    group_name: integration-grp
+    group_type: radius
+    state: create
+- arubanetworks.aoscx.aoscx_radius_proxy_client_group:
+    group_name: integration-nas
+    clients:
+      - address: 192.0.2.50
+    state: create
+- name: Create profile tying client group and server group
+  arubanetworks.aoscx.aoscx_radius_proxy_profile:
+    profile_name: integration-proxy
+    enabled: true
+    vrf: default
+    client_group: integration-nas
+    server_group: integration-grp
+    state: create
+  register: create_result
+- ansible.builtin.assert:
+    that:
+      - create_result is changed
+- name: Re-apply identical (idempotent)
+  arubanetworks.aoscx.aoscx_radius_proxy_profile:
+    profile_name: integration-proxy
+    enabled: true
+    vrf: default
+    client_group: integration-nas
+    server_group: integration-grp
+    state: create
+  register: idem_result
+- ansible.builtin.assert:
+    that:
+      - idem_result is not changed
+- name: Tear down
+  block:
+    - arubanetworks.aoscx.aoscx_radius_proxy_profile:
+        profile_name: integration-proxy
+        state: delete
+    - arubanetworks.aoscx.aoscx_radius_proxy_client_group:
+        group_name: integration-nas
+        state: delete
+    - arubanetworks.aoscx.aoscx_aaa_server_group:
+        group_name: integration-grp
+        group_type: radius
+        state: delete

--- a/tests/unit/modules/test_aoscx_radius_proxy_client_group.py
+++ b/tests/unit/modules/test_aoscx_radius_proxy_client_group.py
@@ -1,0 +1,156 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for the aoscx_radius_proxy_client_group module."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_radius_proxy_client_group,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_radius_proxy_client_group"
+)
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    kwargs.setdefault("changed", False)
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    basic._ANSIBLE_ARGS = to_bytes(json.dumps({"ANSIBLE_MODULE_ARGS": args}))
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json
+    ):
+        yield
+
+
+def build_group(exists, clients=None):
+    group = MagicMock()
+    group.clients = clients or {}
+    if exists:
+        group.get.return_value = True
+    else:
+        group.get.side_effect = [Exception("nf"), True]
+    return group
+
+
+def build_session(group):
+    session = MagicMock()
+
+    def get_module(sess, module, index=None, **kwargs):
+        assert module == "RadiusProxyClientGroup"
+        return group
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_radius_proxy_client_group.main()
+    return exc.value.args[0]
+
+
+def test_invalid_group_name():
+    result = run_module({"group_name": "a/b"}, build_session(build_group(False)))
+    assert result["failed"] is True
+
+
+def test_create_with_clients():
+    group = build_group(False)
+    session = build_session(group)
+    result = run_module(
+        {
+            "group_name": "g",
+            "clients": [{"address": "192.0.2.50", "secret_key": "s"}],
+        },
+        session,
+    )
+    assert result["changed"] is True
+    group.create.assert_called_once()
+    assert "192.0.2.50" in group.clients
+
+
+def test_idempotent_without_secret():
+    group = build_group(
+        True, clients={"192.0.2.50": {"connection_type": "udp"}}
+    )
+    session = build_session(group)
+    result = run_module(
+        {"group_name": "g", "clients": [{"address": "192.0.2.50"}],
+         "state": "update"},
+        session,
+    )
+    assert result["changed"] is False
+    group.update.assert_not_called()
+
+
+def test_secret_forces_update():
+    group = build_group(
+        True, clients={"192.0.2.50": {"connection_type": "udp"}}
+    )
+    session = build_session(group)
+    result = run_module(
+        {
+            "group_name": "g",
+            "clients": [{"address": "192.0.2.50", "secret_key": "s"}],
+            "state": "update",
+        },
+        session,
+    )
+    assert result["changed"] is True
+
+
+def test_clear_clients():
+    group = build_group(
+        True, clients={"192.0.2.50": {"connection_type": "udp"}}
+    )
+    session = build_session(group)
+    result = run_module(
+        {"group_name": "g", "clients": [], "state": "update"}, session
+    )
+    assert result["changed"] is True
+    assert group.clients == {}
+
+
+def test_delete_idempotent():
+    group = build_group(False)
+    session = build_session(group)
+    result = run_module({"group_name": "g", "state": "delete"}, session)
+    assert result["changed"] is False
+    group.delete.assert_not_called()

--- a/tests/unit/modules/test_aoscx_radius_proxy_profile.py
+++ b/tests/unit/modules/test_aoscx_radius_proxy_profile.py
@@ -1,0 +1,168 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for the aoscx_radius_proxy_profile module."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_radius_proxy_profile,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_radius_proxy_profile"
+)
+PREFIX = "/rest/latest/"
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    kwargs.setdefault("changed", False)
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    basic._ANSIBLE_ARGS = to_bytes(json.dumps({"ANSIBLE_MODULE_ARGS": args}))
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json
+    ):
+        yield
+
+
+def build_profile(exists, **attrs):
+    profile = MagicMock()
+    for k, v in attrs.items():
+        setattr(profile, k, v)
+    if exists:
+        profile.get.return_value = True
+    else:
+        profile.get.side_effect = [Exception("nf"), True]
+    return profile
+
+
+def build_session(profile, ref_exists=True):
+    session = MagicMock()
+    session.resource_prefix = PREFIX
+    session.api.compound_index_separator = ","
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "RadiusProxyProfile":
+            return profile
+        ref = MagicMock()
+        if ref_exists:
+            ref.get.return_value = True
+        else:
+            ref.get.side_effect = Exception("nf")
+        return ref
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_radius_proxy_profile.main()
+    return exc.value.args[0]
+
+
+def test_invalid_profile_name():
+    result = run_module(
+        {"profile_name": "a/b"}, build_session(build_profile(False))
+    )
+    assert result["failed"] is True
+
+
+def test_missing_server_group():
+    session = build_session(build_profile(False), ref_exists=False)
+    result = run_module(
+        {"profile_name": "p", "server_group": "g"}, session
+    )
+    assert result["failed"] is True
+    assert "Could not find AAA server group" in result["msg"]
+
+
+def test_create_ties_refs():
+    profile = build_profile(
+        False, enabled=False, vrf={}, client_group={}, server_group={},
+        address=None, port=None, port_type=None, accounting_udp_port=None,
+        nas_id=None, nas_ip_addr=None, timeout=None,
+    )
+    session = build_session(profile)
+    result = run_module(
+        {
+            "profile_name": "p",
+            "enabled": True,
+            "client_group": "cg",
+            "server_group": "sg",
+        },
+        session,
+    )
+    assert result["changed"] is True
+    profile.create.assert_called_once()
+    assert "cg" in profile.client_group
+    # The reference key is the group name only (not the name,type index).
+    assert list(profile.server_group) == ["sg"]
+
+
+def test_idempotent():
+    profile = build_profile(
+        True,
+        enabled=True,
+        vrf={"default": PREFIX + "system/vrfs/default"},
+        client_group={"cg": PREFIX + "system/radius_proxy_client_groups/cg"},
+        server_group={"sg": PREFIX + "system/aaa_server_groups/sg,radius"},
+        address=None, port=None, port_type=None, accounting_udp_port=None,
+        nas_id=None, nas_ip_addr=None, timeout=None,
+    )
+    session = build_session(profile)
+    result = run_module(
+        {
+            "profile_name": "p",
+            "enabled": True,
+            "client_group": "cg",
+            "server_group": "sg",
+            "state": "update",
+        },
+        session,
+    )
+    assert result["changed"] is False
+    profile.update.assert_not_called()
+
+
+def test_delete_idempotent():
+    profile = build_profile(False)
+    session = build_session(profile)
+    result = run_module({"profile_name": "p", "state": "delete"}, session)
+    assert result["changed"] is False
+    profile.delete.assert_not_called()


### PR DESCRIPTION
Fixes #215

Depends on SDK PR aruba/pyaoscx#110.

## Summary

Adds `aoscx_radius_proxy_client_group` (downstream NAS clients) and `aoscx_radius_proxy_profile` (tying a client group and an AAA server group within a VRF) to manage the RADIUS proxy feature.

## Notes

Requires aruba/pyaoscx#110. Includes documentation, changelog, unit and integration tests.

## Testing

- `ansible-test sanity` (pep8, pylint, validate-modules) and `ansible-doc` pass; unit tests pass.
- Validated live on a CX 6300 (FL.10.17, REST `latest`): create / idempotency / update / delete.

## Depends on
- aruba/pyaoscx#110 — RADIUS proxy classes
