### PR TITLE
Add Port Access CDP/LLDP device classification group modules

### DIFF
--- a/changelogs/fragments/port_access_device_groups.yml
+++ b/changelogs/fragments/port_access_device_groups.yml
@@ -1,0 +1,8 @@
+---
+minor_changes:
+  - aoscx_port_access_cdp_group - new module to create, update or delete Port
+    Access CDP device classification groups and their match entries
+    (system/port_access_cdp_groups).
+  - aoscx_port_access_lldp_group - new module to create, update or delete Port
+    Access LLDP device classification groups and their match entries
+    (system/port_access_lldp_groups).

--- a/plugins/module_utils/port_access_device_group.py
+++ b/plugins/module_utils/port_access_device_group.py
@@ -1,0 +1,236 @@
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Shared helpers for the port access device classification group modules
+(aoscx_port_access_cdp_group, aoscx_port_access_lldp_group).
+
+Both families share the same shape:
+
+    container (system/port_access_<cdp|lldp>_groups, indexed by name)
+      -> entries/{sequence_number} (match fields only)
+
+Unlike the policy families, the entries hold only match fields; there is no
+referenced traffic class and no action set. The supplied entries fully replace
+the existing entries of the container, unless ``entries`` is omitted, in which
+case the entries are left untouched and only the container existence is
+reconciled. Within an entry, the supplied match fields fully replace the
+current ones (a field that is not supplied is cleared on the switch).
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+def _normalize(value):
+    """
+    Normalize an unset match field to None so that the empty representations
+    returned by the switch (null, empty string, empty dict/list) compare equal
+    to a field that was not supplied.
+    """
+    if value in (None, "", {}, []):
+        return None
+    return value
+
+
+def build_argument_spec(match_fields):
+    """
+    Build the full argument_spec for a port access device group module.
+
+    :param match_fields: list of dicts describing the per-entry match fields,
+        each with keys ``name``, ``type`` (str/int/dict) and optionally
+        ``choices``.
+    """
+    entry_spec = dict(
+        sequence_number=dict(type="int", required=True),
+    )
+    for field in match_fields:
+        spec = dict(type=field["type"], required=False, default=None)
+        if field.get("choices"):
+            spec["choices"] = list(field["choices"])
+        entry_spec[field["name"]] = spec
+
+    return dict(
+        name=dict(type="str", required=True),
+        entries=dict(
+            type="list",
+            elements="dict",
+            options=entry_spec,
+            required=False,
+            default=None,
+        ),
+        state=dict(
+            type="str",
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+
+
+def _get_entries(session, entry_cls, container, field_names):
+    entries = {}
+    for entry in entry_cls.get_all(session, container).values():
+        entry.get(selector="configuration")
+        seq = int(entry.sequence_number)
+        entries[seq] = {
+            field: _normalize(getattr(entry, field, None))
+            for field in field_names
+        }
+    return entries
+
+
+def run_port_access_device_group(
+    ansible_module, session, container_cls, match_fields
+):
+    """
+    Reconcile a port access device classification group and its entries.
+
+    :param session: an established pyaoscx session.
+    :param container_cls: the pyaoscx container class for this family
+        (e.g. ``PortAccessCdpGroup``). Its ``entry_class`` drives the entry
+        reconciliation.
+    :param match_fields: the same list passed to build_argument_spec.
+    """
+    entry_cls = container_cls.entry_class
+    field_names = [field["name"] for field in match_fields]
+
+    params = ansible_module.params
+    name = params["name"]
+    state = params["state"]
+    entries_param = params["entries"]
+    manage_entries = entries_param is not None
+    entries = entries_param or []
+    check_mode = ansible_module.check_mode
+
+    result = dict(changed=False)
+
+    container = container_cls(session, name)
+    try:
+        container.get()
+        exists = True
+    except Exception:
+        exists = False
+
+    # --------------------------------------------------------------- delete
+    if state == "delete":
+        if exists and not check_mode:
+            try:
+                container.delete()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not delete {0}: {1}".format(name, str(e))
+                )
+        result["changed"] = exists
+        ansible_module.exit_json(**result)
+
+    # Build the desired entries; detect duplicate sequence numbers.
+    desired = {}
+    if manage_entries:
+        for entry in entries:
+            seq = entry["sequence_number"]
+            if seq in desired:
+                ansible_module.fail_json(
+                    msg="Duplicate sequence_number {0}".format(seq)
+                )
+            desired[seq] = {
+                field: _normalize(entry.get(field)) for field in field_names
+            }
+
+    changed = False
+
+    # --------------------------------------------------------------- create
+    if not exists:
+        changed = True
+        if not check_mode:
+            try:
+                container_cls(session, name).create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create {0}: {1}".format(name, str(e))
+                )
+        current = {}
+    elif manage_entries:
+        current = _get_entries(session, entry_cls, container, field_names)
+    else:
+        current = {}
+
+    if manage_entries:
+        changed = _reconcile_entries(
+            ansible_module,
+            session,
+            container,
+            entry_cls,
+            field_names,
+            desired,
+            current,
+            check_mode,
+            changed,
+        )
+
+    result["changed"] = changed
+    ansible_module.exit_json(**result)
+
+
+def _reconcile_entries(
+    ansible_module,
+    session,
+    container,
+    entry_cls,
+    field_names,
+    desired,
+    current,
+    check_mode,
+    changed,
+):
+    # Remove entries that are no longer desired (full replace).
+    for seq in current:
+        if seq not in desired:
+            changed = True
+            if not check_mode:
+                entry_cls(session, seq, container).delete()
+
+    for seq, want in desired.items():
+        cur = current.get(seq)
+        if cur is not None and cur == want:
+            continue
+
+        changed = True
+        if check_mode:
+            continue
+
+        # Only the supplied (not None) match fields are written.
+        attrs = {
+            field: value
+            for field, value in want.items()
+            if value is not None
+        }
+
+        if cur is None:
+            entry = entry_cls(session, seq, container, **attrs)
+            try:
+                entry.create()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not create entry {0}: {1}".format(
+                        seq, str(e)
+                    )
+                )
+        else:
+            entry = entry_cls(session, seq, container)
+            for field, value in attrs.items():
+                setattr(entry, field, value)
+            entry.config_attrs = list(attrs.keys())
+            try:
+                entry.update()
+            except Exception as e:
+                ansible_module.fail_json(
+                    msg="Could not update entry {0}: {1}".format(
+                        seq, str(e)
+                    )
+                )
+
+    return changed

--- a/plugins/modules/aoscx_port_access_cdp_group.py
+++ b/plugins/modules/aoscx_port_access_cdp_group.py
@@ -1,0 +1,144 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_port_access_cdp_group
+version_added: "4.6.0"
+short_description: Create, update or delete a Port Access CDP device group
+description: >
+  This module provides configuration management of Port Access CDP device
+  classification groups on AOS-CX devices (system/port_access_cdp_groups). A
+  CDP group is an ordered list of entries; each entry matches a connected
+  device against the attributes advertised through CDP (platform, software
+  version and voice VLAN query value). The group can then be referenced by a
+  device profile to classify devices. This module requires REST API version
+  10.13 or higher. The supplied entries fully replace the existing entries of
+  the group; within an entry, the supplied match fields fully replace the
+  current ones.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: >
+      Name of the CDP group. This is the index of the resource under
+      system/port_access_cdp_groups.
+    required: true
+    type: str
+  entries:
+    description: >
+      Ordered list of group entries. The supplied list fully replaces the
+      existing entries of the group. Omit to leave the entries untouched and
+      only reconcile the group existence.
+    required: false
+    type: list
+    elements: dict
+    suboptions:
+      sequence_number:
+        description: Sequence number of the entry within the group.
+        required: true
+        type: int
+      platform:
+        description: Hardware or model details of the neighbor to match.
+        required: false
+        type: str
+      software_version:
+        description: Software version of the neighbor to match.
+        required: false
+        type: str
+      voice_vlan_query_value:
+        description: Voice VLAN query value of the neighbor to match.
+        required: false
+        type: int
+  state:
+    description: The action to be taken with the current group.
+    required: false
+    type: str
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+"""
+
+EXAMPLES = """
+- name: Create a CDP device group with two match entries
+  arubanetworks.aoscx.aoscx_port_access_cdp_group:
+    name: ip_phones
+    entries:
+      - sequence_number: 10
+        platform: "Cisco IP Phone 7961"
+      - sequence_number: 20
+        software_version: "SCCP 9.4"
+        voice_vlan_query_value: 200
+    state: create
+
+- name: Delete a CDP device group
+  arubanetworks.aoscx.aoscx_port_access_cdp_group:
+    name: ip_phones
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.port_access_device_group import (  # NOQA
+    build_argument_spec,
+    run_port_access_device_group,
+)
+
+try:
+    from pyaoscx.port_access_device_group import PortAccessCdpGroup
+
+    HAS_PYAOSCX_PORT_ACCESS = True
+except ImportError:
+    HAS_PYAOSCX_PORT_ACCESS = False
+
+MATCH_FIELDS = [
+    {"name": "platform", "type": "str"},
+    {"name": "software_version", "type": "str"},
+    {"name": "voice_vlan_query_value", "type": "int"},
+]
+
+
+def main():
+    ansible_module = AnsibleModule(
+        argument_spec=build_argument_spec(MATCH_FIELDS),
+        supports_check_mode=True,
+    )
+    if not HAS_PYAOSCX_PORT_ACCESS:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support port access device "
+                "groups. Upgrade pyaoscx."
+            )
+        )
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+    run_port_access_device_group(
+        ansible_module, session, PortAccessCdpGroup, MATCH_FIELDS
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_port_access_lldp_group.py
+++ b/plugins/modules/aoscx_port_access_lldp_group.py
@@ -1,0 +1,151 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_port_access_lldp_group
+version_added: "4.6.0"
+short_description: Create, update or delete a Port Access LLDP device group
+description: >
+  This module provides configuration management of Port Access LLDP device
+  classification groups on AOS-CX devices (system/port_access_lldp_groups). An
+  LLDP group is an ordered list of entries; each entry matches a connected
+  device against the attributes advertised through LLDP (system description,
+  system name, vendor OUI and vendor OUI subtype). The group can then be
+  referenced by a device profile to classify devices. This module requires
+  REST API version 10.13 or higher. The supplied entries fully replace the
+  existing entries of the group; within an entry, the supplied match fields
+  fully replace the current ones.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: >
+      Name of the LLDP group. This is the index of the resource under
+      system/port_access_lldp_groups.
+    required: true
+    type: str
+  entries:
+    description: >
+      Ordered list of group entries. The supplied list fully replaces the
+      existing entries of the group. Omit to leave the entries untouched and
+      only reconcile the group existence.
+    required: false
+    type: list
+    elements: dict
+    suboptions:
+      sequence_number:
+        description: Sequence number of the entry within the group.
+        required: true
+        type: int
+      system_description:
+        description: System description TLV of the vendor to match.
+        required: false
+        type: str
+      system_name:
+        description: System name TLV of the device vendor to match.
+        required: false
+        type: str
+      vendor_oui:
+        description: >
+          The organization unique identifier (OUI) of the device vendor to
+          match.
+        required: false
+        type: str
+      vendor_oui_subtype:
+        description: The OUI subtype of the device vendor to match.
+        required: false
+        type: dict
+  state:
+    description: The action to be taken with the current group.
+    required: false
+    type: str
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+"""
+
+EXAMPLES = """
+- name: Create an LLDP device group with two match entries
+  arubanetworks.aoscx.aoscx_port_access_lldp_group:
+    name: ip_phones
+    entries:
+      - sequence_number: 10
+        system_name: "SEP-phone"
+      - sequence_number: 20
+        system_description: "IP Phone"
+        vendor_oui: "00:1b:0c"
+    state: create
+
+- name: Delete an LLDP device group
+  arubanetworks.aoscx.aoscx_port_access_lldp_group:
+    name: ip_phones
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.port_access_device_group import (  # NOQA
+    build_argument_spec,
+    run_port_access_device_group,
+)
+
+try:
+    from pyaoscx.port_access_device_group import PortAccessLldpGroup
+
+    HAS_PYAOSCX_PORT_ACCESS = True
+except ImportError:
+    HAS_PYAOSCX_PORT_ACCESS = False
+
+MATCH_FIELDS = [
+    {"name": "system_description", "type": "str"},
+    {"name": "system_name", "type": "str"},
+    {"name": "vendor_oui", "type": "str"},
+    {"name": "vendor_oui_subtype", "type": "dict"},
+]
+
+
+def main():
+    ansible_module = AnsibleModule(
+        argument_spec=build_argument_spec(MATCH_FIELDS),
+        supports_check_mode=True,
+    )
+    if not HAS_PYAOSCX_PORT_ACCESS:
+        ansible_module.fail_json(
+            msg=(
+                "This pyaoscx version does not support port access device "
+                "groups. Upgrade pyaoscx."
+            )
+        )
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+    run_port_access_device_group(
+        ansible_module, session, PortAccessLldpGroup, MATCH_FIELDS
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Adds two modules to manage Port Access device classification groups, which classify connected devices by the attributes they advertise through CDP/LLDP and are referenced by device profiles:

- `aoscx_port_access_cdp_group` — `system/port_access_cdp_groups`; entries match `platform`, `software_version`, `voice_vlan_query_value`.
- `aoscx_port_access_lldp_group` — `system/port_access_lldp_groups`; entries match `system_description`, `system_name`, `vendor_oui`, `vendor_oui_subtype`.

Each group is an ordered list of match entries indexed by `sequence_number`; the supplied entries fully replace the existing ones. Shared logic lives in `module_utils/port_access_device_group.py`. Supports check mode.

## Testing
Validated live on a CX6300 (FL.10.17, REST latest): create, idempotency, per-entry update and delete of both CDP and LLDP groups. `show running-config` confirmed the expected `port-access cdp-group`/`lldp-group` blocks with their `seq N match ...` entries. Sanity (pep8, pylint, validate-modules) passes.

Fixes #220

Depends on SDK PR aruba/pyaoscx#113

## Depends on
- aruba/pyaoscx#113 — PortAccess CDP/LLDP device group classes
