### PR TITLE
aoscx_checkpoint: add auto-checkpoint (confirmed commit) timer support

### DIFF
--- a/changelogs/fragments/checkpoint_auto.yml
+++ b/changelogs/fragments/checkpoint_auto.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - aoscx_checkpoint - add the C(auto) and C(auto_timeout) options to manage the
+    auto-checkpoint (confirmed commit) timer (the C(checkpoint auto <minutes>)
+    and C(checkpoint auto confirm) commands), so a risky change can be deployed
+    with an automatic rollback if it is not confirmed within the timer.

--- a/plugins/modules/aoscx_checkpoint.py
+++ b/plugins/modules/aoscx_checkpoint.py
@@ -89,8 +89,6 @@ EXAMPLES = """
 
 RETURN = r""" # """
 
-import json
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
     get_pyaoscx_session,
@@ -138,31 +136,20 @@ def main():
             msg="Could not get PYAOSCX Session: {0}".format(str(e))
         )
 
-    # Auto-checkpoint (confirmed commit) timer management.
-    if auto is not None:
-        if auto == "start":
-            response = session.request(
-                "POST",
-                "configs/autocheckpoint",
-                data=json.dumps({"minutes": auto_timeout}),
-            )
-        else:
-            response = session.request(
-                "PUT", "configs/autocheckpoint", data=json.dumps({})
-            )
-        if not 200 <= response.status_code < 300:
-            ansible_module.fail_json(
-                msg="Could not {0} the auto-checkpoint timer: {1}".format(
-                    auto, response.text
-                )
-            )
-        result["changed"] = True
-        ansible_module.exit_json(**result)
-
     device = Device(session)
 
     # Create a Configuration Object
     config = device.configuration()
+
+    # Auto-checkpoint (confirmed commit) timer management.
+    if auto is not None:
+        if auto == "start":
+            success = config.set_auto_checkpoint(auto_timeout)
+        else:
+            success = config.confirm_auto_checkpoint()
+        result["changed"] = success
+        ansible_module.exit_json(**result)
+
     success = config.create_checkpoint(source_config, destination_config)
 
     # Changed

--- a/plugins/modules/aoscx_checkpoint.py
+++ b/plugins/modules/aoscx_checkpoint.py
@@ -39,6 +39,26 @@ options:
     type: str
     required: false
     default: startup-config
+  auto:
+    description: >
+      Manage the auto-checkpoint (confirmed commit) timer instead of copying a
+      configuration. C(start) arms the timer and takes an automatic rollback
+      checkpoint (the C(checkpoint auto <minutes>) command); if it is not
+      confirmed before the timer expires the switch automatically restores the
+      configuration. C(confirm) ends the timer and keeps the running
+      configuration (the C(checkpoint auto confirm) command). When set, the
+      C(source_config) and C(destination_config) options are ignored.
+    type: str
+    required: false
+    choices:
+      - start
+      - confirm
+  auto_timeout:
+    description: >
+      Auto-checkpoint timer interval in minutes (1-60). Required when C(auto)
+      is C(start).
+    type: int
+    required: false
 """
 
 EXAMPLES = """
@@ -56,9 +76,20 @@ EXAMPLES = """
   aoscx_checkpoint:
     source_config: 'running-config'
     destination_config: 'checkpoint_20200128'
+
+- name: Arm the auto-checkpoint timer for 2 minutes before a risky change
+  aoscx_checkpoint:
+    auto: start
+    auto_timeout: 2
+
+- name: Confirm the configuration and stop the auto-checkpoint timer
+  aoscx_checkpoint:
+    auto: confirm
 """
 
 RETURN = r""" # """
+
+import json
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
@@ -70,16 +101,27 @@ def main():
     module_args = dict(
         source_config=dict(type="str", default="running-config"),
         destination_config=dict(type="str", default="startup-config"),
+        auto=dict(type="str", required=False, choices=["start", "confirm"]),
+        auto_timeout=dict(type="int", required=False),
     )
     ansible_module = AnsibleModule(
-        argument_spec=module_args, supports_check_mode=True
+        argument_spec=module_args,
+        supports_check_mode=True,
+        required_if=[("auto", "start", ["auto_timeout"])],
     )
 
     # Get playbook's arguments
     source_config = ansible_module.params["source_config"]
     destination_config = ansible_module.params["destination_config"]
+    auto = ansible_module.params["auto"]
+    auto_timeout = ansible_module.params["auto_timeout"]
 
     result = dict(changed=False)
+
+    if auto == "start" and auto_timeout not in range(1, 61):
+        ansible_module.fail_json(
+            msg="auto_timeout must be between 1 and 60 minutes"
+        )
 
     if ansible_module.check_mode:
         ansible_module.exit_json(**result)
@@ -95,6 +137,27 @@ def main():
         ansible_module.fail_json(
             msg="Could not get PYAOSCX Session: {0}".format(str(e))
         )
+
+    # Auto-checkpoint (confirmed commit) timer management.
+    if auto is not None:
+        if auto == "start":
+            response = session.request(
+                "POST",
+                "configs/autocheckpoint",
+                data=json.dumps({"minutes": auto_timeout}),
+            )
+        else:
+            response = session.request(
+                "PUT", "configs/autocheckpoint", data=json.dumps({})
+            )
+        if not 200 <= response.status_code < 300:
+            ansible_module.fail_json(
+                msg="Could not {0} the auto-checkpoint timer: {1}".format(
+                    auto, response.text
+                )
+            )
+        result["changed"] = True
+        ansible_module.exit_json(**result)
 
     device = Device(session)
 


### PR DESCRIPTION
Fixes #225

## Summary
Extends the existing `aoscx_checkpoint` module with two options to manage the auto-checkpoint (confirmed commit) timer, mapping 1:1 to the AOS-CX CLI:

- `auto: start` + `auto_timeout: <1-60>` -> `checkpoint auto <minutes>`
- `auto: confirm` -> `checkpoint auto confirm`

When `auto` is set, `source_config`/`destination_config` are ignored. If the configuration is not confirmed before the timer expires, the switch automatically rolls it back — ideal for safe remote deployments (auto-rollback on lost connectivity).

Backed by the pyaoscx `Configuration` SDK methods, no raw REST in the module.

## Example
```yaml
- name: Arm a 2-minute auto-checkpoint before a risky change
  arubanetworks.aoscx.aoscx_checkpoint:
    auto: start
    auto_timeout: 2

- name: Confirm and keep the configuration
  arubanetworks.aoscx.aoscx_checkpoint:
    auto: confirm
```

## Testing
Live-tested on a CX6300 (FL.10.17): start + confirm keep the change; without confirm the switch auto-rolls back. flake8, pep8, pylint and validate-modules all pass.

## Depends on
- aruba/pyaoscx#114 — Configuration auto-checkpoint methods
