### PR TITLE
aoscx_facts: add stacking subset with VSF member count

### DIFF
--- a/changelogs/fragments/facts_vsf_stacking.yml
+++ b/changelogs/fragments/facts_vsf_stacking.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - aoscx_facts - add the C(stacking) gather_subset which returns the number of
+    switches in the VSF stack (C(ansible_net_vsf_member_count)) and the VSF
+    members with their role and status (C(ansible_net_vsf_members)). A
+    standalone switch is reported as a single VSF member.

--- a/plugins/modules/aoscx_facts.py
+++ b/plugins/modules/aoscx_facts.py
@@ -47,6 +47,7 @@ options:
       - software_images
       - software_info
       - software_version
+      - stacking
     required: false
     default:
       - domain_name
@@ -160,6 +161,8 @@ ansible_net_mgmt_intf_status:
   returned: always
   type: dict
 """
+import json
+
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.arubanetworks.aoscx.plugins.module_utils.aoscx_pyaoscx import (  # NOQA
@@ -204,6 +207,7 @@ def main():
                 "software_images",
                 "software_info",
                 "software_version",
+                "stacking",
             ],
         ),
         "gather_network_resources": dict(
@@ -418,6 +422,26 @@ def main():
                 else:
                     intfs = switch.subsystems[subsystem][subset]
                 ansible_facts[str_subset].update({subsystem: intfs})
+
+    # VSF (stacking) members: the number of switches in the stack and their
+    # role/status. A standalone switch is reported as a single VSF member.
+    if "stacking" in subset_list:
+        try:
+            vsf_depth = session.api.default_facts_depth
+            response = session.request(
+                "GET", "system/vsf_members?depth={0}".format(vsf_depth)
+            )
+            members_data = json.loads(response.text)
+        except Exception as e:
+            ansible_module.fail_json(msg="VSF members: {0}".format(str(e)))
+        vsf_members = {}
+        for member_id, data in members_data.items():
+            vsf_members[member_id] = {
+                "role": data.get("role"),
+                "status": data.get("status"),
+            }
+        ansible_facts["ansible_net_vsf_members"] = vsf_members
+        ansible_facts["ansible_net_vsf_member_count"] = len(members_data)
 
     ansible_module.exit_json(ansible_facts=ansible_facts)
 


### PR DESCRIPTION
Fixes #236

## Summary
Adds a `stacking` `gather_subset` to `aoscx_facts` that returns:
- `ansible_net_vsf_member_count` — the number of switches in the VSF stack
- `ansible_net_vsf_members` — the members with their `role` and `status`

A standalone switch is reported as a single VSF member (count = 1), matching how AOS-CX represents it.

## Example
```yaml
- arubanetworks.aoscx.aoscx_facts:
    gather_subset: [stacking]
- debug:
    msg: "{{ ansible_net_vsf_member_count }} switch(es) in the stack"
```

## Testing
Live-tested on 3 switches: a standalone (count=1) and two 2-member VSF stacks (count=2, roles conductor/standby). pep8, pylint and validate-modules pass.

## Depends on
No pyaoscx changes required — uses existing pyaoscx classes (Device / Vlan / Interface).
