### PR TITLE
aoscx_client_probe: new module to manage Client Probe Profiles

### DIFF
--- a/changelogs/fragments/client_probe.yml
+++ b/changelogs/fragments/client_probe.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - aoscx_client_probe - new module to manage Client Probe Profiles
+    (system/client_probe_profiles) and their entries, including the per-entry
+    VLAN, source IPv4/MAC, broadcast IPv4, directed IPv4 list and directed
+    IPv4 range.

--- a/changelogs/fragments/client_probe.yml
+++ b/changelogs/fragments/client_probe.yml
@@ -5,3 +5,5 @@ minor_changes:
     VLAN, source IPv4/MAC, broadcast IPv4, directed IPv4 list and directed
     IPv4 range, as well as the global client probe settings C(enable),
     C(duration), C(time_interval), C(probe_types) and C(vlan_list).
+  - aoscx_interface - add the C(client_probe_enable) option to enable client
+    probing on a physical interface (the C(client probe enable) command).

--- a/changelogs/fragments/client_probe.yml
+++ b/changelogs/fragments/client_probe.yml
@@ -3,4 +3,5 @@ minor_changes:
   - aoscx_client_probe - new module to manage Client Probe Profiles
     (system/client_probe_profiles) and their entries, including the per-entry
     VLAN, source IPv4/MAC, broadcast IPv4, directed IPv4 list and directed
-    IPv4 range.
+    IPv4 range, as well as the global client probe settings C(enable),
+    C(duration), C(time_interval), C(probe_types) and C(vlan_list).

--- a/plugins/modules/aoscx_client_probe.py
+++ b/plugins/modules/aoscx_client_probe.py
@@ -183,8 +183,6 @@ EXAMPLES = """
 
 RETURN = r""" # """
 
-import json
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
     get_pyaoscx_session,
@@ -193,6 +191,7 @@ from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx 
 try:
     from pyaoscx.client_probe_profile import ClientProbeProfile
     from pyaoscx.client_probe_profile_entry import ClientProbeProfileEntry
+    from pyaoscx.device import Device
 
     HAS_PYAOSCX = True
 except ImportError:
@@ -373,30 +372,22 @@ def _apply_globals(ansible_module, session):
     if not desired and params["vlan_list"] is None:
         return False
 
-    response = session.request(
-        "GET", "system", params={"selector": "writable", "depth": 2}
-    )
-    system_doc = json.loads(response.text)
+    device = Device(session)
+    device.get(selector="writable")
 
     if params["vlan_list"] is not None:
-        vlan_list = dict(system_doc.get("client_probe_vlan_list") or {})
+        vlan_list = dict(
+            getattr(device, "client_probe_vlan_list", None) or {}
+        )
         for key in ("secured", "unsecured"):
             if params["vlan_list"].get(key) is not None:
                 vlan_list[key] = params["vlan_list"][key]
         desired["client_probe_vlan_list"] = vlan_list
 
-    if all(system_doc.get(k) == v for k, v in desired.items()):
-        return False
+    for attr, value in desired.items():
+        setattr(device, attr, value)
 
-    system_doc.update(desired)
-    put = session.request("PUT", "system", data=json.dumps(system_doc))
-    if not 200 <= put.status_code < 300:
-        ansible_module.fail_json(
-            msg="Could not update global client probe settings: {0}".format(
-                put.text
-            )
-        )
-    return True
+    return device.update()
 
 
 if __name__ == "__main__":

--- a/plugins/modules/aoscx_client_probe.py
+++ b/plugins/modules/aoscx_client_probe.py
@@ -26,9 +26,57 @@ description: >
 author: Aruba Networks (@ArubaNetworks)
 options:
   name:
-    description: Name of the Client Probe Profile.
+    description: >
+      Name of the Client Probe Profile. Required to manage a profile or its
+      entries, and to delete a profile. May be omitted when only the global
+      client probe settings are configured.
     type: str
-    required: true
+    required: false
+  enable:
+    description: Global switch to enable or disable client probing.
+    type: bool
+    required: false
+  duration:
+    description: >
+      Global duration mode of the probes. C(periodic) keeps sending probes
+      even after a client is detected.
+    type: str
+    required: false
+    choices:
+      - periodic
+      - client-detection
+  time_interval:
+    description: >
+      Global time interval, in seconds, between two successive probe packets.
+    type: int
+    required: false
+  probe_types:
+    description: >
+      Global list of probe packet types to use to discover clients. The
+      supplied list fully replaces the enabled types.
+    type: list
+    elements: str
+    required: false
+    choices:
+      - garp
+      - ping_broadcast
+      - ping_sweep
+      - ping_unicast
+  vlan_list:
+    description: Global VLANs on which clients are probed.
+    type: dict
+    required: false
+    suboptions:
+      secured:
+        description: >
+          Secured VLANs to probe (C(all) or a VLAN list such as C(1,2,3)).
+        type: str
+        required: false
+      unsecured:
+        description: >
+          Unsecured VLANs to probe (C(all) or a VLAN list such as C(1,2,3)).
+        type: str
+        required: false
   entries:
     description: >
       List of probe entries in the profile. Supplied entries are created or
@@ -114,6 +162,18 @@ EXAMPLES = """
           end_ip_addr: 10.0.0.20
     state: create
 
+- name: Configure the global client probe settings
+  aoscx_client_probe:
+    enable: true
+    duration: periodic
+    time_interval: 30
+    probe_types:
+      - garp
+      - ping_broadcast
+    vlan_list:
+      secured: all
+      unsecured: all
+
 - name: Delete a Client Probe Profile
   aoscx_client_probe:
     name: WakeUp-Clients
@@ -121,6 +181,8 @@ EXAMPLES = """
 """
 
 RETURN = r""" # """
+
+import json
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
@@ -144,10 +206,33 @@ ENTRY_FIELDS = (
     "directed_ipv4_range",
 )
 
+PROBE_TYPES = ("garp", "ping_broadcast", "ping_sweep", "ping_unicast")
+
 
 def main():
     module_args = dict(
-        name=dict(type="str", required=True),
+        name=dict(type="str", required=False),
+        enable=dict(type="bool", required=False),
+        duration=dict(
+            type="str",
+            required=False,
+            choices=["periodic", "client-detection"],
+        ),
+        time_interval=dict(type="int", required=False),
+        probe_types=dict(
+            type="list",
+            elements="str",
+            required=False,
+            choices=list(PROBE_TYPES),
+        ),
+        vlan_list=dict(
+            type="dict",
+            required=False,
+            options=dict(
+                secured=dict(type="str", required=False),
+                unsecured=dict(type="str", required=False),
+            ),
+        ),
         entries=dict(
             type="list",
             elements="dict",
@@ -198,51 +283,113 @@ def main():
             msg="Could not get PYAOSCX Session: {0}".format(str(e))
         )
 
-    profile = ClientProbeProfile(session, name)
-    try:
-        profile.get()
-        exists = True
-    except Exception:
-        exists = False
-
     if state == "delete":
+        if name is None:
+            ansible_module.fail_json(
+                msg="name is required to delete a Client Probe Profile"
+            )
+        profile = ClientProbeProfile(session, name)
+        try:
+            profile.get()
+            exists = True
+        except Exception:
+            exists = False
         if exists:
             profile.delete()
             result["changed"] = True
         ansible_module.exit_json(**result)
 
     changed = False
-    if not exists:
-        profile.apply()
-        changed = True
 
-    if entries:
-        current = ClientProbeProfileEntry.get_all(session, profile)
-        for entry in entries:
-            entry_id = entry["entry_id"]
-            supplied = {
-                field: entry[field]
-                for field in ENTRY_FIELDS
-                if entry.get(field) is not None
-            }
-            key = str(entry_id)
-            if key in current:
-                obj = current[key]
-                obj.get()
-                for field, value in supplied.items():
-                    setattr(obj, field, value)
-                    if field not in obj.config_attrs:
-                        obj.config_attrs.append(field)
-                changed |= obj.apply()
-            else:
-                obj = ClientProbeProfileEntry(
-                    session, entry_id, profile, **supplied
-                )
-                obj.apply()
-                changed = True
+    # Global (system-wide) client probe settings.
+    changed |= _apply_globals(ansible_module, session)
+
+    if name is not None:
+        profile = ClientProbeProfile(session, name)
+        try:
+            profile.get()
+            exists = True
+        except Exception:
+            exists = False
+
+        if not exists:
+            profile.apply()
+            changed = True
+
+        if entries:
+            current = ClientProbeProfileEntry.get_all(session, profile)
+            for entry in entries:
+                entry_id = entry["entry_id"]
+                supplied = {
+                    field: entry[field]
+                    for field in ENTRY_FIELDS
+                    if entry.get(field) is not None
+                }
+                key = str(entry_id)
+                if key in current:
+                    obj = current[key]
+                    obj.get()
+                    for field, value in supplied.items():
+                        setattr(obj, field, value)
+                        if field not in obj.config_attrs:
+                            obj.config_attrs.append(field)
+                    changed |= obj.apply()
+                else:
+                    obj = ClientProbeProfileEntry(
+                        session, entry_id, profile, **supplied
+                    )
+                    obj.apply()
+                    changed = True
 
     result["changed"] = changed
     ansible_module.exit_json(**result)
+
+
+def _apply_globals(ansible_module, session):
+    """Apply the system-wide client probe settings, return True if changed."""
+    params = ansible_module.params
+    scalar_map = {
+        "enable": "client_probe_enable",
+        "duration": "client_probe_duration",
+        "time_interval": "client_probe_time_interval",
+    }
+    desired = {
+        attr: params[param]
+        for param, attr in scalar_map.items()
+        if params[param] is not None
+    }
+    if params["probe_types"] is not None:
+        desired["client_probe_type"] = {
+            probe: probe in params["probe_types"] for probe in PROBE_TYPES
+        }
+
+    if not desired and params["vlan_list"] is None:
+        return False
+
+    response = session.request(
+        "GET", "system", params={"selector": "writable", "depth": 2}
+    )
+    system_doc = json.loads(response.text)
+
+    if params["vlan_list"] is not None:
+        vlan_list = dict(system_doc.get("client_probe_vlan_list") or {})
+        for key in ("secured", "unsecured"):
+            if params["vlan_list"].get(key) is not None:
+                vlan_list[key] = params["vlan_list"][key]
+        desired["client_probe_vlan_list"] = vlan_list
+
+    if all(system_doc.get(k) == v for k, v in desired.items()):
+        return False
+
+    system_doc.update(desired)
+    put = session.request("PUT", "system", data=json.dumps(system_doc))
+    if not 200 <= put.status_code < 300:
+        ansible_module.fail_json(
+            msg="Could not update global client probe settings: {0}".format(
+                put.text
+            )
+        )
+    return True
 
 
 if __name__ == "__main__":

--- a/plugins/modules/aoscx_client_probe.py
+++ b/plugins/modules/aoscx_client_probe.py
@@ -1,0 +1,249 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_client_probe
+version_added: "5.0.0"
+short_description: Manage Client Probe Profiles on AOS-CX switches.
+description: >
+  This module provides configuration management of Client Probe Profiles and
+  their entries on AOS-CX devices.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  name:
+    description: Name of the Client Probe Profile.
+    type: str
+    required: true
+  entries:
+    description: >
+      List of probe entries in the profile. Supplied entries are created or
+      updated; entries already present on the device but not listed here are
+      left untouched.
+    type: list
+    elements: dict
+    required: false
+    suboptions:
+      entry_id:
+        description: Identifier of the entry within the profile.
+        type: int
+        required: true
+      vlan:
+        description: VLAN on which the client is probed.
+        type: int
+        required: false
+      source_ipv4:
+        description: Source IPv4 address used in the probe packets.
+        type: str
+        required: false
+      broadcast_ipv4:
+        description: >
+          Broadcast IPv4 address used in the probe packets when the client
+          probe type ping-broadcast is enabled.
+        type: str
+        required: false
+      source_mac:
+        description: Source MAC address used in the probe packets.
+        type: str
+        required: false
+      directed_ipv4_list:
+        description: >
+          List of unicast IPv4 addresses being probed when the client probe
+          type ping-unicast or GARP is enabled.
+        type: list
+        elements: str
+        required: false
+      directed_ipv4_range:
+        description: >
+          Range of IPv4 addresses being probed when the client probe type
+          ping-sweep or GARP is enabled. Provide a dictionary with the keys
+          C(start_ip_addr) and C(end_ip_addr).
+        type: dict
+        required: false
+  state:
+    description: Create, update or delete the Client Probe Profile.
+    type: str
+    required: false
+    default: create
+    choices:
+      - create
+      - update
+      - delete
+"""
+
+EXAMPLES = """
+- name: Create a Client Probe Profile with two entries
+  aoscx_client_probe:
+    name: WakeUp-Clients
+    entries:
+      - entry_id: 1
+        vlan: 99
+        source_ipv4: 9.9.9.1
+        broadcast_ipv4: 9.9.9.255
+      - entry_id: 2
+        vlan: 100
+        source_ipv4: 10.0.0.1
+        directed_ipv4_list:
+          - 10.0.0.5
+          - 10.0.0.6
+    state: create
+
+- name: Probe a range of addresses
+  aoscx_client_probe:
+    name: Sweep
+    entries:
+      - entry_id: 1
+        vlan: 100
+        source_ipv4: 10.0.0.1
+        directed_ipv4_range:
+          start_ip_addr: 10.0.0.10
+          end_ip_addr: 10.0.0.20
+    state: create
+
+- name: Delete a Client Probe Profile
+  aoscx_client_probe:
+    name: WakeUp-Clients
+    state: delete
+"""
+
+RETURN = r""" # """
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+try:
+    from pyaoscx.client_probe_profile import ClientProbeProfile
+    from pyaoscx.client_probe_profile_entry import ClientProbeProfileEntry
+
+    HAS_PYAOSCX = True
+except ImportError:
+    HAS_PYAOSCX = False
+
+ENTRY_FIELDS = (
+    "vlan",
+    "source_ipv4",
+    "broadcast_ipv4",
+    "source_mac",
+    "directed_ipv4_list",
+    "directed_ipv4_range",
+)
+
+
+def main():
+    module_args = dict(
+        name=dict(type="str", required=True),
+        entries=dict(
+            type="list",
+            elements="dict",
+            required=False,
+            options=dict(
+                entry_id=dict(type="int", required=True),
+                vlan=dict(type="int", required=False),
+                source_ipv4=dict(type="str", required=False),
+                broadcast_ipv4=dict(type="str", required=False),
+                source_mac=dict(type="str", required=False),
+                directed_ipv4_list=dict(
+                    type="list", elements="str", required=False
+                ),
+                directed_ipv4_range=dict(type="dict", required=False),
+            ),
+        ),
+        state=dict(
+            type="str",
+            required=False,
+            default="create",
+            choices=["create", "update", "delete"],
+        ),
+    )
+
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    result = dict(changed=False)
+
+    if not HAS_PYAOSCX:
+        ansible_module.fail_json(
+            msg="This module requires a pyaoscx version that provides the "
+            "ClientProbeProfile class. Upgrade pyaoscx."
+        )
+
+    if ansible_module.check_mode:
+        ansible_module.exit_json(**result)
+
+    name = ansible_module.params["name"]
+    entries = ansible_module.params["entries"]
+    state = ansible_module.params["state"]
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    profile = ClientProbeProfile(session, name)
+    try:
+        profile.get()
+        exists = True
+    except Exception:
+        exists = False
+
+    if state == "delete":
+        if exists:
+            profile.delete()
+            result["changed"] = True
+        ansible_module.exit_json(**result)
+
+    changed = False
+    if not exists:
+        profile.apply()
+        changed = True
+
+    if entries:
+        current = ClientProbeProfileEntry.get_all(session, profile)
+        for entry in entries:
+            entry_id = entry["entry_id"]
+            supplied = {
+                field: entry[field]
+                for field in ENTRY_FIELDS
+                if entry.get(field) is not None
+            }
+            key = str(entry_id)
+            if key in current:
+                obj = current[key]
+                obj.get()
+                for field, value in supplied.items():
+                    setattr(obj, field, value)
+                    if field not in obj.config_attrs:
+                        obj.config_attrs.append(field)
+                changed |= obj.apply()
+            else:
+                obj = ClientProbeProfileEntry(
+                    session, entry_id, profile, **supplied
+                )
+                obj.apply()
+                changed = True
+
+    result["changed"] = changed
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_client_probe.py
+++ b/plugins/modules/aoscx_client_probe.py
@@ -47,7 +47,8 @@ options:
       - client-detection
   time_interval:
     description: >
-      Global time interval, in seconds, between two successive probe packets.
+      Global time interval, in seconds, between two successive probe packets
+      (30-300).
     type: int
     required: false
   probe_types:
@@ -275,6 +276,12 @@ def main():
     name = ansible_module.params["name"]
     entries = ansible_module.params["entries"]
     state = ansible_module.params["state"]
+
+    time_interval = ansible_module.params["time_interval"]
+    if time_interval is not None and not 30 <= time_interval <= 300:
+        ansible_module.fail_json(
+            msg="time_interval must be between 30 and 300 seconds"
+        )
 
     try:
         session = get_pyaoscx_session(ansible_module)

--- a/plugins/modules/aoscx_client_probe.py
+++ b/plugins/modules/aoscx_client_probe.py
@@ -22,7 +22,10 @@ version_added: "5.0.0"
 short_description: Manage Client Probe Profiles on AOS-CX switches.
 description: >
   This module provides configuration management of Client Probe Profiles and
-  their entries on AOS-CX devices.
+  their entries on AOS-CX devices. Managing client probe profiles (the
+  C(name) and C(entries) options) requires REST API version 10.16 or later
+  (set ansible_aoscx_rest_version to 10.16); the global client probe settings
+  are available from earlier versions.
 author: Aruba Networks (@ArubaNetworks)
 options:
   name:

--- a/plugins/modules/aoscx_interface.py
+++ b/plugins/modules/aoscx_interface.py
@@ -52,6 +52,12 @@ options:
     description: Configure MTU value of the interface
     type: int
     required: false
+  client_probe_enable:
+    description: >
+      Enable the interface to send periodic client probe packets to discover
+      clients (the C(client probe enable) interface command).
+    type: bool
+    required: false
   autoneg:
     description: >
       Configure the auto-negotiation state of the interface. If `off` both
@@ -351,6 +357,11 @@ def get_argument_spec():
             "type": "int",
             "required": False,
         },
+        "client_probe_enable": {
+            "type": "bool",
+            "required": False,
+            "default": None,
+        },
         "duplex": {
             "type": "str",
             "required": False,
@@ -522,6 +533,7 @@ def main():
     vsx_sync = ansible_module.params["vsx_sync"]
     state = ansible_module.params["state"]
     mtu = ansible_module.params["mtu"]
+    client_probe_enable = ansible_module.params["client_probe_enable"]
     acl_name = ansible_module.params["acl_name"]
     acl_type = ansible_module.params["acl_type"]
     acl_direction = ansible_module.params["acl_direction"]
@@ -583,6 +595,8 @@ def main():
         interface.admin_state = "up" if enabled else "down"
     if mtu:
         interface.mtu = mtu
+    if client_probe_enable is not None:
+        interface.client_probe_enable = client_probe_enable
     if vsx_sync:
         if not device.materialized:
             device.get()


### PR DESCRIPTION
Fixes #226

## Summary
New module `aoscx_client_probe` to manage AOS-CX Client Probe Profiles (`system/client_probe_profiles`) and their entries.

## Options
- `name` — profile name
- `entries` — list of entries (`entry_id`, `vlan`, `source_ipv4`, `broadcast_ipv4`, `source_mac`, `directed_ipv4_list`, `directed_ipv4_range`)
- `state` — create / update / delete

Also adds `client_probe_enable` to `aoscx_interface` to enable client probing on a physical interface.

Backed by the pyaoscx `ClientProbeProfile` / `ClientProbeProfileEntry` SDK classes.

## Example
```yaml
- arubanetworks.aoscx.aoscx_client_probe:
    name: WakeUp-Clients
    entries:
      - {entry_id: 1, vlan: 99, source_ipv4: 9.9.9.1, broadcast_ipv4: 9.9.9.255}
    state: create
```

## Testing
Live-tested on a CX6300 (FL.10.17): create + entries, idempotency, update, directed range, delete. flake8, pep8, pylint and validate-modules pass.

## Depends on
- aruba/pyaoscx#117 — adds `ClientProbeProfile` / `ClientProbeProfileEntry`.
- aruba/pyaoscx#119 — REST API version modules `v10.13` / `v10.16` (client probe **profiles** are only exposed at REST 10.16+, the current LTS baseline).
