### PR TITLE
aoscx_dhcp_snooping: global DHCPv4 snooping module; aoscx_vlan per-VLAN snooping

### DIFF
--- a/changelogs/fragments/dhcp_snooping.yml
+++ b/changelogs/fragments/dhcp_snooping.yml
@@ -1,0 +1,10 @@
+---
+minor_changes:
+  - aoscx_dhcp_snooping - new module to manage the global DHCPv4 snooping
+    settings (system/dhcpv4_snooping_general_configuration), including
+    C(enable), C(allow_overwrite_binding), C(disable_mac_verification),
+    C(enable_client_attribute_caching), C(enable_client_event_log) and
+    C(vxlan_trusted).
+  - aoscx_vlan - add the per-VLAN DHCP snooping options
+    C(dhcpv4_snooping_enable), C(dhcpv4_snooping_ip_binding_disable),
+    C(dhcpv6_snooping_enable) and C(dhcpv6_snooping_ip_binding_disable).

--- a/plugins/modules/aoscx_dhcp_snooping.py
+++ b/plugins/modules/aoscx_dhcp_snooping.py
@@ -72,12 +72,17 @@ EXAMPLES = """
 
 RETURN = r""" # """
 
-import json
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
     get_pyaoscx_session,
 )
+
+try:
+    from pyaoscx.device import Device
+
+    HAS_PYAOSCX = True
+except ImportError:
+    HAS_PYAOSCX = False
 
 GENERAL_CONFIG_KEY = "dhcpv4_snooping_general_configuration"
 
@@ -102,6 +107,11 @@ def main():
 
     result = dict(changed=False)
 
+    if not HAS_PYAOSCX:
+        ansible_module.fail_json(
+            msg="Could not find the PYAOSCX SDK. Make sure it is installed."
+        )
+
     if ansible_module.check_mode:
         ansible_module.exit_json(**result)
 
@@ -120,23 +130,14 @@ def main():
             msg="Could not get PYAOSCX Session: {0}".format(str(e))
         )
 
-    response = session.request(
-        "GET", "system", params={"selector": "writable", "depth": 2}
-    )
-    system_doc = json.loads(response.text)
-    general_config = dict(system_doc.get(GENERAL_CONFIG_KEY) or {})
+    device = Device(session)
+    device.get(selector="writable")
 
-    if any(general_config.get(k) != v for k, v in supplied.items()):
-        general_config.update(supplied)
-        system_doc[GENERAL_CONFIG_KEY] = general_config
-        put = session.request("PUT", "system", data=json.dumps(system_doc))
-        if not 200 <= put.status_code < 300:
-            ansible_module.fail_json(
-                msg="Could not update DHCPv4 snooping settings: {0}".format(
-                    put.text
-                )
-            )
-        result["changed"] = True
+    general_config = dict(getattr(device, GENERAL_CONFIG_KEY, None) or {})
+    general_config.update(supplied)
+    setattr(device, GENERAL_CONFIG_KEY, general_config)
+
+    result["changed"] = device.update()
 
     ansible_module.exit_json(**result)
 

--- a/plugins/modules/aoscx_dhcp_snooping.py
+++ b/plugins/modules/aoscx_dhcp_snooping.py
@@ -1,0 +1,145 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "certified",
+}
+
+DOCUMENTATION = """
+---
+module: aoscx_dhcp_snooping
+version_added: "5.0.0"
+short_description: Manage the global DHCPv4 snooping settings on AOS-CX.
+description: >
+  This module manages the global DHCPv4 snooping configuration
+  (system/dhcpv4_snooping_general_configuration) on AOS-CX devices. Per-VLAN
+  snooping is managed with the aoscx_vlan module and per-port trust with the
+  aoscx_interface module.
+author: Aruba Networks (@ArubaNetworks)
+options:
+  enable:
+    description: >
+      Globally enable DHCPv4 snooping on the device (the C(dhcpv4-snooping)
+      command).
+    type: bool
+    required: false
+  allow_overwrite_binding:
+    description: Allow a binding to be overwritten by a new one.
+    type: bool
+    required: false
+  disable_mac_verification:
+    description: >
+      Disable the verification of the source MAC address against the DHCP
+      client hardware address.
+    type: bool
+    required: false
+  enable_client_attribute_caching:
+    description: Enable caching of the DHCP client attributes.
+    type: bool
+    required: false
+  enable_client_event_log:
+    description: >
+      Enable the DHCPv4 snooping client event log (the
+      C(dhcpv4-snooping event-log client) command).
+    type: bool
+    required: false
+  vxlan_trusted:
+    description: Treat VXLAN tunnels as trusted for DHCPv4 snooping.
+    type: bool
+    required: false
+"""
+
+EXAMPLES = """
+- name: Enable DHCPv4 snooping globally with the client event log
+  aoscx_dhcp_snooping:
+    enable: true
+    enable_client_event_log: true
+
+- name: Disable DHCPv4 snooping globally
+  aoscx_dhcp_snooping:
+    enable: false
+"""
+
+RETURN = r""" # """
+
+import json
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
+    get_pyaoscx_session,
+)
+
+GENERAL_CONFIG_KEY = "dhcpv4_snooping_general_configuration"
+
+SETTINGS = (
+    "enable",
+    "allow_overwrite_binding",
+    "disable_mac_verification",
+    "enable_client_attribute_caching",
+    "enable_client_event_log",
+    "vxlan_trusted",
+)
+
+
+def main():
+    module_args = {
+        setting: dict(type="bool", required=False) for setting in SETTINGS
+    }
+
+    ansible_module = AnsibleModule(
+        argument_spec=module_args, supports_check_mode=True
+    )
+
+    result = dict(changed=False)
+
+    if ansible_module.check_mode:
+        ansible_module.exit_json(**result)
+
+    supplied = {
+        setting: ansible_module.params[setting]
+        for setting in SETTINGS
+        if ansible_module.params[setting] is not None
+    }
+    if not supplied:
+        ansible_module.exit_json(**result)
+
+    try:
+        session = get_pyaoscx_session(ansible_module)
+    except Exception as e:
+        ansible_module.fail_json(
+            msg="Could not get PYAOSCX Session: {0}".format(str(e))
+        )
+
+    response = session.request(
+        "GET", "system", params={"selector": "writable", "depth": 2}
+    )
+    system_doc = json.loads(response.text)
+    general_config = dict(system_doc.get(GENERAL_CONFIG_KEY) or {})
+
+    if any(general_config.get(k) != v for k, v in supplied.items()):
+        general_config.update(supplied)
+        system_doc[GENERAL_CONFIG_KEY] = general_config
+        put = session.request("PUT", "system", data=json.dumps(system_doc))
+        if not 200 <= put.status_code < 300:
+            ansible_module.fail_json(
+                msg="Could not update DHCPv4 snooping settings: {0}".format(
+                    put.text
+                )
+            )
+        result["changed"] = True
+
+    ansible_module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/aoscx_dhcp_snooping.py
+++ b/plugins/modules/aoscx_dhcp_snooping.py
@@ -24,7 +24,10 @@ description: >
   This module manages the global DHCPv4 snooping configuration
   (system/dhcpv4_snooping_general_configuration) on AOS-CX devices. Per-VLAN
   snooping is managed with the aoscx_vlan module and per-port trust with the
-  aoscx_interface module.
+  aoscx_interface module. Some advanced options (for example
+  C(enable_client_event_log)) require REST API version 10.16 or later (set
+  ansible_aoscx_rest_version to 10.16); the base C(enable) setting is
+  available on earlier versions.
 author: Aruba Networks (@ArubaNetworks)
 options:
   enable:

--- a/plugins/modules/aoscx_vlan.py
+++ b/plugins/modules/aoscx_vlan.py
@@ -76,6 +76,22 @@ options:
     description: Enable IP IGMP Snooping
     required: false
     type: bool
+  dhcpv4_snooping_enable:
+    description: Enable DHCPv4 snooping on the VLAN.
+    required: false
+    type: bool
+  dhcpv4_snooping_ip_binding_disable:
+    description: Disable the DHCPv4 snooping IP source binding on the VLAN.
+    required: false
+    type: bool
+  dhcpv6_snooping_enable:
+    description: Enable DHCPv6 snooping on the VLAN.
+    required: false
+    type: bool
+  dhcpv6_snooping_ip_binding_disable:
+    description: Disable the DHCPv6 snooping IP source binding on the VLAN.
+    required: false
+    type: bool
   state:
     description: Create or update or delete the VLAN.
     required: false
@@ -177,6 +193,22 @@ def get_argument_spec():
             "type": "bool",
             "required": False,
         },
+        "dhcpv4_snooping_enable": {
+            "type": "bool",
+            "required": False,
+        },
+        "dhcpv4_snooping_ip_binding_disable": {
+            "type": "bool",
+            "required": False,
+        },
+        "dhcpv6_snooping_enable": {
+            "type": "bool",
+            "required": False,
+        },
+        "dhcpv6_snooping_ip_binding_disable": {
+            "type": "bool",
+            "required": False,
+        },
         "state": {
             "type": "str",
             "default": "create",
@@ -213,6 +245,16 @@ def main():
     voice = ansible_module.params["voice"]
     vsx_sync = ansible_module.params["vsx_sync"]
     ip_igmp_snooping = ansible_module.params["ip_igmp_snooping"]
+    dhcp_snooping_attrs = {
+        key: ansible_module.params[key]
+        for key in (
+            "dhcpv4_snooping_enable",
+            "dhcpv4_snooping_ip_binding_disable",
+            "dhcpv6_snooping_enable",
+            "dhcpv6_snooping_ip_binding_disable",
+        )
+        if ansible_module.params[key] is not None
+    }
     state = ansible_module.params["state"]
     try:
         session = get_pyaoscx_session(ansible_module)
@@ -293,6 +335,10 @@ def main():
                 or vlan.mgmd_enable["igmp"] != ip_igmp_snooping
             )
             vlan.mgmd_enable["igmp"] = ip_igmp_snooping
+
+        for attr, value in dhcp_snooping_attrs.items():
+            modified |= getattr(vlan, attr, None) != value
+            setattr(vlan, attr, value)
 
         if modified:
             try:


### PR DESCRIPTION
Fixes #228

## Summary
- New module `aoscx_dhcp_snooping` to manage the global DHCPv4 snooping configuration (system/dhcpv4_snooping_general_configuration): `enable`, `allow_overwrite_binding`, `disable_mac_verification`, `enable_client_attribute_caching`, `enable_client_event_log`, `vxlan_trusted`.
- `aoscx_vlan` gains the per-VLAN options `dhcpv4_snooping_enable`, `dhcpv4_snooping_ip_binding_disable`, `dhcpv6_snooping_enable`, `dhcpv6_snooping_ip_binding_disable`.

Together with the existing per-port trust (aoscx_interface), this completes DHCPv4 snooping coverage (global + per-VLAN + per-port).

## Example
```yaml
- arubanetworks.aoscx.aoscx_dhcp_snooping:
    enable: true
    enable_client_event_log: true
- arubanetworks.aoscx.aoscx_vlan:
    vlan_id: 99
    dhcpv4_snooping_enable: true
    state: update
```

## Testing
Live-tested on a CX6300 (FL.10.17): global `dhcpv4-snooping` + `event-log client`, per-VLAN `dhcpv4-snooping`, idempotency, cleanup via playbook. flake8, pep8, pylint and validate-modules pass.

## Depends on
- aruba/pyaoscx#119 — REST API version modules `v10.13` / `v10.16` (needed to reach this feature at the 10.13/10.16 REST schema)
