### PR TITLE
Add aoscx_radius_config_attribute module

### DIFF
--- a/changelogs/fragments/aoscx_radius_config_attribute.yml
+++ b/changelogs/fragments/aoscx_radius_config_attribute.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - Add ``aoscx_radius_config_attribute`` module to manage the RADIUS
+    configuration attributes (Framed-IP-Address, NAS-Identifier, NAS-IP-Address,
+    Tunnel-Private-Group-ID) attached to an AAA server group. Requires a pyaoscx
+    release that ships the ``RadiusConfigAttribute`` class.

--- a/docs/aoscx_radius_config_attribute.md
+++ b/docs/aoscx_radius_config_attribute.md
@@ -1,0 +1,72 @@
+# module: aoscx_radius_config_attribute
+
+description: This module provides configuration management of the RADIUS
+configuration attributes attached to an AAA server group on AOS-CX devices.
+Each attribute controls whether a RADIUS attribute is included for its service.
+The resource is identified by the AAA server group it applies to.
+
+##### ARGUMENTS
+
+```YAML
+  server_group:
+    description: >
+      Name of the AAA server group the RADIUS configuration attributes apply
+      to. The server group must already exist.
+    required: true
+    type: str
+  server_group_type:
+    description: Type of the referenced AAA server group.
+    required: false
+    default: radius
+    choices:
+      - radius
+      - tacacs
+    type: str
+  framed_ip_addr:
+    description: Include the Framed-IP-Address attribute (port-access service).
+    required: false
+    type: bool
+  nas_id:
+    description: Include the NAS-Identifier attribute (port-access service).
+    required: false
+    type: bool
+  nas_ip_addr:
+    description: Include the NAS-IP-Address attribute (user-management service).
+    required: false
+    type: bool
+  tunnel_private_group_id:
+    description: >
+      Include the Tunnel-Private-Group-ID attribute (port-access service).
+    required: false
+    type: bool
+  state:
+    description: Create, update or delete the RADIUS configuration attributes.
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+    type: str
+```
+
+##### EXAMPLES
+
+```YAML
+- name: Enable NAS-Identifier and NAS-IP-Address for a server group
+  aoscx_radius_config_attribute:
+    server_group: my-radius-group
+    nas_id: true
+    nas_ip_addr: true
+
+- name: Disable the NAS-Identifier attribute
+  aoscx_radius_config_attribute:
+    server_group: my-radius-group
+    nas_id: false
+    state: update
+
+- name: Delete the RADIUS configuration attributes of a server group
+  aoscx_radius_config_attribute:
+    server_group: my-radius-group
+    state: delete
+```

--- a/plugins/modules/aoscx_radius_config_attribute.py
+++ b/plugins/modules/aoscx_radius_config_attribute.py
@@ -1,0 +1,261 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_radius_config_attribute
+version_added: "4.6.0"
+short_description: >
+  Manage the RADIUS configuration attributes of an AAA server group on AOS-CX.
+description: >
+  This module provides configuration management of the RADIUS configuration
+  attributes attached to an AAA server group on AOS-CX devices. Each attribute
+  controls whether a RADIUS attribute is included for the port-access service.
+  The resource is identified by the AAA server group it applies to.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  server_group:
+    description: >
+      Name of the AAA server group the RADIUS configuration attributes apply
+      to. The server group must already exist.
+    type: str
+    required: true
+  server_group_type:
+    description: Type of the referenced AAA server group.
+    type: str
+    required: false
+    default: radius
+    choices:
+      - radius
+      - tacacs
+  framed_ip_addr:
+    description: >
+      Include the Framed-IP-Address attribute for the port-access service.
+    type: bool
+    required: false
+  nas_id:
+    description: >
+      Include the NAS-Identifier attribute for the port-access service.
+    type: bool
+    required: false
+  nas_ip_addr:
+    description: >
+      Include the NAS-IP-Address attribute for the port-access service.
+    type: bool
+    required: false
+  tunnel_private_group_id:
+    description: >
+      Include the Tunnel-Private-Group-ID attribute for the port-access
+      service.
+    type: bool
+    required: false
+  state:
+    description: Create, update or delete the RADIUS configuration attributes.
+    choices:
+      - create
+      - update
+      - delete
+    default: create
+    required: false
+    type: str
+"""
+
+EXAMPLES = """
+- name: Enable NAS-Identifier and NAS-IP-Address for a server group
+  arubanetworks.aoscx.aoscx_radius_config_attribute:
+    server_group: my-radius-group
+    nas_id: true
+    nas_ip_addr: true
+    state: create
+
+- name: Disable the NAS-Identifier attribute
+  arubanetworks.aoscx.aoscx_radius_config_attribute:
+    server_group: my-radius-group
+    nas_id: false
+    state: update
+
+- name: Delete the RADIUS configuration attributes of a server group
+  arubanetworks.aoscx.aoscx_radius_config_attribute:
+    server_group: my-radius-group
+    state: delete
+"""
+
+RETURN = r"""
+changed:
+  description: Whether the RADIUS configuration attributes were modified.
+  returned: always
+  type: bool
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+# Each RADIUS configuration attribute is enabled for a single, fixed service
+# type. The HPE-ANW-AVPair VSA uses a different schema and is not handled here.
+ATTR_SERVICE_TYPE = {
+    "framed_ip_addr": "port-access",
+    "nas_id": "port-access",
+    "nas_ip_addr": "user-management",
+    "tunnel_private_group_id": "port-access",
+}
+ATTRIBUTES = tuple(ATTR_SERVICE_TYPE)
+
+
+def main():
+    module_args = dict(
+        server_group=dict(type="str", required=True),
+        server_group_type=dict(
+            type="str", required=False, default="radius",
+            choices=["radius", "tacacs"],
+        ),
+        framed_ip_addr=dict(type="bool", required=False, default=None),
+        nas_id=dict(type="bool", required=False, default=None),
+        nas_ip_addr=dict(type="bool", required=False, default=None),
+        tunnel_private_group_id=dict(
+            type="bool", required=False, default=None
+        ),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    p = ansible_module.params
+    server_group = p["server_group"]
+    server_group_type = p["server_group_type"]
+    state = p["state"]
+
+    result = dict(changed=False)
+
+    if server_group in ("", ".", "..") or "/" in server_group \
+            or "," in server_group:
+        ansible_module.fail_json(
+            msg="Invalid server group: {0}".format(server_group)
+        )
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    rp = session.resource_prefix
+    sep = session.api.compound_index_separator
+    grp_index = "{0}{1}{2}".format(server_group, sep, server_group_type)
+    grp_uri = "{0}system/aaa_server_groups/{1}".format(rp, grp_index)
+
+    try:
+        entry = session.api.get_module(
+            session, "RadiusConfigAttribute", server_group,
+            server_group_uri=grp_uri,
+        )
+    except Exception as e:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support RADIUS configuration "
+                "attributes. Upgrade pyaoscx. Details: {0}".format(str(e))
+            )
+        )
+
+    try:
+        entry.get(selector="writable")
+        exists = True
+    except Exception:
+        exists = False
+
+    # ----------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not ansible_module.check_mode:
+            try:
+                entry.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete config attributes: {0}".format(
+                        str(e)
+                    )
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # Validate the referenced AAA server group exists.
+    grp = session.api.get_module(
+        session, "AaaServerGroup", server_group,
+        group_type=server_group_type,
+    )
+    try:
+        grp.get()
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not find AAA server group {0}: {1}".format(
+                server_group, str(e)
+            )
+        )
+
+    # ----------------------------------------------------------- check mode
+    if ansible_module.check_mode:
+        result["changed"] = (not exists) or any(
+            p[a] is not None for a in ATTRIBUTES
+        )
+        ansible_module.exit_json(**result)
+
+    # ----------------------------------------------------------- create/update
+    created = False
+    if not exists:
+        try:
+            entry.create()
+            entry.get(selector="writable")
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not create config attributes: {0}".format(str(e))
+            )
+        created = True
+
+    needs_update = False
+    for attr in ATTRIBUTES:
+        value = p[attr]
+        if value is None:
+            continue
+        desired = (
+            {"service_type": ATTR_SERVICE_TYPE[attr]} if value else {}
+        )
+        current = getattr(entry, attr, None) or {}
+        if current != desired:
+            needs_update = True
+            setattr(entry, attr, desired)
+
+    if needs_update:
+        try:
+            entry.update()
+        except Exception as e:
+            ansible_module.fail_json(
+                msg="Could not update config attributes: {0}".format(str(e))
+            )
+
+    result["changed"] = created or needs_update
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/aoscx_radius_config_attribute/aliases
+++ b/tests/integration/targets/aoscx_radius_config_attribute/aliases
@@ -1,0 +1,2 @@
+network/aoscx
+unsupported

--- a/tests/integration/targets/aoscx_radius_config_attribute/tasks/main.yml
+++ b/tests/integration/targets/aoscx_radius_config_attribute/tasks/main.yml
@@ -1,0 +1,44 @@
+# Integration tests for aoscx_radius_config_attribute.
+- name: Ensure the AAA server group exists
+  arubanetworks.aoscx.aoscx_aaa_server_group:
+    group_name: integration-grp
+    group_type: radius
+    state: create
+- name: Enable NAS-Identifier and NAS-IP-Address
+  arubanetworks.aoscx.aoscx_radius_config_attribute:
+    server_group: integration-grp
+    nas_id: true
+    nas_ip_addr: true
+    state: create
+  register: create_result
+- ansible.builtin.assert:
+    that:
+      - create_result is changed
+- name: Re-apply identical (idempotent)
+  arubanetworks.aoscx.aoscx_radius_config_attribute:
+    server_group: integration-grp
+    nas_id: true
+    nas_ip_addr: true
+    state: create
+  register: idem_result
+- ansible.builtin.assert:
+    that:
+      - idem_result is not changed
+- name: Disable NAS-Identifier
+  arubanetworks.aoscx.aoscx_radius_config_attribute:
+    server_group: integration-grp
+    nas_id: false
+    state: update
+  register: update_result
+- ansible.builtin.assert:
+    that:
+      - update_result is changed
+- name: Tear down
+  block:
+    - arubanetworks.aoscx.aoscx_radius_config_attribute:
+        server_group: integration-grp
+        state: delete
+    - arubanetworks.aoscx.aoscx_aaa_server_group:
+        group_name: integration-grp
+        group_type: radius
+        state: delete

--- a/tests/unit/modules/test_aoscx_radius_config_attribute.py
+++ b/tests/unit/modules/test_aoscx_radius_config_attribute.py
@@ -1,0 +1,162 @@
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Unit tests for the aoscx_radius_config_attribute module."""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ansible.module_utils import basic
+from ansible.module_utils.common.text.converters import to_bytes
+
+from ansible_collections.arubanetworks.aoscx.plugins.modules import (
+    aoscx_radius_config_attribute,
+)
+
+MODULE = (
+    "ansible_collections.arubanetworks.aoscx.plugins.modules."
+    "aoscx_radius_config_attribute"
+)
+PA = {"service_type": "port-access"}
+UM = {"service_type": "user-management"}
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    kwargs.setdefault("changed", False)
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs["failed"] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def set_module_args(args):
+    basic._ANSIBLE_ARGS = to_bytes(json.dumps({"ANSIBLE_MODULE_ARGS": args}))
+
+
+@pytest.fixture(autouse=True)
+def patch_ansible_module():
+    with patch.multiple(
+        basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json
+    ):
+        yield
+
+
+def build_entry(exists, **attrs):
+    entry = MagicMock()
+    for k, v in attrs.items():
+        setattr(entry, k, v)
+    if exists:
+        entry.get.return_value = True
+    else:
+        entry.get.side_effect = [Exception("nf"), True]
+    return entry
+
+
+def build_session(entry, grp_exists=True):
+    session = MagicMock()
+    session.resource_prefix = "/rest/latest/"
+    session.api.compound_index_separator = ","
+
+    def get_module(sess, module, index=None, **kwargs):
+        if module == "RadiusConfigAttribute":
+            return entry
+        grp = MagicMock()
+        if grp_exists:
+            grp.get.return_value = True
+        else:
+            grp.get.side_effect = Exception("nf")
+        return grp
+
+    session.api.get_module.side_effect = get_module
+    return session
+
+
+def run_module(args, session):
+    set_module_args(args)
+    with patch(MODULE + ".get_pyaoscx_session", return_value=session):
+        with pytest.raises((AnsibleExitJson, AnsibleFailJson)) as exc:
+            aoscx_radius_config_attribute.main()
+    return exc.value.args[0]
+
+
+def test_invalid_server_group():
+    result = run_module(
+        {"server_group": "a,b"}, build_session(build_entry(False))
+    )
+    assert result["failed"] is True
+
+
+def test_missing_server_group():
+    session = build_session(build_entry(False), grp_exists=False)
+    result = run_module({"server_group": "g", "nas_id": True}, session)
+    assert result["failed"] is True
+    assert "Could not find AAA server group" in result["msg"]
+
+
+def test_create_enables_with_correct_service_type():
+    entry = build_entry(
+        False, framed_ip_addr={}, nas_id={}, nas_ip_addr={},
+        tunnel_private_group_id={},
+    )
+    session = build_session(entry)
+    result = run_module(
+        {"server_group": "g", "nas_id": True, "nas_ip_addr": True}, session
+    )
+    assert result["changed"] is True
+    entry.create.assert_called_once()
+    assert entry.nas_id == PA
+    assert entry.nas_ip_addr == UM
+
+
+def test_idempotent():
+    entry = build_entry(
+        True, framed_ip_addr=PA, nas_id=PA, nas_ip_addr=UM,
+        tunnel_private_group_id=PA,
+    )
+    session = build_session(entry)
+    result = run_module(
+        {"server_group": "g", "nas_id": True, "nas_ip_addr": True,
+         "state": "update"},
+        session,
+    )
+    assert result["changed"] is False
+    entry.update.assert_not_called()
+
+
+def test_disable_attribute():
+    entry = build_entry(
+        True, framed_ip_addr=PA, nas_id=PA, nas_ip_addr=UM,
+        tunnel_private_group_id=PA,
+    )
+    session = build_session(entry)
+    result = run_module(
+        {"server_group": "g", "nas_id": False, "state": "update"}, session
+    )
+    assert result["changed"] is True
+    assert entry.nas_id == {}
+
+
+def test_delete_idempotent():
+    entry = build_entry(False)
+    session = build_session(entry)
+    result = run_module({"server_group": "g", "state": "delete"}, session)
+    assert result["changed"] is False
+    entry.delete.assert_not_called()


### PR DESCRIPTION
Fixes #216

Depends on SDK PR aruba/pyaoscx#111.

## Summary

Adds `aoscx_radius_config_attribute` to manage the RADIUS configuration attributes (Framed-IP-Address, NAS-Identifier, NAS-IP-Address, Tunnel-Private-Group-ID) attached to an AAA server group. Each attribute is enabled for its fixed service type.

## Notes

Requires aruba/pyaoscx#111. Includes documentation, changelog, unit and integration tests.

## Testing

- `ansible-test sanity` (pep8, pylint, validate-modules) and `ansible-doc` pass; unit tests pass.
- Validated live on a CX 6300 (FL.10.17, REST `latest`): create / idempotency / update / delete.

## Depends on
- aruba/pyaoscx#111 — RadiusConfigAttribute
