### PR TITLE
Add Private VLAN (PVLAN) support

### DIFF
--- a/changelogs/fragments/interface-physical.yml
+++ b/changelogs/fragments/interface-physical.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - aoscx_interface - add ``pause``, ``eee``, ``error_control``, ``speed_downshift``,
+    ``udld_enable``, ``udld_interval``, ``udld_retries``, ``loop_protect_enable``,
+    ``loop_protect_action``, ``urpf_check`` and ``ip_mtu`` options.

--- a/changelogs/fragments/interface_sflow_snooping.yml
+++ b/changelogs/fragments/interface_sflow_snooping.yml
@@ -1,0 +1,10 @@
+---
+minor_changes:
+  - aoscx_interface - add the C(sflow_enabled) option to enable or disable sFlow
+    sampling per interface (the per-port C(no sflow) override).
+  - aoscx_interface - add the C(arp_inspection_trust) option to mark the
+    interface as trusted for Dynamic ARP Inspection.
+  - aoscx_interface - add the C(dhcpv4_snooping_trust),
+    C(dhcpv4_snooping_max_bindings), C(dhcpv6_snooping_trust) and
+    C(dhcpv6_snooping_max_bindings) options to configure the per-interface
+    DHCP snooping trust and binding limits.

--- a/changelogs/fragments/private_vlan.yml
+++ b/changelogs/fragments/private_vlan.yml
@@ -1,0 +1,7 @@
+---
+minor_changes:
+  - aoscx_vlan - add the C(pvlan_type) and C(pvlan_association) options to
+    configure Private VLANs (primary, isolated or community VLANs and the
+    association of a secondary VLAN to its primary).
+  - aoscx_interface - add the C(pvlan_port_type) option to set the Private VLAN
+    port type (promiscuous or secondary) on an interface.

--- a/plugins/modules/aoscx_interface.py
+++ b/plugins/modules/aoscx_interface.py
@@ -276,12 +276,14 @@ options:
   pvlan_port_type:
     description: >
       Private VLAN port type. C(promiscuous) for a port in the primary VLAN,
-      C(secondary) for a port in a secondary VLAN.
+      C(secondary) for a port in a secondary VLAN. Set to an empty string to
+      clear the port type (back to a regular port).
     type: str
     required: false
     choices:
       - promiscuous
       - secondary
+      - ""
   state:
     description: Create, Update or Delete the Interface.
     type: str
@@ -618,7 +620,7 @@ def get_argument_spec():
             "type": "str",
             "required": False,
             "default": None,
-            "choices": ["promiscuous", "secondary"],
+            "choices": ["promiscuous", "secondary", ""],
         },
         "qos_rate": {
             "type": "dict",
@@ -847,13 +849,21 @@ def main():
         "loop_protect_action": loop_protect_action,
         "urpf_check": urpf_check,
         "ip_mtu": ip_mtu,
-        "pvlan_port_type": pvlan_port_type,
     }
     for key, val in top_level.items():
         if val is not None:
             setattr(interface, key, val)
             if key not in interface.config_attrs:
                 interface.config_attrs.append(key)
+    # Private VLAN port type: an empty string clears it (sent as null).
+    if pvlan_port_type is not None:
+        new_pvlan_port_type = (
+            None if pvlan_port_type == "" else pvlan_port_type
+        )
+        if getattr(interface, "pvlan_port_type", None) != new_pvlan_port_type:
+            interface.pvlan_port_type = new_pvlan_port_type
+            if "pvlan_port_type" not in interface.config_attrs:
+                interface.config_attrs.append("pvlan_port_type")
     if vsx_sync:
         if not device.materialized:
             device.get()

--- a/plugins/modules/aoscx_interface.py
+++ b/plugins/modules/aoscx_interface.py
@@ -186,6 +186,63 @@ options:
       - none
       - global
     required: false
+  pause:
+    description: Flow control (pause) mode applied to the interface.
+    type: str
+    required: false
+  eee:
+    description: Enable or disable Energy Efficient Ethernet on the interface.
+    type: bool
+    required: false
+  error_control:
+    description: Forward error correction (FEC) mode of the interface.
+    type: str
+    choices:
+      - auto
+      - none
+      - base-r-fec
+      - rs-fec
+    required: false
+  speed_downshift:
+    description: Enable or disable speed downshift on the interface.
+    type: bool
+    required: false
+  udld_enable:
+    description: Enable or disable UDLD on the interface.
+    type: bool
+    required: false
+  udld_interval:
+    description: UDLD probe interval in milliseconds.
+    type: int
+    required: false
+  udld_retries:
+    description: Number of UDLD retries before a port is marked down.
+    type: int
+    required: false
+  loop_protect_enable:
+    description: Enable or disable loop protection on the interface.
+    type: bool
+    required: false
+  loop_protect_action:
+    description: Action taken when a loop is detected.
+    type: str
+    choices:
+      - do-not-disable
+      - tx-disable
+      - tx-rx-disable
+    required: false
+  urpf_check:
+    description: Unicast Reverse Path Forwarding mode on the interface.
+    type: str
+    choices:
+      - disable
+      - loose
+      - strict
+    required: false
+  ip_mtu:
+    description: IP MTU of the interface.
+    type: int
+    required: false
   state:
     description: Create, Update or Delete the Interface.
     type: str
@@ -430,6 +487,64 @@ def get_argument_spec():
             "required": False,
             "choices": ["cos", "dscp", "none", "global"],
         },
+        "pause": {
+            "type": "str",
+            "required": False,
+            "default": None,
+        },
+        "eee": {
+            "type": "bool",
+            "required": False,
+            "default": None,
+        },
+        "error_control": {
+            "type": "str",
+            "required": False,
+            "default": None,
+            "choices": ["auto", "none", "base-r-fec", "rs-fec"],
+        },
+        "speed_downshift": {
+            "type": "bool",
+            "required": False,
+            "default": None,
+        },
+        "udld_enable": {
+            "type": "bool",
+            "required": False,
+            "default": None,
+        },
+        "udld_interval": {
+            "type": "int",
+            "required": False,
+            "default": None,
+        },
+        "udld_retries": {
+            "type": "int",
+            "required": False,
+            "default": None,
+        },
+        "loop_protect_enable": {
+            "type": "bool",
+            "required": False,
+            "default": None,
+        },
+        "loop_protect_action": {
+            "type": "str",
+            "required": False,
+            "default": None,
+            "choices": ["do-not-disable", "tx-disable", "tx-rx-disable"],
+        },
+        "urpf_check": {
+            "type": "str",
+            "required": False,
+            "default": None,
+            "choices": ["disable", "loose", "strict"],
+        },
+        "ip_mtu": {
+            "type": "int",
+            "required": False,
+            "default": None,
+        },
         "qos_rate": {
             "type": "dict",
             "required": False,
@@ -532,6 +647,18 @@ def main():
     qos_trust_mode = ansible_module.params["qos_trust_mode"]
     qos_rate = ansible_module.params["qos_rate"]
 
+    pause = ansible_module.params["pause"]
+    eee = ansible_module.params["eee"]
+    error_control = ansible_module.params["error_control"]
+    speed_downshift = ansible_module.params["speed_downshift"]
+    udld_enable = ansible_module.params["udld_enable"]
+    udld_interval = ansible_module.params["udld_interval"]
+    udld_retries = ansible_module.params["udld_retries"]
+    loop_protect_enable = ansible_module.params["loop_protect_enable"]
+    loop_protect_action = ansible_module.params["loop_protect_action"]
+    urpf_check = ansible_module.params["urpf_check"]
+    ip_mtu = ansible_module.params["ip_mtu"]
+
     configure_speed = ansible_module.params["configure_speed"]
     autoneg = ansible_module.params["autoneg"]
     duplex = ansible_module.params["duplex"]
@@ -583,6 +710,33 @@ def main():
         interface.admin_state = "up" if enabled else "down"
     if mtu:
         interface.mtu = mtu
+    # Physical user_config attributes
+    user_cfg = {
+        "pause": pause,
+        "eee": eee,
+        "error_control": error_control,
+        "speed_downshift": speed_downshift,
+    }
+    for key, val in user_cfg.items():
+        if val is not None:
+            if not isinstance(interface.user_config, dict):
+                interface.user_config = {}
+            interface.user_config[key] = val
+    # Top-level attributes
+    top_level = {
+        "udld_enable": udld_enable,
+        "udld_interval": udld_interval,
+        "udld_retries": udld_retries,
+        "loop_protect_enable": loop_protect_enable,
+        "loop_protect_action": loop_protect_action,
+        "urpf_check": urpf_check,
+        "ip_mtu": ip_mtu,
+    }
+    for key, val in top_level.items():
+        if val is not None:
+            setattr(interface, key, val)
+            if key not in interface.config_attrs:
+                interface.config_attrs.append(key)
     if vsx_sync:
         if not device.materialized:
             device.get()

--- a/plugins/modules/aoscx_interface.py
+++ b/plugins/modules/aoscx_interface.py
@@ -273,6 +273,15 @@ options:
       Maximum number of DHCPv6 snooping bindings allowed on the port (1-8192).
     type: int
     required: false
+  pvlan_port_type:
+    description: >
+      Private VLAN port type. C(promiscuous) for a port in the primary VLAN,
+      C(secondary) for a port in a secondary VLAN.
+    type: str
+    required: false
+    choices:
+      - promiscuous
+      - secondary
   state:
     description: Create, Update or Delete the Interface.
     type: str
@@ -605,6 +614,12 @@ def get_argument_spec():
             "required": False,
             "default": None,
         },
+        "pvlan_port_type": {
+            "type": "str",
+            "required": False,
+            "default": None,
+            "choices": ["promiscuous", "secondary"],
+        },
         "qos_rate": {
             "type": "dict",
             "required": False,
@@ -728,6 +743,7 @@ def main():
     dhcpv6_snooping_max_bindings = ansible_module.params[
         "dhcpv6_snooping_max_bindings"
     ]
+    pvlan_port_type = ansible_module.params["pvlan_port_type"]
 
     configure_speed = ansible_module.params["configure_speed"]
     autoneg = ansible_module.params["autoneg"]
@@ -831,6 +847,7 @@ def main():
         "loop_protect_action": loop_protect_action,
         "urpf_check": urpf_check,
         "ip_mtu": ip_mtu,
+        "pvlan_port_type": pvlan_port_type,
     }
     for key, val in top_level.items():
         if val is not None:

--- a/plugins/modules/aoscx_interface.py
+++ b/plugins/modules/aoscx_interface.py
@@ -243,6 +243,36 @@ options:
     description: IP MTU of the interface.
     type: int
     required: false
+  sflow_enabled:
+    description: >
+      Enable or disable sFlow sampling on the interface. Set to false to apply
+      C(no sflow) on the port (overriding the global sFlow setting).
+    type: bool
+    required: false
+  arp_inspection_trust:
+    description: >
+      Mark the interface as trusted for Dynamic ARP Inspection. When true,
+      ARP packets received on the port are not inspected.
+    type: bool
+    required: false
+  dhcpv4_snooping_trust:
+    description: Mark the interface as trusted for DHCPv4 snooping.
+    type: bool
+    required: false
+  dhcpv4_snooping_max_bindings:
+    description: >
+      Maximum number of DHCPv4 snooping bindings allowed on the port (1-8192).
+    type: int
+    required: false
+  dhcpv6_snooping_trust:
+    description: Mark the interface as trusted for DHCPv6 snooping.
+    type: bool
+    required: false
+  dhcpv6_snooping_max_bindings:
+    description: >
+      Maximum number of DHCPv6 snooping bindings allowed on the port (1-8192).
+    type: int
+    required: false
   state:
     description: Create, Update or Delete the Interface.
     type: str
@@ -545,6 +575,36 @@ def get_argument_spec():
             "required": False,
             "default": None,
         },
+        "sflow_enabled": {
+            "type": "bool",
+            "required": False,
+            "default": None,
+        },
+        "arp_inspection_trust": {
+            "type": "bool",
+            "required": False,
+            "default": None,
+        },
+        "dhcpv4_snooping_trust": {
+            "type": "bool",
+            "required": False,
+            "default": None,
+        },
+        "dhcpv4_snooping_max_bindings": {
+            "type": "int",
+            "required": False,
+            "default": None,
+        },
+        "dhcpv6_snooping_trust": {
+            "type": "bool",
+            "required": False,
+            "default": None,
+        },
+        "dhcpv6_snooping_max_bindings": {
+            "type": "int",
+            "required": False,
+            "default": None,
+        },
         "qos_rate": {
             "type": "dict",
             "required": False,
@@ -658,6 +718,16 @@ def main():
     loop_protect_action = ansible_module.params["loop_protect_action"]
     urpf_check = ansible_module.params["urpf_check"]
     ip_mtu = ansible_module.params["ip_mtu"]
+    sflow_enabled = ansible_module.params["sflow_enabled"]
+    arp_inspection_trust = ansible_module.params["arp_inspection_trust"]
+    dhcpv4_snooping_trust = ansible_module.params["dhcpv4_snooping_trust"]
+    dhcpv4_snooping_max_bindings = ansible_module.params[
+        "dhcpv4_snooping_max_bindings"
+    ]
+    dhcpv6_snooping_trust = ansible_module.params["dhcpv6_snooping_trust"]
+    dhcpv6_snooping_max_bindings = ansible_module.params[
+        "dhcpv6_snooping_max_bindings"
+    ]
 
     configure_speed = ansible_module.params["configure_speed"]
     autoneg = ansible_module.params["autoneg"]
@@ -722,6 +792,36 @@ def main():
             if not isinstance(interface.user_config, dict):
                 interface.user_config = {}
             interface.user_config[key] = val
+    # sFlow per-interface enable lives in the other_config dict.
+    if sflow_enabled is not None:
+        if not isinstance(interface.other_config, dict):
+            interface.other_config = {}
+        interface.other_config["sflow-enabled"] = sflow_enabled
+        if "other_config" not in interface.config_attrs:
+            interface.config_attrs.append("other_config")
+    # ARP inspection and DHCP snooping trust live in nested dicts.
+    nested_updates = {
+        "arp_inspection": {"trust": arp_inspection_trust},
+        "dhcpv4_snooping_configuration": {
+            "trusted": dhcpv4_snooping_trust,
+            "max_bindings": dhcpv4_snooping_max_bindings,
+        },
+        "dhcpv6_snooping_configuration": {
+            "trusted": dhcpv6_snooping_trust,
+            "max_bindings": dhcpv6_snooping_max_bindings,
+        },
+    }
+    for target, updates in nested_updates.items():
+        wanted = {k: v for k, v in updates.items() if v is not None}
+        if not wanted:
+            continue
+        if not isinstance(getattr(interface, target, None), dict):
+            setattr(interface, target, {})
+        current = getattr(interface, target)
+        for key, value in wanted.items():
+            current[key] = value
+        if target not in interface.config_attrs:
+            interface.config_attrs.append(target)
     # Top-level attributes
     top_level = {
         "udld_enable": udld_enable,

--- a/plugins/modules/aoscx_vlan.py
+++ b/plugins/modules/aoscx_vlan.py
@@ -76,6 +76,24 @@ options:
     description: Enable IP IGMP Snooping
     required: false
     type: bool
+  pvlan_type:
+    description: >
+      Private VLAN type of this VLAN. C(primary) for the primary VLAN,
+      C(isolated) or C(community) for a secondary VLAN. When not set the VLAN
+      behaves as a regular VLAN.
+    required: false
+    type: str
+    choices:
+      - primary
+      - isolated
+      - community
+  pvlan_association:
+    description: >
+      VLAN id of the primary VLAN this secondary VLAN is associated with.
+      Only applicable to secondary (isolated or community) VLANs. The primary
+      VLAN must already exist.
+    required: false
+    type: int
   state:
     description: Create or update or delete the VLAN.
     required: false
@@ -177,6 +195,15 @@ def get_argument_spec():
             "type": "bool",
             "required": False,
         },
+        "pvlan_type": {
+            "type": "str",
+            "required": False,
+            "choices": ["primary", "isolated", "community"],
+        },
+        "pvlan_association": {
+            "type": "int",
+            "required": False,
+        },
         "state": {
             "type": "str",
             "default": "create",
@@ -213,6 +240,8 @@ def main():
     voice = ansible_module.params["voice"]
     vsx_sync = ansible_module.params["vsx_sync"]
     ip_igmp_snooping = ansible_module.params["ip_igmp_snooping"]
+    pvlan_type = ansible_module.params["pvlan_type"]
+    pvlan_association = ansible_module.params["pvlan_association"]
     state = ansible_module.params["state"]
     try:
         session = get_pyaoscx_session(ansible_module)
@@ -293,6 +322,28 @@ def main():
                 or vlan.mgmd_enable["igmp"] != ip_igmp_snooping
             )
             vlan.mgmd_enable["igmp"] = ip_igmp_snooping
+
+        if pvlan_type is not None:
+            modified |= getattr(vlan, "pvlan_type", None) != pvlan_type
+            vlan.pvlan_type = pvlan_type
+
+        if pvlan_association is not None:
+            primary_uri = "{0}system/vlans/{1}".format(
+                session.resource_prefix, pvlan_association
+            )
+            current = getattr(vlan, "pvlan_association", None)
+            if isinstance(current, dict):
+                current_uri = next(iter(current.values()), None)
+            else:
+                current_uri = current
+            cur_id = (
+                str(current_uri).rstrip("/").rsplit("/", 1)[-1]
+                if current_uri
+                else None
+            )
+            if str(cur_id) != str(pvlan_association):
+                modified = True
+                vlan.pvlan_association = primary_uri
 
         if modified:
             try:

--- a/plugins/modules/aoscx_vlan.py
+++ b/plugins/modules/aoscx_vlan.py
@@ -260,6 +260,20 @@ def main():
     except Exception:
         vlan_exists = False
 
+    # Validate the referenced primary VLAN exists before making any change so
+    # a secondary VLAN is not created when the association would be rejected.
+    if pvlan_association is not None and state != "delete":
+        primary_vlan = Vlan(session, pvlan_association)
+        try:
+            primary_vlan.get()
+        except Exception:
+            ansible_module.fail_json(
+                msg=(
+                    "Primary VLAN {0} referenced by pvlan_association does "
+                    "not exist".format(pvlan_association)
+                )
+            )
+
     if state == "delete":
         if acl_type:
             try:


### PR DESCRIPTION
## Summary
Adds Private VLAN (PVLAN) configuration to the collection:
- `aoscx_vlan`: `pvlan_type` (primary / isolated / community) and `pvlan_association` (VLAN id of the primary VLAN a secondary VLAN is associated with).
- `aoscx_interface`: `pvlan_port_type` (promiscuous / secondary).

Together these allow a full PVLAN to be configured: a primary VLAN, one or more secondary (isolated/community) VLANs associated to it, and the promiscuous/secondary port assignments.

All changes are collection-only (the VLAN and Interface pyaoscx classes are generic); no SDK change is required.

## Testing
Validated live on a CX6300 (FL.10.17, REST latest): create, idempotency and update of primary/secondary VLANs, the secondary-to-primary association and the interface port type. `show running-config` confirmed:
```
vlan 401
    private-vlan isolated primary-vlan 400
interface 1/1/5
    private-vlan port-type promiscuous
```
Sanity (pep8, pylint, validate-modules) passes for both modules.

Fixes #222

Note: this branch is based on feature/interface-physical (#167) as it extends the same aoscx_interface module; the interface diff will reduce to only C(pvlan_port_type) once #167 is merged.

## Depends on
No pyaoscx changes required — uses existing pyaoscx classes (Device / Vlan / Interface).
