### PR TITLE
aoscx_vlan: add arp_inspection_enable for per-VLAN Dynamic ARP inspection

### DIFF
--- a/changelogs/fragments/arp_inspection.yml
+++ b/changelogs/fragments/arp_inspection.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - aoscx_vlan - add the C(arp_inspection_enable) option to enable Dynamic ARP
+    inspection on a VLAN (the C(arp inspection) command).

--- a/plugins/modules/aoscx_vlan.py
+++ b/plugins/modules/aoscx_vlan.py
@@ -76,6 +76,12 @@ options:
     description: Enable IP IGMP Snooping
     required: false
     type: bool
+  arp_inspection_enable:
+    description: >
+      Enable Dynamic ARP inspection on the VLAN (the C(arp inspection)
+      command).
+    required: false
+    type: bool
   state:
     description: Create or update or delete the VLAN.
     required: false
@@ -177,6 +183,10 @@ def get_argument_spec():
             "type": "bool",
             "required": False,
         },
+        "arp_inspection_enable": {
+            "type": "bool",
+            "required": False,
+        },
         "state": {
             "type": "str",
             "default": "create",
@@ -213,6 +223,7 @@ def main():
     voice = ansible_module.params["voice"]
     vsx_sync = ansible_module.params["vsx_sync"]
     ip_igmp_snooping = ansible_module.params["ip_igmp_snooping"]
+    arp_inspection_enable = ansible_module.params["arp_inspection_enable"]
     state = ansible_module.params["state"]
     try:
         session = get_pyaoscx_session(ansible_module)
@@ -293,6 +304,13 @@ def main():
                 or vlan.mgmd_enable["igmp"] != ip_igmp_snooping
             )
             vlan.mgmd_enable["igmp"] = ip_igmp_snooping
+
+        if arp_inspection_enable is not None:
+            modified |= (
+                getattr(vlan, "arp_inspection_enable", None)
+                != arp_inspection_enable
+            )
+            vlan.arp_inspection_enable = arp_inspection_enable
 
         if modified:
             try:


### PR DESCRIPTION
Fixes #230

## Summary
Adds the `arp_inspection_enable` option to `aoscx_vlan` to enable Dynamic ARP inspection (DAI) on a VLAN (the `arp inspection` command). Combined with the existing per-port trust in `aoscx_interface`, this completes DAI coverage.

## Example
```yaml
- arubanetworks.aoscx.aoscx_vlan:
    vlan_id: 99
    arp_inspection_enable: true
    state: update
```

## Testing
Live-tested on a CX6300 (FL.10.17): enabling DAI renders `vlan 99 / arp inspection`, idempotency confirmed, cleanup via playbook. flake8, pep8, pylint and validate-modules pass.

## Depends on
No pyaoscx changes required — uses existing pyaoscx classes (Device / Vlan / Interface).
